### PR TITLE
Improve empty state messaging in Results tab

### DIFF
--- a/src/lib/AnalysisHistory.svelte
+++ b/src/lib/AnalysisHistory.svelte
@@ -14,10 +14,10 @@
   // Define sortedAnalyses variable first
   let sortedAnalyses = [];
   
-  // Store subscriptions
-  $: filteredAnalyses = filterByCurrentFile && $currentFile 
-    ? $analysisStore.analyses.filter(a => a.fileId === $currentFile.id)
-    : $analysisStore.analyses;
+  // Store subscriptions - exclude datareader analyses as they're just file processing
+  $: filteredAnalyses = (filterByCurrentFile && $currentFile 
+    ? $analysisStore.analyses.filter(a => a.fileId === $currentFile.id && a.method !== 'datareader')
+    : $analysisStore.analyses.filter(a => a.method !== 'datareader'));
   
   // Sort analyses by date (newest first)
   $: {
@@ -124,8 +124,13 @@
     </div>
   {:else if sortedAnalyses.length === 0}
     <div class="rounded border border-gray-200 bg-gray-50 p-4 text-center text-gray-500">
-      <p>No analyses found{filterByCurrentFile ? ' for the current file' : ''}.</p>
-      <p class="mt-2 text-sm">Run an analysis method to see results here.</p>
+      <div class="flex flex-col items-center">
+        <svg class="w-12 h-12 text-gray-400 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"></path>
+        </svg>
+        <p class="font-medium">No analyses found{filterByCurrentFile ? ' for the current file' : ''}.</p>
+        <p class="mt-2 text-sm">Run an analysis method (FEL, SLAC, etc.) to see results here.</p>
+      </div>
     </div>
   {:else}
     <div class="max-h-[500px] overflow-y-auto pr-1">

--- a/src/lib/ResultsTab.svelte
+++ b/src/lib/ResultsTab.svelte
@@ -108,9 +108,31 @@
         <h2 class="text-premium-header font-semibold text-text-rich mb-premium-md">Analysis Results</h2>
         {#if selectedAnalysisId}
           <AnalysisResultViewer analysisId={selectedAnalysisId} />
+        {:else if $analysisStore.analyses.filter(a => a.method !== 'datareader').length > 0}
+          <div class="flex flex-col items-center justify-center h-64 bg-brand-whisper rounded-premium text-center">
+            <div class="mb-premium-md">
+              <svg class="w-16 h-16 text-text-muted mx-auto mb-premium-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+              </svg>
+              <h3 class="text-premium-title font-semibold text-text-rich mb-premium-xs">Select an Analysis</h3>
+              <p class="text-premium-body text-text-slate">Choose an analysis from the history to view detailed results</p>
+            </div>
+          </div>
         {:else}
-          <div class="flex items-center justify-center h-64 bg-brand-whisper rounded-premium">
-            <p class="text-premium-body text-text-slate">Select an analysis from the history to view results</p>
+          <div class="flex flex-col items-center justify-center h-64 bg-brand-whisper rounded-premium text-center">
+            <div class="mb-premium-md">
+              <svg class="w-16 h-16 text-text-muted mx-auto mb-premium-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+              </svg>
+              <h3 class="text-premium-title font-semibold text-text-rich mb-premium-xs">No Analyses Yet</h3>
+              <p class="text-premium-body text-text-slate mb-premium-md">You haven't run any analyses yet. Get started by uploading a file and running an analysis method.</p>
+              <button 
+                on:click={() => onChange('analyze')}
+                class="bg-brand-royal hover:bg-brand-deep text-white font-medium py-premium-sm px-premium-md rounded-premium transition-colors"
+              >
+                Go to Analyze Tab
+              </button>
+            </div>
           </div>
         {/if}
       </div>


### PR DESCRIPTION
## Summary
- Replaces error messages with friendly empty states in Results tab
- Shows helpful guidance when no analyses have been run yet
- Adds "Go to Analyze Tab" button for better user flow
- Distinguishes between "no analyses" and "select an analysis" states
- Excludes datareader analyses from counts (they're just file processing)

## Test plan
- [x] Visit Results tab without any analyses - shows friendly empty state with guidance
- [x] Load a file (only datareader runs) - still shows empty state since datareader isn't a user analysis
- [x] Run an actual analysis - shows "Select an Analysis" state
- [x] Select an analysis - shows results properly

🤖 Generated with [Claude Code](https://claude.ai/code)