### PR TITLE
Validate GARD model/datatype compatibility with auto-detection

### DIFF
--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -2,6 +2,7 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 	import { backendConnectivity } from '../stores/backendConnectivity.js';
+	import { fileMetricsStore } from '../stores/fileInfo';
 	import { treeStore } from '../stores/tree';
 	import BranchSelector from './BranchSelector.svelte';
 	import AnalysisTimingEstimate from './AnalysisTimingEstimate.svelte';
@@ -575,15 +576,26 @@
 			datatype: {
 				type: 'select',
 				label: 'Data type',
-				default: 'codon',
+				default: 'nucleotide',
 				options: ['codon', 'nucleotide', 'protein'],
 				description: 'Type of data to analyze for recombination'
 			},
 			model: {
 				type: 'select',
 				label: 'Substitution model',
-				default: 'JTT',
+				default: 'GTR',
 				options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
+				filteredOptionsBy: 'datatype',
+				filteredOptions: {
+					codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
+					nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
+					protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
+				},
+				filteredDefaults: {
+					codon: 'GTR',
+					nucleotide: 'GTR',
+					protein: 'JTT'
+				},
 				description: 'Substitution model to use for the analysis'
 			},
 			mode: {
@@ -947,6 +959,30 @@
 		initializeMethodOptions(selectedMethod);
 	}
 
+	// Auto-detect data type from uploaded file for GARD
+	$: if ($fileMetricsStore?.FILE_INFO?.gencodeid !== undefined &&
+		selectedMethod?.toLowerCase() === 'gard' &&
+		methodOptions[selectedMethod]) {
+		const gencodeid = $fileMetricsStore.FILE_INFO.gencodeid;
+		const detectedType = gencodeid === -2 ? 'protein' : gencodeid === -1 ? 'nucleotide' : 'codon';
+		if (methodOptions[selectedMethod].datatype !== detectedType) {
+			methodOptions[selectedMethod].datatype = detectedType;
+			methodOptions = { ...methodOptions };
+		}
+	}
+
+	// When GARD datatype changes, ensure model is compatible
+	$: if (selectedMethod?.toLowerCase() === 'gard' && methodOptions[selectedMethod]) {
+		const dt = methodOptions[selectedMethod].datatype;
+		const modelConfig = METHOD_ADVANCED_OPTIONS.gard.model;
+		const validModels = modelConfig.filteredOptions?.[dt];
+		const currentModel = methodOptions[selectedMethod].model;
+		if (validModels && !validModels.includes(currentModel)) {
+			methodOptions[selectedMethod].model = modelConfig.filteredDefaults?.[dt] || validModels[0];
+			methodOptions = { ...methodOptions };
+		}
+	}
+
 	// Pre-computed renderable options array (excludes interactive-tree)
 	$: renderableAdvancedOptions = (selectedMethod && methodOptions[selectedMethod])
 		? Object.entries(currentMethodOptions)
@@ -958,7 +994,18 @@
 						config.enabledWhen.includes(
 							methodOptions[selectedMethod][config.dependsOn]
 						));
-				return { key, config, isEnabled };
+
+				// Resolve filtered options for selects constrained by another option
+				let effectiveConfig = config;
+				if (config.filteredOptionsBy && config.filteredOptions) {
+					const controllerValue = methodOptions[selectedMethod][config.filteredOptionsBy];
+					const filtered = config.filteredOptions[controllerValue];
+					if (filtered) {
+						effectiveConfig = { ...config, options: filtered };
+					}
+				}
+
+				return { key, config: effectiveConfig, isEnabled };
 			})
 		: [];
 

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -536,11 +536,24 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			case 'gard':
 				// Map frontend rv to backend site_to_site_variation
 				const rvMap = { None: 'none', GDD: 'general_discrete', Gamma: 'beta_gamma' };
+				const gardDatatype = config.datatype || 'nucleotide';
+				let gardModel = config.model || 'GTR';
+
+				// Safety net: validate model is compatible with datatype
+				const nucleotideModels = ['GTR', 'HKY85', 'TN93', 'JC69'];
+				const proteinModels = ['JTT', 'WAG', 'LG', 'Dayhoff'];
+				if ((gardDatatype === 'nucleotide' || gardDatatype === 'codon') && !nucleotideModels.includes(gardModel)) {
+					console.warn(`GARD: Model "${gardModel}" incompatible with ${gardDatatype} data, falling back to GTR`);
+					gardModel = 'GTR';
+				} else if (gardDatatype === 'protein' && !proteinModels.includes(gardModel)) {
+					console.warn(`GARD: Model "${gardModel}" incompatible with protein data, falling back to JTT`);
+					gardModel = 'JTT';
+				}
+
 				return {
 					...baseParams,
-					// Map GARD-specific parameters to backend format
-					datatype: config.datatype || 'codon',
-					model: config.model || 'JTT',
+					datatype: gardDatatype,
+					model: gardModel,
 					run_mode: config.mode || 'Normal',
 					site_to_site_variation: rvMap[config.rv] || 'none',
 					rate_classes: config.rate_classes || 4,

--- a/src/test/gard-model-validation.test.js
+++ b/src/test/gard-model-validation.test.js
@@ -1,0 +1,174 @@
+/**
+ * Tests for GARD model/datatype compatibility validation
+ * Verifies that:
+ * - Model options are correctly filtered by datatype
+ * - gencodeid maps correctly to datatype
+ * - Invalid model+datatype combos are corrected by the safety net
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Model compatibility constants (mirroring MethodSelector and BackendAnalysisRunner)
+const NUCLEOTIDE_MODELS = ['GTR', 'HKY85', 'TN93', 'JC69'];
+const PROTEIN_MODELS = ['JTT', 'WAG', 'LG', 'Dayhoff'];
+
+const FILTERED_OPTIONS = {
+	codon: NUCLEOTIDE_MODELS,
+	nucleotide: NUCLEOTIDE_MODELS,
+	protein: PROTEIN_MODELS
+};
+
+const FILTERED_DEFAULTS = {
+	codon: 'GTR',
+	nucleotide: 'GTR',
+	protein: 'JTT'
+};
+
+/**
+ * Maps gencodeid to GARD datatype string
+ * (same logic as the reactive block in MethodSelector)
+ */
+function gencodeidToDatatype(gencodeid) {
+	if (gencodeid === -2) return 'protein';
+	if (gencodeid === -1) return 'nucleotide';
+	return 'codon'; // >= 0
+}
+
+/**
+ * Validates and corrects a GARD model for a given datatype
+ * (same logic as BackendAnalysisRunner safety net)
+ */
+function validateGardModel(model, datatype) {
+	if ((datatype === 'nucleotide' || datatype === 'codon') && !NUCLEOTIDE_MODELS.includes(model)) {
+		return 'GTR';
+	}
+	if (datatype === 'protein' && !PROTEIN_MODELS.includes(model)) {
+		return 'JTT';
+	}
+	return model;
+}
+
+describe('GARD model/datatype compatibility', () => {
+	describe('gencodeid to datatype mapping', () => {
+		it('maps gencodeid >= 0 to codon', () => {
+			expect(gencodeidToDatatype(0)).toBe('codon');
+			expect(gencodeidToDatatype(1)).toBe('codon');
+			expect(gencodeidToDatatype(11)).toBe('codon');
+		});
+
+		it('maps gencodeid -1 to nucleotide', () => {
+			expect(gencodeidToDatatype(-1)).toBe('nucleotide');
+		});
+
+		it('maps gencodeid -2 to protein', () => {
+			expect(gencodeidToDatatype(-2)).toBe('protein');
+		});
+	});
+
+	describe('model filtering by datatype', () => {
+		it('codon data shows only nucleotide models', () => {
+			const models = FILTERED_OPTIONS['codon'];
+			expect(models).toEqual(['GTR', 'HKY85', 'TN93', 'JC69']);
+			expect(models).not.toContain('JTT');
+			expect(models).not.toContain('WAG');
+		});
+
+		it('nucleotide data shows only nucleotide models', () => {
+			const models = FILTERED_OPTIONS['nucleotide'];
+			expect(models).toEqual(['GTR', 'HKY85', 'TN93', 'JC69']);
+		});
+
+		it('protein data shows only protein models', () => {
+			const models = FILTERED_OPTIONS['protein'];
+			expect(models).toEqual(['JTT', 'WAG', 'LG', 'Dayhoff']);
+			expect(models).not.toContain('GTR');
+			expect(models).not.toContain('HKY85');
+		});
+	});
+
+	describe('default model per datatype', () => {
+		it('codon defaults to GTR', () => {
+			expect(FILTERED_DEFAULTS['codon']).toBe('GTR');
+		});
+
+		it('nucleotide defaults to GTR', () => {
+			expect(FILTERED_DEFAULTS['nucleotide']).toBe('GTR');
+		});
+
+		it('protein defaults to JTT', () => {
+			expect(FILTERED_DEFAULTS['protein']).toBe('JTT');
+		});
+	});
+
+	describe('safety net: model validation and correction', () => {
+		it('accepts valid nucleotide model for codon data', () => {
+			expect(validateGardModel('GTR', 'codon')).toBe('GTR');
+			expect(validateGardModel('HKY85', 'codon')).toBe('HKY85');
+			expect(validateGardModel('TN93', 'nucleotide')).toBe('TN93');
+			expect(validateGardModel('JC69', 'nucleotide')).toBe('JC69');
+		});
+
+		it('accepts valid protein model for protein data', () => {
+			expect(validateGardModel('JTT', 'protein')).toBe('JTT');
+			expect(validateGardModel('WAG', 'protein')).toBe('WAG');
+			expect(validateGardModel('LG', 'protein')).toBe('LG');
+			expect(validateGardModel('Dayhoff', 'protein')).toBe('Dayhoff');
+		});
+
+		it('corrects protein model on codon data to GTR', () => {
+			expect(validateGardModel('JTT', 'codon')).toBe('GTR');
+			expect(validateGardModel('WAG', 'codon')).toBe('GTR');
+			expect(validateGardModel('LG', 'nucleotide')).toBe('GTR');
+			expect(validateGardModel('Dayhoff', 'nucleotide')).toBe('GTR');
+		});
+
+		it('corrects nucleotide model on protein data to JTT', () => {
+			expect(validateGardModel('GTR', 'protein')).toBe('JTT');
+			expect(validateGardModel('HKY85', 'protein')).toBe('JTT');
+			expect(validateGardModel('TN93', 'protein')).toBe('JTT');
+			expect(validateGardModel('JC69', 'protein')).toBe('JTT');
+		});
+	});
+
+	describe('filteredOptionsBy mechanism', () => {
+		it('resolves filtered options based on controller value', () => {
+			// Simulates what renderableAdvancedOptions does
+			const modelConfig = {
+				type: 'select',
+				options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
+				filteredOptionsBy: 'datatype',
+				filteredOptions: FILTERED_OPTIONS
+			};
+
+			function resolveOptions(config, controllerValue) {
+				if (config.filteredOptionsBy && config.filteredOptions) {
+					const filtered = config.filteredOptions[controllerValue];
+					if (filtered) return filtered;
+				}
+				return config.options;
+			}
+
+			expect(resolveOptions(modelConfig, 'codon')).toEqual(NUCLEOTIDE_MODELS);
+			expect(resolveOptions(modelConfig, 'nucleotide')).toEqual(NUCLEOTIDE_MODELS);
+			expect(resolveOptions(modelConfig, 'protein')).toEqual(PROTEIN_MODELS);
+		});
+
+		it('falls back to full options for unknown controller value', () => {
+			const modelConfig = {
+				options: ['A', 'B', 'C'],
+				filteredOptionsBy: 'datatype',
+				filteredOptions: { known: ['A'] }
+			};
+
+			function resolveOptions(config, controllerValue) {
+				if (config.filteredOptionsBy && config.filteredOptions) {
+					const filtered = config.filteredOptions[controllerValue];
+					if (filtered) return filtered;
+				}
+				return config.options;
+			}
+
+			expect(resolveOptions(modelConfig, 'unknown')).toEqual(['A', 'B', 'C']);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Auto-detects data type from uploaded file (`FILE_INFO.gencodeid`) and sets GARD's datatype accordingly
- Filters model dropdown to only show compatible models: nucleotide/codon → GTR, HKY85, TN93, JC69; protein → JTT, WAG, LG, Dayhoff
- Auto-corrects model selection when datatype changes
- Adds generic `filteredOptionsBy` mechanism in renderableAdvancedOptions — reusable for any future method
- Safety net in BackendAnalysisRunner catches incompatible combos before SLURM submission
- Fixes defaults from codon/JTT to nucleotide/GTR

Fixes #124
Related: veg/datamonkey-js#845

## Test plan
- [x] 15 unit tests passing (gard-model-validation.test.js)
- [ ] Upload nucleotide FASTA → GARD datatype auto-sets to "codon", model shows only nucleotide models
- [ ] Change datatype to "protein" → model auto-switches to JTT, dropdown shows only protein models
- [ ] Submit GARD with valid combo → job runs successfully
- [ ] Verify other methods unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)