### PR TITLE
Add auto-updating analysis status and remove refresh button

### DIFF
--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -82,6 +82,16 @@
 		return new Date(timestamp).toLocaleString();
 	}
 
+	// Subscribe to store changes to auto-update when analysis status changes
+	$: if (analysisId && $analysisStore.analyses) {
+		// Find the current analysis in the store
+		const storeAnalysis = $analysisStore.analyses.find(a => a.id === analysisId);
+		if (storeAnalysis && (!analysis || storeAnalysis.status !== analysis.status || storeAnalysis.completedAt !== analysis.completedAt)) {
+			// Analysis has been updated in the store, reload it
+			loadAnalysis(analysisId);
+		}
+	}
+
 	onMount(() => {
 		if (analysisId) {
 			loadAnalysis(analysisId);
@@ -108,26 +118,6 @@
 			<div class="bg-gray-100 p-4">
 				<div class="flex items-center justify-between">
 					<h2 class="text-xl font-bold">{analysis.method.toUpperCase()} Analysis</h2>
-					<button
-						class="flex items-center rounded bg-blue-500 px-3 py-1 text-sm text-white hover:bg-blue-600"
-						on:click={() => loadAnalysis(analysisId)}
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							class="mr-1 h-4 w-4"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-							/>
-						</svg>
-						Refresh
-					</button>
 				</div>
 				<div class="text-sm text-gray-600">
 					<p>File: {file.filename}</p>


### PR DESCRIPTION
## Summary
Fixes the issue where analysis status stays "Pending" until manually refreshed by adding automatic status updates and removing the now-unnecessary refresh button.

## Problem
- Analysis results showing "Pending" status never auto-update to "Completed"
- Users had to manually click "Refresh" button to see status changes
- Poor UX requiring manual intervention for status updates

## Solution
- **Added reactive store subscription** to automatically detect analysis status changes
- **Removed manual refresh button** since auto-updates make it unnecessary
- **Improved real-time UX** with automatic status updates

## Changes
- ✅ Add reactive `$:` statement to watch `$analysisStore.analyses` for changes
- ✅ Auto-reload analysis when status or completedAt changes in store
- ✅ Remove refresh button from AnalysisResultViewer header
- ✅ Prevent infinite update loops with smart change detection

## Test plan
- [x] Start an analysis and verify it shows as "Pending"
- [x] Wait for analysis to complete and verify it automatically updates to "Completed"
- [x] Verify no manual refresh is needed
- [x] Verify refresh button is removed from UI
- [x] Verify no infinite update loops occur

🤖 Generated with [Claude Code](https://claude.ai/code)