### PR TITLE
Remove GitHub link from header navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,16 +38,6 @@
 							Home
 						</a>
 					</li>
-					<li>
-						<a
-							class="rounded-premium-sm bg-brand-gradient px-[16px] py-[8px] text-premium-body font-semibold tracking-premium-wide text-white shadow-sm transition-all duration-premium hover:bg-brand-deep"
-							href="https://github.com/stevenweaver/datamonkey3"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							GitHub
-						</a>
-					</li>
 				</ul>
 
 				<!-- Analysis Status Indicator -->


### PR DESCRIPTION
## Summary
Removed the GitHub link from the top navigation bar to simplify the header UI.

## Changes
- Removed GitHub button from header navigation
- Kept GitHub link in footer for users who need repository access
- Header now only shows Home link alongside the analysis status indicator

## Test plan
- [x] Header renders correctly without GitHub button
- [x] Home link still works
- [x] Analysis status indicator remains properly positioned
- [x] GitHub link is still accessible in footer
- [x] No build or TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)