### PR TITLE
Add Umami route tracking for SPA navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import Toast from '../lib/Toast.svelte';
 	import { X, Menu, FlaskConical } from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
+	import { afterNavigate } from '$app/navigation';
 
 	// Get version from Vite define
 	const version = __APP_VERSION__;
@@ -29,6 +30,13 @@
 	function closeMobileMenu() {
 		mobileMenuOpen = false;
 	}
+
+	// Track SPA route changes in Umami so each navigation registers as a pageview
+	afterNavigate(() => {
+		if (typeof window.umami !== 'undefined') {
+			window.umami.track();
+		}
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Adds `afterNavigate` hook in root layout to call `umami.track()` on every SPA route change
- Each navigation now registers as a pageview with the correct path instead of all showing as `/`
- Enables page-level breakdown (e.g., `/demo/fel`, `/demo/busted`) for direct comparison with DM2 analytics

Fixes #128

## Test plan
- [ ] Navigate between pages/tabs and verify Umami dashboard shows distinct page paths
- [ ] Verify initial page load still registers correctly
- [ ] Verify no errors when Umami script is not loaded (graceful degradation)