### PR TITLE
Fix AnalysisProgress to show status of clicked analysis

### DIFF
--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -324,7 +324,7 @@
 					{/if}
 				{:else if ['pending', 'running', 'mounting', 'processing', 'saving'].includes(analysis.status)}
 					<!-- Show the detailed analysis progress when viewing a pending/running analysis -->
-					<AnalysisProgress />
+					<AnalysisProgress analysisId={analysisId} />
 				{:else}
 					<p class="text-gray-600">No results available</p>
 				{/if}


### PR DESCRIPTION
## Summary
- Fixed AnalysisProgress component to show status of the specific analysis being viewed instead of always showing the most recently run analysis
- Added analysisId prop to AnalysisProgress component for context-aware progress display
- Updated AnalysisResultViewer to pass the current analysis ID to AnalysisProgress

## Changes Made
- Modified AnalysisProgress.svelte to accept optional analysisId prop
- Added getAnalysisProgress() function to determine which progress data to display
- Updated all progress references to use the contextual analysis data
- Updated AnalysisResultViewer.svelte to pass analysisId to AnalysisProgress component

## Test Plan
- [x] Run multiple analyses and verify each shows correct progress when clicked
- [x] Verify completed analyses show proper completion status
- [x] Verify running analyses show live progress when active
- [x] Verify pending analyses show appropriate pending status