### PR TITLE
Fix ReferenceError: currentLogs is not defined in analyses.js

### DIFF
--- a/src/stores/analyses.js
+++ b/src/stores/analyses.js
@@ -339,20 +339,23 @@ function createAnalysisStore() {
 			});
 			
 			// If we have an active analysis ID, update its status in both client and server
-			if (analysisId) {					
+			if (analysisId) {
+				// Get current logs and result from the active analysis
+				const currentLogs = currentState.activeAnalysis.logs || [];
+				const currentResult = currentState.activeAnalysis.result || null;
+				
 				// Update IndexedDB
 				try {
 					const analysis = await analysisStorage.getAnalysis(analysisId);
 					if (analysis) {
-						// Get current logs and result from the active analysis
-						const currentLogs = currentState.activeAnalysis.logs || [];
-						const currentResult = currentState.activeAnalysis.result || analysis.result;
+						// Use the saved result if no current result is available
+						const finalResult = currentResult || analysis.result;
 						
 						await analysisStorage.saveAnalysis({
 							...analysis,
 							status,
 							logs: currentLogs, // Include logs from active analysis
-							result: currentResult, // Ensure result is saved with raw stdout
+							result: finalResult, // Ensure result is saved with raw stdout
 							completedAt: success ? new Date().getTime() : undefined
 						});
 						
@@ -365,7 +368,7 @@ function createAnalysisStore() {
 											...a, 
 											status, 
 											logs: currentLogs, // Include logs here too
-											result: currentResult, // Include result with raw stdout here too
+											result: finalResult, // Include result with raw stdout here too
 											completedAt: success ? new Date().getTime() : undefined 
 										}
 									: a


### PR DESCRIPTION
## Summary
- Fixes JavaScript error that occurred when loading sample files
- Resolves ReferenceError where currentLogs and currentResult were undefined
- Was caused by variable scope issue in completeAnalysisProgress function

## Problem
Variables `currentLogs` and `currentResult` were defined inside the first try block but referenced in the second try block where they were out of scope, causing ReferenceError.

## Solution
- Move variable declarations outside try blocks to proper scope
- Use `finalResult` variable for IndexedDB storage to handle null currentResult
- Maintain access to variables in both IndexedDB and server API calls

## Test plan
- [x] Load a sample file (e.g., CD2-slim.fna) 
- [x] Check browser console for no ReferenceError
- [x] Verify analysis progress tracking works properly
- [x] Confirm both IndexedDB and server updates work

🤖 Generated with [Claude Code](https://claude.ai/code)