### PR TITLE
Validate codon alignment before SLURM submission

### DIFF
--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -206,8 +206,8 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			configKeys: Object.keys(config || {})
 		});
 
-		// Validate input using base class method
-		this.validateInput(fastaData, treeData, method);
+		// Validate input using base class method (includes codon alignment check)
+		this.validateInput(fastaData, treeData, method, config);
 
 		if (!this.socket || !this.socket.connected) {
 			console.log('🔌 Socket not connected, attempting to connect...');

--- a/src/lib/services/BaseAnalysisRunner.js
+++ b/src/lib/services/BaseAnalysisRunner.js
@@ -6,6 +6,15 @@
 import { analysisStore } from '../../stores/analyses.js';
 import { toastStore } from '../../stores/toast.js';
 import { get } from 'svelte/store';
+import { validateCodonAlignment } from '../utils/fastaValidation.js';
+
+/**
+ * Methods that require codon-aligned input (sequence length divisible by 3, no premature stop codons).
+ */
+const CODON_AWARE_METHODS = new Set([
+	'fel', 'slac', 'fubar', 'meme', 'absrel', 'busted', 'relax',
+	'contrast-fel', 'bgm', 'prime', 'multi-hit', 'multihit', 'b-still', 'bstill'
+]);
 
 export class BaseAnalysisRunner {
 	constructor() {
@@ -167,8 +176,12 @@ export class BaseAnalysisRunner {
 
 	/**
 	 * Validate common input parameters
+	 * @param {string} fastaData - FASTA sequence data
+	 * @param {string} treeData - Phylogenetic tree data
+	 * @param {string} method - Analysis method name
+	 * @param {Object} [config={}] - Analysis configuration (used for geneticCodeId)
 	 */
-	validateInput(fastaData, treeData, method) {
+	validateInput(fastaData, treeData, method, config = {}) {
 		if (!fastaData || !fastaData.trim()) {
 			throw new Error('FASTA data is empty or invalid');
 		}
@@ -179,6 +192,15 @@ export class BaseAnalysisRunner {
 
 		if (!method || !method.trim()) {
 			throw new Error('Analysis method is required');
+		}
+
+		// For codon-aware methods, validate alignment is proper codon data
+		if (CODON_AWARE_METHODS.has(method.toLowerCase())) {
+			const geneticCodeId = config.geneticCodeId !== undefined ? config.geneticCodeId : 0;
+			const result = validateCodonAlignment(fastaData, geneticCodeId);
+			if (!result.valid) {
+				throw new Error(result.errors.join('\n'));
+			}
 		}
 	}
 

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -101,8 +101,8 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 			console.log('No tree data provided');
 		}
 
-		// Validate input using base class method
-		this.validateInput(fastaData, treeData, method);
+		// Validate input using base class method (includes codon alignment check)
+		this.validateInput(fastaData, treeData, method, config);
 
 		// Ensure WASM is initialized
 		await this.initialize();

--- a/src/lib/utils/fastaValidation.js
+++ b/src/lib/utils/fastaValidation.js
@@ -271,6 +271,93 @@ export function sanitizeSequenceNames(fastaData, treeData) {
 }
 
 /**
+ * Stop codons by genetic code ID.
+ * Only entries that differ from Universal (0) are listed separately.
+ */
+const STOP_CODONS_BY_GENETIC_CODE = {
+	0: ['TAA', 'TAG', 'TGA'],  // Universal
+	1: ['TAA', 'TAG', 'AGA', 'AGG'],  // Vertebrate mitochondrial
+	2: ['TAA', 'TAG'],  // Yeast mitochondrial
+	3: ['TAA', 'TAG'],  // Mold mitochondrial
+	4: ['TAA', 'TAG'],  // Invertebrate mitochondrial
+	5: ['TGA'],  // Ciliate nuclear (TAA/TAG code for Gln)
+	6: ['TAA', 'TAG'],  // Echinoderm mitochondrial
+	7: ['TAA', 'TAG'],  // Euplotid nuclear
+	8: ['TAA', 'TAG', 'TGA'],  // Alternative yeast nuclear
+	9: ['TAA', 'TAG'],  // Ascidian mitochondrial
+	10: ['TAA', 'TAG'],  // Flatworm mitochondrial
+	11: ['TAA', 'TGA']  // Blepharisma nuclear
+};
+
+/**
+ * Validate a codon alignment for submission to codon-aware methods.
+ * Checks that sequence lengths are divisible by 3 and scans for in-frame stop codons.
+ *
+ * @param {string} fastaData - Raw FASTA string content
+ * @param {number} [geneticCodeId=0] - Genetic code ID (0 = Universal)
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateCodonAlignment(fastaData, geneticCodeId = 0) {
+	const errors = [];
+
+	if (!fastaData || !fastaData.trim()) {
+		return { valid: false, errors: ['FASTA data is empty'] };
+	}
+
+	let parsed;
+	try {
+		parsed = parseFasta(fastaData);
+	} catch (e) {
+		return { valid: false, errors: [e.message] };
+	}
+
+	const { sequences } = parsed;
+
+	if (sequences.length === 0) {
+		return { valid: false, errors: ['No sequences found in FASTA data'] };
+	}
+
+	// Check divisibility by 3 using the first sequence
+	const firstSeqLength = sequences[0].sequence.replace(/[-.]/g, '').length;
+	if (firstSeqLength % 3 !== 0) {
+		errors.push(
+			`Sequence length (${firstSeqLength}) is not divisible by 3. ` +
+			`Codon-based analyses require in-frame coding sequences.`
+		);
+	}
+
+	// Determine stop codons for this genetic code
+	const stopCodons = STOP_CODONS_BY_GENETIC_CODE[geneticCodeId] ||
+		STOP_CODONS_BY_GENETIC_CODE[0];
+
+	const stopCodonSet = new Set(stopCodons);
+
+	// Scan each sequence for in-frame stop codons (excluding the last codon)
+	for (const seq of sequences) {
+		const cleanSeq = seq.sequence.replace(/[-.]/g, '').toUpperCase();
+		// Only check if length is divisible by 3, otherwise we already reported that error
+		if (cleanSeq.length % 3 !== 0) continue;
+
+		const lastCodonStart = cleanSeq.length - 3;
+		for (let i = 0; i < lastCodonStart; i += 3) {
+			const codon = cleanSeq.substring(i, i + 3);
+			if (stopCodonSet.has(codon)) {
+				const codonPosition = (i / 3) + 1;
+				errors.push(
+					`In-frame stop codon (${codon}) found in sequence "${seq.header}" ` +
+					`at codon position ${codonPosition}. Codon-based analyses cannot proceed ` +
+					`with premature stop codons.`
+				);
+				// Only report first stop codon per sequence to keep messages manageable
+				break;
+			}
+		}
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+/**
  * Convert sequences to FASTA format string
  * @param {Array} sequences - Array of sequence objects
  * @param {number} lineWidth - Line width for sequence wrapping (default: 80)

--- a/src/test/codon-validation.test.js
+++ b/src/test/codon-validation.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for validateCodonAlignment() utility
+ * Verifies that codon alignment validation catches:
+ * - Sequences not divisible by 3
+ * - In-frame stop codons for various genetic codes
+ * - Edge cases (empty input, single codons, etc.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateCodonAlignment } from '../lib/utils/fastaValidation.js';
+
+// Helper to build a simple FASTA string
+function fasta(seqs) {
+	return seqs.map(([name, seq]) => `>${name}\n${seq}`).join('\n');
+}
+
+describe('validateCodonAlignment', () => {
+	describe('valid alignments', () => {
+		it('accepts a valid codon alignment (divisible by 3, no stop codons)', () => {
+			const data = fasta([
+				['Seq1', 'ATGAAACCC'],
+				['Seq2', 'ATGAAAGGG']
+			]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(true);
+			expect(result.errors).toHaveLength(0);
+		});
+
+		it('accepts a single codon sequence (length 3)', () => {
+			const data = fasta([['Seq1', 'ATG']]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(true);
+		});
+
+		it('allows a terminal stop codon (last codon)', () => {
+			// TAA at the end should not be flagged since it is the terminal codon
+			const data = fasta([['Seq1', 'ATGAAATAA']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe('not divisible by 3', () => {
+		it('rejects alignment whose length is not divisible by 3', () => {
+			const data = fasta([
+				['Seq1', 'ATGAA'],
+				['Seq2', 'ATGCC']
+			]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+			expect(result.errors.length).toBeGreaterThan(0);
+			expect(result.errors[0]).toContain('not divisible by 3');
+		});
+
+		it('rejects single nucleotide', () => {
+			const data = fasta([['Seq1', 'A']]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('not divisible by 3');
+		});
+	});
+
+	describe('in-frame stop codons (Universal code)', () => {
+		it('detects TAA stop codon in-frame', () => {
+			// TAA at codon position 2 (in-frame, not terminal)
+			const data = fasta([['Seq1', 'ATGTAACCC']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TAA');
+			expect(result.errors[0]).toContain('codon position 2');
+		});
+
+		it('detects TAG stop codon in-frame', () => {
+			const data = fasta([['Seq1', 'ATGTAGCCC']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TAG');
+		});
+
+		it('detects TGA stop codon in-frame', () => {
+			const data = fasta([['Seq1', 'ATGTGACCC']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TGA');
+		});
+
+		it('does not flag stop codons that are out of frame', () => {
+			// "AATAAGGCC" - TAA starts at position 1 (out of frame)
+			// Codons: AAT AAG GCC - none are stop codons
+			const data = fasta([['Seq1', 'AATAAGCCC']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe('multiple sequences', () => {
+		it('detects stop codon in second sequence only', () => {
+			const data = fasta([
+				['Clean', 'ATGAAACCC'],
+				['Dirty', 'ATGTAACCC']
+			]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('Dirty');
+		});
+
+		it('reports stop codons in multiple sequences', () => {
+			const data = fasta([
+				['Seq1', 'ATGTAACCC'],
+				['Seq2', 'ATGTAGCCC']
+			]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors).toHaveLength(2);
+		});
+	});
+
+	describe('genetic code variants', () => {
+		it('Ciliate nuclear (5): TAA is NOT a stop codon', () => {
+			// In ciliate nuclear code, only TGA is a stop codon
+			const data = fasta([['Seq1', 'ATGTAACCC']]);
+			const result = validateCodonAlignment(data, 5);
+			// TAA codes for Gln in ciliate nuclear, should be valid
+			expect(result.valid).toBe(true);
+		});
+
+		it('Ciliate nuclear (5): TGA IS a stop codon', () => {
+			const data = fasta([['Seq1', 'ATGTGACCC']]);
+			const result = validateCodonAlignment(data, 5);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TGA');
+		});
+
+		it('Vertebrate mito (1): AGA is a stop codon', () => {
+			const data = fasta([['Seq1', 'ATGAGACCC']]);
+			const result = validateCodonAlignment(data, 1);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('AGA');
+		});
+
+		it('Vertebrate mito (1): TGA is NOT a stop codon', () => {
+			// In vertebrate mitochondrial code, TGA codes for Trp
+			const data = fasta([['Seq1', 'ATGTGACCC']]);
+			const result = validateCodonAlignment(data, 1);
+			expect(result.valid).toBe(true);
+		});
+
+		it('unknown genetic code falls back to Universal', () => {
+			const data = fasta([['Seq1', 'ATGTAACCC']]);
+			const result = validateCodonAlignment(data, 999);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TAA');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns invalid for null input', () => {
+			const result = validateCodonAlignment(null);
+			expect(result.valid).toBe(false);
+			expect(result.errors).toHaveLength(1);
+		});
+
+		it('returns invalid for empty string', () => {
+			const result = validateCodonAlignment('');
+			expect(result.valid).toBe(false);
+		});
+
+		it('returns invalid for whitespace-only input', () => {
+			const result = validateCodonAlignment('   \n  ');
+			expect(result.valid).toBe(false);
+		});
+
+		it('handles lowercase sequences', () => {
+			const data = fasta([['Seq1', 'atgtaaccc']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TAA');
+		});
+
+		it('ignores gap characters when checking length', () => {
+			// 9 nucleotides + 3 gaps = 12 chars, but clean length is 9 (divisible by 3)
+			const data = fasta([['Seq1', 'ATG---AAACCC']]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(true);
+		});
+
+		it('defaults to genetic code 0 when not specified', () => {
+			const data = fasta([['Seq1', 'ATGTAACCC']]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `validateCodonAlignment(fastaData, geneticCodeId)` to check sequence length is divisible by 3 and scan for in-frame stop codons before job submission
- Supports all 12 genetic codes with correct stop codon tables (e.g., Ciliate nuclear where TAA/TAG are Gln, not stops)
- Extends `BaseAnalysisRunner.validateInput()` to run codon validation for all codon-aware methods (FEL, SLAC, FUBAR, MEME, aBSREL, BUSTED, RELAX, Contrast-FEL, BGM, PRIME, Multi-Hit, B-STILL)
- Errors propagate through existing error handling in AnalyzeTab and surface as user-facing toast messages
- Terminal stop codons (last codon) are allowed; only premature in-frame stops are flagged

Fixes #121

## Test plan
- [x] 22 unit tests passing (codon-validation.test.js)
- [ ] Upload alignment not divisible by 3 → verify error toast before submission
- [ ] Upload alignment with in-frame stop codons → verify error toast
- [ ] Upload valid codon alignment → verify submission proceeds normally
- [ ] Test with non-Universal genetic code (e.g., Vertebrate mito)
- [ ] Verify GARD (non-codon method) is not affected by validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)