### PR TITLE
Remove unused routes and tree inference disclaimer

### DIFF
--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -273,28 +273,6 @@
 				<span class="mr-premium-xs">🌳</span> Phylogenetic Tree
 			</h2>
 
-			<!-- Development Preview Banner -->
-			<div class="mb-premium-md rounded-premium border border-amber-200 bg-amber-50 p-premium-sm">
-				<p class="flex items-center text-premium-caption text-amber-800">
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						class="mr-2 h-4 w-4 flex-shrink-0"
-						viewBox="0 0 20 20"
-						fill="currentColor"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-							clip-rule="evenodd"
-						/>
-					</svg>
-					<span>
-						<strong>Development Preview:</strong> The tree inference functionality is currently simulated
-						for UI demonstration purposes. Backend implementation coming soon.
-					</span>
-				</p>
-			</div>
-
 			<div
 				class="rounded-premium border border-border-platinum bg-white p-premium-lg shadow-premium"
 			>

--- a/src/lib/TreeInferenceSection.svelte
+++ b/src/lib/TreeInferenceSection.svelte
@@ -158,28 +158,6 @@
 		<span class="mr-premium-xs">🌳</span> Phylogenetic Tree
 	</h2>
 
-	<!-- Disclaimer banner -->
-	<div class="mb-premium-md rounded-premium border border-amber-200 bg-amber-50 p-premium-sm">
-		<p class="flex items-center text-premium-caption text-amber-800">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				class="mr-2 h-4 w-4 flex-shrink-0"
-				viewBox="0 0 20 20"
-				fill="currentColor"
-			>
-				<path
-					fill-rule="evenodd"
-					d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-					clip-rule="evenodd"
-				/>
-			</svg>
-			<span
-				><strong>Development Preview:</strong> The tree inference functionality is currently simulated
-				for UI demonstration purposes. Backend implementation coming soon.</span
-			>
-		</p>
-	</div>
-
 	<div class="rounded-premium border border-border-platinum bg-white p-premium-lg shadow-premium">
 		{#if !$currentFile}
 			<div class="rounded-premium bg-brand-whisper p-premium-md text-center">


### PR DESCRIPTION
## Summary
- Removed unused routes: `/methods/`, `/sentry-example-page/`, and `/hyphy/`
- Removed tree inference development preview disclaimer from UI components
- Kept demo and debug routes as they are actively used

## Changes
1. **Deleted routes:**
   - `/src/routes/methods/[...method]/+page.svelte` - Old routing structure no longer used
   - `/src/routes/sentry-example-page/` - Example page not needed in production
   - `/src/routes/hyphy/` - Unused HyPhy route

2. **Updated components:**
   - `src/lib/AnalyzeTab.svelte` - Removed tree inference disclaimer
   - `src/lib/TreeInferenceSection.svelte` - Removed tree inference disclaimer

## Test plan
- [x] Verify application still builds successfully
- [x] Confirm demo routes still work at `/demo`
- [x] Ensure debug routes remain accessible
- [x] Check that tree inference UI displays without disclaimer

🤖 Generated with [Claude Code](https://claude.ai/code)