### PR TITLE
Add Clear All button to remove all analyses at once

### DIFF
--- a/src/lib/ResultsTab.svelte
+++ b/src/lib/ResultsTab.svelte
@@ -26,6 +26,23 @@
 	function setViewMode(mode) {
 		viewMode = mode;
 	}
+
+	// Handle Clear All analyses
+	async function handleClearAll() {
+		const filteredAnalyses = $analysisStore.analyses.filter((a) => a.method !== 'datareader');
+		if (filteredAnalyses.length === 0) return;
+
+		const confirmMessage = `Are you sure you want to delete all ${filteredAnalyses.length} analyses? This action cannot be undone.`;
+		
+		if (confirm(confirmMessage)) {
+			try {
+				await analysisStore.clearAllAnalyses();
+			} catch (error) {
+				console.error('Error clearing all analyses:', error);
+				alert('Failed to clear analyses: ' + error.message);
+			}
+		}
+	}
 </script>
 
 <div class="results-tab">
@@ -98,9 +115,37 @@
 		<div class="grid grid-cols-1 gap-premium-xl lg:grid-cols-3">
 			<!-- Left column: Analysis history -->
 			<div class="rounded-premium bg-white p-premium-lg shadow-premium lg:col-span-1">
-				<h2 class="mb-premium-md text-premium-header font-semibold text-text-rich">
-					Analyses
-				</h2>
+				<div class="mb-premium-md flex items-center justify-between">
+					<h2 class="text-premium-header font-semibold text-text-rich">
+						Analyses
+					</h2>
+					{#if $analysisStore.analyses.filter((a) => a.method !== 'datareader').length > 0}
+						<button
+							on:click={handleClearAll}
+							class="inline-flex items-center rounded bg-red-100 px-2.5 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-200"
+							title="Delete all analyses"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="mr-1 h-3 w-3"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+							>
+								<path
+									fill-rule="evenodd"
+									d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"
+									clip-rule="evenodd"
+								/>
+								<path
+									fill-rule="evenodd"
+									d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+							Clear All
+						</button>
+					{/if}
+				</div>
 				<AnalysisHistory
 					filterByCurrentFile={!showAllHistory && !!$currentFile}
 					onSelectAnalysis={selectAnalysis}

--- a/src/lib/utils/indexedDBStorage.js
+++ b/src/lib/utils/indexedDBStorage.js
@@ -453,6 +453,34 @@ export const analysisStorage = {
 			console.error('Error in deleteAnalysis:', error);
 			throw error;
 		}
+	},
+
+	/**
+	 * Clear all analyses from IndexedDB
+	 * @returns {Promise<boolean>} - True if successful
+	 */
+	async clearAllAnalyses() {
+		try {
+			const db = await initDB();
+
+			return new Promise((resolve, reject) => {
+				const transaction = db.transaction([ANALYSES_STORE], 'readwrite');
+				const store = transaction.objectStore(ANALYSES_STORE);
+				const request = store.clear();
+
+				request.onsuccess = () => {
+					resolve(true);
+				};
+
+				request.onerror = (event) => {
+					console.error('Error clearing all analyses:', event.target.error);
+					reject(event.target.error);
+				};
+			});
+		} catch (error) {
+			console.error('Error in clearAllAnalyses:', error);
+			throw error;
+		}
 	}
 };
 

--- a/src/stores/analyses.js
+++ b/src/stores/analyses.js
@@ -454,6 +454,38 @@ function createAnalysisStore() {
 				...state,
 				activeAnalysesList: state.activeAnalysesList.filter((a) => a.id !== analysisId)
 			}));
+		},
+
+		// Clear all analyses
+		async clearAllAnalyses() {
+			if (!browser) return;
+
+			update((state) => ({ ...state, isLoading: true, error: null }));
+
+			try {
+				// Clear all analyses from IndexedDB
+				await analysisStorage.clearAllAnalyses();
+
+				// Reset the store state
+				update((state) => ({
+					...state,
+					analyses: [],
+					currentAnalysisId: null,
+					activeAnalysis: {
+						id: null,
+						status: null,
+						progress: 0,
+						message: '',
+						logs: []
+					},
+					activeAnalysesList: [],
+					isLoading: false
+				}));
+			} catch (error) {
+				console.error('Error clearing all analyses:', error);
+				update((state) => ({ ...state, error: error.message, isLoading: false }));
+				throw error;
+			}
 		}
 	};
 }


### PR DESCRIPTION
## Summary
- Add "Clear All" button to the analyses section in Results tab
- Only displays when analyses exist (excluding datareader operations)
- Shows confirmation dialog with count of analyses to be deleted
- Clears all analyses from IndexedDB and resets store state

## Test plan
- [x] Clear All button appears in analyses section when analyses exist
- [x] Button is hidden when no analyses are present
- [x] Confirmation dialog shows correct count of analyses
- [x] Successfully clears all analyses from IndexedDB
- [x] Resets store state including active analyses
- [x] UI updates immediately after clearing

🤖 Generated with [Claude Code](https://claude.ai/code)