### PR TITLE
Add Umami events for file upload and validation flow

### DIFF
--- a/src/lib/AlignmentViewer.svelte
+++ b/src/lib/AlignmentViewer.svelte
@@ -5,6 +5,7 @@
 	import { alignmentFileStore } from '../stores/fileInfo';
 	import { persistentFileStore } from '../stores/fileInfo';
 	import { Save } from 'lucide-svelte';
+	import { trackEvent } from './utils/analytics.js';
 
 	export let alignmentFile = null;
 	export let fileMetricsJSON = null;
@@ -22,6 +23,8 @@
 
 	async function loadAlignment() {
 		if (!alignmentFile) return;
+
+		trackEvent('alignment-viewer-opened');
 
 		isLoading = true;
 		error = null;

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -240,6 +240,11 @@
 			}
 		} catch (error) {
 			console.error('❌ Analysis execution failed:', error);
+
+			trackEvent('analysis-start-blocked', {
+				reason: error.message
+			});
+
 			// Show error toast instead of alert
 			toastStore.error(`Analysis failed: ${error.message}`, {
 				duration: 8000

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -7,6 +7,7 @@
 	import BranchSelector from './BranchSelector.svelte';
 	import AnalysisTimingEstimate from './AnalysisTimingEstimate.svelte';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
+	import { trackEvent } from './utils/analytics.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -957,6 +958,13 @@
 	// Initialize method options when method changes (must run before renderableAdvancedOptions)
 	$: if (selectedMethod && !methodOptions[selectedMethod]) {
 		initializeMethodOptions(selectedMethod);
+	}
+
+	// Track method selection for analytics
+	let lastTrackedMethod = null;
+	$: if (selectedMethod && selectedMethod !== lastTrackedMethod) {
+		lastTrackedMethod = selectedMethod;
+		trackEvent('method-selected', { method: selectedMethod });
 	}
 
 	// Auto-detect data type from uploaded file for GARD

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -706,6 +706,8 @@
 			analysisId = await analysisStore.createAnalysis(fileId, 'datareader');
 			analysisStore.startAnalysisProgress(analysisId, 'Initializing file analysis...');
 
+			trackEvent('file-validation-started');
+
 			// Mount the file for analysis
 			analysisStore.updateAnalysisProgressById(
 				analysisId,
@@ -824,6 +826,12 @@
 			fileMetricsStore.set(fileMetricsJSON);
 			alignmentFileStore.set(file);
 
+			trackEvent('file-validation-success', {
+				format: fileMetricsJSON.FILE_INFO?.gencodeid >= 0 ? 'codon' : fileMetricsJSON.FILE_INFO?.gencodeid === -1 ? 'nucleotide' : 'protein',
+				sequenceCount: fileMetricsJSON.FILE_INFO?.sequences || 0,
+				siteCount: fileMetricsJSON.FILE_INFO?.sites || 0
+			});
+
 			// Extract trees
 			trees['nj'] = fileMetricsJSON.FILE_INFO?.nj;
 			if (fileMetricsJSON?.FILE_PARTITION_INFO) {
@@ -890,6 +898,13 @@
 			const errorMsg = error.message || '';
 			const isTreeError = errorMsg.includes('Tree') || errorMsg.includes('tree') ||
 				errorMsg.includes('Topology') || errorMsg.includes('Newick');
+
+			const errorType = isTreeError ? 'invalid-tree'
+				: errorMsg.includes('divisible by 3') ? 'not-codon-aligned'
+				: errorMsg.includes('stop codon') ? 'stop-codons'
+				: errorMsg.includes('format') ? 'invalid-format'
+				: 'unknown';
+			trackEvent('file-validation-error', { errorType });
 
 			// Set validation error for display
 			validationError = {


### PR DESCRIPTION
## Summary

Adds 6 tracking events to close the visibility gap between file upload and analysis start:

- **file-validation-started** — fires when datareader begins analyzing an uploaded file
- **file-validation-success** — fires on successful validation, with `format`, `sequenceCount`, `siteCount`
- **file-validation-error** — fires on validation failure, with classified `errorType` (invalid-format, not-codon-aligned, stop-codons, invalid-tree, unknown)
- **alignment-viewer-opened** — fires when the alignment viewer loads
- **method-selected** — fires when user selects an analysis method, with `method` name
- **analysis-start-blocked** — fires when an analysis attempt is blocked by validation, with `reason`

These complement the existing `file-uploaded` and `analysis-started` events and will help identify where and why 50% of users who upload a file never start an analysis.

Fixes #126

## Test plan
- [ ] Upload a valid file → verify `file-validation-started` and `file-validation-success` fire in Umami
- [ ] Upload an invalid file → verify `file-validation-error` fires with correct errorType
- [ ] View alignment after upload → verify `alignment-viewer-opened` fires
- [ ] Select a method in Analyze tab → verify `method-selected` fires (only once per selection change)
- [ ] Trigger a validation block (e.g., no tree available) → verify `analysis-start-blocked` fires
- [ ] Verify existing events (`file-uploaded`, `analysis-started`) still work