### PR TITLE
Clean up Analysis History duplicate headers

### DIFF
--- a/src/lib/AnalysisHistory.svelte
+++ b/src/lib/AnalysisHistory.svelte
@@ -118,7 +118,6 @@
 </script>
 
 <div class="analysis-history">
-	<h2 class="mb-3 text-xl font-bold">Analysis History</h2>
 
 	{#if $analysisStore.isLoading}
 		<div class="flex items-center justify-center p-4">

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -175,7 +175,7 @@
 		{/if}
 	</div>
 
-	<!-- Analysis History Section (collapsible) -->
+	<!-- Recent Analyses Section (collapsible) -->
 	<div class="mb-premium-xl rounded-premium border border-border-platinum bg-white shadow-premium">
 		<div
 			class="flex cursor-pointer items-center justify-between rounded-t-premium bg-brand-whisper p-premium-md transition-all duration-premium hover:bg-brand-ghost"

--- a/src/lib/ResultsTab.svelte
+++ b/src/lib/ResultsTab.svelte
@@ -99,7 +99,7 @@
 			<!-- Left column: Analysis history -->
 			<div class="rounded-premium bg-white p-premium-lg shadow-premium lg:col-span-1">
 				<h2 class="mb-premium-md text-premium-header font-semibold text-text-rich">
-					Analysis History
+					Analyses
 				</h2>
 				<AnalysisHistory
 					filterByCurrentFile={!showAllHistory && !!$currentFile}


### PR DESCRIPTION
## Summary
- Removed duplicate "Analysis History" header that was appearing twice in the sidebar
- Renamed the section to just "Analyses" for cleaner, more concise labeling
- Updated related comments for consistency

## Changes Made
- **ResultsTab.svelte**: Changed "Analysis History" header to "Analyses"
- **AnalysisHistory.svelte**: Removed the duplicate internal "Analysis History" header
- **AnalyzeTab.svelte**: Updated comment from "Analysis History" to "Recent Analyses"

## Before/After
**Before**: Two "Analysis History" headers stacked vertically  
**After**: Single "Analyses" header with clean layout

## Test Plan
- [x] Verify no duplicate headers in Results tab sidebar
- [x] Confirm "Analyses" header displays correctly
- [x] Check that analysis list functionality remains unchanged