### PR TITLE
Remove Compare button from AnalysisCard component

### DIFF
--- a/src/lib/AnalysisCard.svelte
+++ b/src/lib/AnalysisCard.svelte
@@ -155,11 +155,6 @@
 		dispatch('export', { analysisId: analysis.id });
 	}
 
-	// Handle compare action
-	function compareAnalysis() {
-		dispatch('compare', { analysisId: analysis.id });
-	}
-
 	// Handle cancel action
 	function cancelAnalysis() {
 		dispatch('cancel', { analysisId: analysis.id });
@@ -391,25 +386,6 @@
 						/>
 					</svg>
 					Export
-				</button>
-
-				<button
-					on:click|stopPropagation={compareAnalysis}
-					class="inline-flex items-center rounded bg-purple-100 px-2.5 py-1.5 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-200"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						class="mr-1 h-3 w-3"
-						viewBox="0 0 20 20"
-						fill="currentColor"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-						clip-rule="evenodd"
-					/>
-					</svg>
-					Compare
 				</button>
 			{/if}
 

--- a/src/lib/AnalysisHistory.svelte
+++ b/src/lib/AnalysisHistory.svelte
@@ -99,12 +99,6 @@
 		// Implement export functionality
 	}
 
-	// Handle compare action
-	function handleCompare(event) {
-		const { analysisId } = event.detail;
-		// Implementation depends on comparison UI
-	}
-
 	// Handle cancel action
 	async function handleCancel(event) {
 		const { analysisId } = event.detail;
@@ -205,7 +199,6 @@
 									on:select={handleSelect}
 									on:view={handleView}
 									on:export={handleExport}
-									on:compare={handleCompare}
 									on:cancel={handleCancel}
 									on:delete={handleDelete}
 								/>
@@ -224,7 +217,6 @@
 							on:select={handleSelect}
 							on:view={handleView}
 							on:export={handleExport}
-							on:compare={handleCompare}
 							on:cancel={handleCancel}
 							on:delete={handleDelete}
 						/>


### PR DESCRIPTION
## Summary
Removed the remaining Compare button that was still showing in the AnalysisCard component after removing the Compare View functionality.

## Changes
- Removed Compare button from completed analyses action buttons
- Removed `compareAnalysis` function from AnalysisCard component
- Removed `handleCompare` function from AnalysisHistory component  
- Removed `on:compare` event bindings from AnalysisCard instances

## Test plan
- [x] Analysis cards no longer show Compare button
- [x] All other action buttons (View, Export, Cancel, Delete) work correctly
- [x] No TypeScript or build errors
- [x] UI is cleaner with just the essential action buttons

🤖 Generated with [Claude Code](https://claude.ai/code)