### PR TITLE
Fix codon validation: check alignment site count and add NEXUS support

### DIFF
--- a/src/lib/FastaExport.svelte
+++ b/src/lib/FastaExport.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { exportData } from './utils/exportUtils';
+	import { parseAlignment } from './utils/fastaValidation';
 	import { Download } from 'lucide-svelte';
 
 	// Props
@@ -46,108 +47,11 @@
 	}
 
 	/**
-	 * Parse FASTA or NEXUS format content
+	 * Parse FASTA or NEXUS format content using shared utility
 	 */
 	function parseFastaOrNexus(content) {
-		const trimmed = content.trim();
-
-		// Check if it's NEXUS format
-		if (trimmed.toLowerCase().startsWith('#nexus')) {
-			return parseNexus(trimmed);
-		}
-
-		// Otherwise assume FASTA format
-		return parseFasta(trimmed);
-	}
-
-	/**
-	 * Parse FASTA format content
-	 */
-	function parseFasta(content) {
-		const result = [];
-		const lines = content.split('\n');
-		let currentName = '';
-		let currentSequence = '';
-
-		for (const line of lines) {
-			const trimmedLine = line.trim();
-
-			// Skip empty lines
-			if (!trimmedLine) continue;
-
-			// Skip comment lines
-			if (trimmedLine.startsWith(';')) continue;
-
-			// Skip lines that look like Newick trees (start with '(' and contain ':')
-			if (trimmedLine.startsWith('(') && trimmedLine.includes(':')) {
-				continue;
-			}
-
-			if (trimmedLine.startsWith('>')) {
-				// Save previous sequence if exists
-				if (currentName && currentSequence) {
-					result.push({
-						name: currentName,
-						sequence: currentSequence
-					});
-				}
-				// Start new sequence
-				currentName = trimmedLine.substring(1).trim();
-				currentSequence = '';
-			} else {
-				// Append to current sequence, but filter out any tree characters that might be embedded
-				// Trees contain characters like ( ) : ; which aren't valid in sequences
-				const cleanedLine = trimmedLine.replace(/\s/g, '');
-				// Only add if it looks like sequence data (contains only valid nucleotide/amino acid chars and gaps)
-				if (/^[A-Za-z\-\.\*]+$/.test(cleanedLine)) {
-					currentSequence += cleanedLine;
-				}
-			}
-		}
-
-		// Don't forget the last sequence
-		if (currentName && currentSequence) {
-			result.push({
-				name: currentName,
-				sequence: currentSequence
-			});
-		}
-
-		return result;
-	}
-
-	/**
-	 * Parse NEXUS format content
-	 */
-	function parseNexus(content) {
-		const result = [];
-
-		// Find the DATA or CHARACTERS block
-		const matrixMatch = content.match(/MATRIX\s*\n([\s\S]*?)\s*;/i);
-		if (!matrixMatch) {
-			return result;
-		}
-
-		const matrixContent = matrixMatch[1];
-		const lines = matrixContent.split('\n');
-
-		for (const line of lines) {
-			const trimmedLine = line.trim();
-			if (!trimmedLine) continue;
-
-			// Split on whitespace - first part is name, rest is sequence
-			const parts = trimmedLine.split(/\s+/);
-			if (parts.length >= 2) {
-				const name = parts[0];
-				const sequence = parts.slice(1).join('').replace(/\s/g, '');
-
-				if (name && sequence) {
-					result.push({ name, sequence });
-				}
-			}
-		}
-
-		return result;
+		const { sequences } = parseAlignment(content.trim());
+		return sequences.map(s => ({ name: s.header, sequence: s.sequence }));
 	}
 
 	/**

--- a/src/lib/utils/fastaValidation.js
+++ b/src/lib/utils/fastaValidation.js
@@ -290,23 +290,86 @@ const STOP_CODONS_BY_GENETIC_CODE = {
 };
 
 /**
+ * Detect whether content is NEXUS format.
+ * @param {string} content - Raw file content
+ * @returns {boolean}
+ */
+export function isNexusFormat(content) {
+	return content?.trim().toLowerCase().startsWith('#nexus') ?? false;
+}
+
+/**
+ * Parse NEXUS format string into sequences.
+ * @param {string} nexusContent - Raw NEXUS content
+ * @returns {Object} { sequences: [{header, sequence}], warnings: [] }
+ */
+export function parseNexus(nexusContent) {
+	if (!nexusContent?.trim()) {
+		throw new Error('File is empty');
+	}
+
+	const sequences = [];
+	const warnings = [];
+
+	const matrixMatch = nexusContent.match(/MATRIX\s*\n([\s\S]*?)\s*;/i);
+	if (!matrixMatch) {
+		throw new Error('No MATRIX block found in NEXUS file');
+	}
+
+	const matrixContent = matrixMatch[1];
+	const lines = matrixContent.split('\n');
+
+	for (const line of lines) {
+		const trimmedLine = line.trim();
+		if (!trimmedLine) continue;
+
+		const parts = trimmedLine.split(/\s+/);
+		if (parts.length >= 2) {
+			const name = parts[0];
+			const sequence = parts.slice(1).join('').replace(/\s/g, '');
+			if (name && sequence) {
+				sequences.push({ header: name, sequence });
+			}
+		}
+	}
+
+	if (sequences.length === 0) {
+		throw new Error('No sequences found in NEXUS MATRIX block');
+	}
+
+	return { sequences, warnings };
+}
+
+/**
+ * Parse alignment content in either FASTA or NEXUS format.
+ * @param {string} content - Raw alignment content
+ * @returns {Object} { sequences: [{header, sequence}], warnings: [] }
+ */
+export function parseAlignment(content) {
+	if (isNexusFormat(content)) {
+		return parseNexus(content);
+	}
+	return parseFasta(content);
+}
+
+/**
  * Validate a codon alignment for submission to codon-aware methods.
- * Checks that sequence lengths are divisible by 3 and scans for in-frame stop codons.
+ * Checks that alignment site count is divisible by 3 and scans for in-frame stop codons.
  *
- * @param {string} fastaData - Raw FASTA string content
+ * @param {string} alignmentData - Raw FASTA or NEXUS alignment content
  * @param {number} [geneticCodeId=0] - Genetic code ID (0 = Universal)
  * @returns {{ valid: boolean, errors: string[] }}
  */
-export function validateCodonAlignment(fastaData, geneticCodeId = 0) {
+export function validateCodonAlignment(alignmentData, geneticCodeId = 0) {
 	const errors = [];
 
-	if (!fastaData || !fastaData.trim()) {
-		return { valid: false, errors: ['FASTA data is empty'] };
+	if (!alignmentData || !alignmentData.trim()) {
+		return { valid: false, errors: ['Alignment data is empty'] };
 	}
 
 	let parsed;
 	try {
-		parsed = parseFasta(fastaData);
+		parsed = parseAlignment(alignmentData);
 	} catch (e) {
 		return { valid: false, errors: [e.message] };
 	}
@@ -314,15 +377,16 @@ export function validateCodonAlignment(fastaData, geneticCodeId = 0) {
 	const { sequences } = parsed;
 
 	if (sequences.length === 0) {
-		return { valid: false, errors: ['No sequences found in FASTA data'] };
+		return { valid: false, errors: ['No sequences found in alignment data'] };
 	}
 
-	// Check divisibility by 3 using the first sequence
-	const firstSeqLength = sequences[0].sequence.replace(/[-.]/g, '').length;
-	if (firstSeqLength % 3 !== 0) {
+	// Check alignment site count (column count including gaps) for divisibility by 3.
+	// HyPhy validates the total number of alignment sites, not ungapped sequence length.
+	const alignmentSites = sequences[0].sequence.length;
+	if (alignmentSites % 3 !== 0) {
 		errors.push(
-			`Sequence length (${firstSeqLength}) is not divisible by 3. ` +
-			`Codon-based analyses require in-frame coding sequences.`
+			`Alignment site count (${alignmentSites}) is not divisible by 3. ` +
+			`Codon-based analyses require the alignment length to be a multiple of 3.`
 		);
 	}
 
@@ -335,7 +399,7 @@ export function validateCodonAlignment(fastaData, geneticCodeId = 0) {
 	// Scan each sequence for in-frame stop codons (excluding the last codon)
 	for (const seq of sequences) {
 		const cleanSeq = seq.sequence.replace(/[-.]/g, '').toUpperCase();
-		// Only check if length is divisible by 3, otherwise we already reported that error
+		// Only check if ungapped length is divisible by 3
 		if (cleanSeq.length % 3 !== 0) continue;
 
 		const lastCodonStart = cleanSeq.length - 3;
@@ -348,7 +412,6 @@ export function validateCodonAlignment(fastaData, geneticCodeId = 0) {
 					`at codon position ${codonPosition}. Codon-based analyses cannot proceed ` +
 					`with premature stop codons.`
 				);
-				// Only report first stop codon per sequence to keep messages manageable
 				break;
 			}
 		}

--- a/src/test/codon-validation.test.js
+++ b/src/test/codon-validation.test.js
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateCodonAlignment } from '../lib/utils/fastaValidation.js';
+import { validateCodonAlignment, parseNexus, isNexusFormat } from '../lib/utils/fastaValidation.js';
 
 // Helper to build a simple FASTA string
 function fasta(seqs) {
@@ -177,17 +177,100 @@ describe('validateCodonAlignment', () => {
 			expect(result.errors[0]).toContain('TAA');
 		});
 
-		it('ignores gap characters when checking length', () => {
-			// 9 nucleotides + 3 gaps = 12 chars, but clean length is 9 (divisible by 3)
+		it('checks alignment column count (with gaps) for divisibility by 3', () => {
+			// 12 columns (including gaps) = divisible by 3
 			const data = fasta([['Seq1', 'ATG---AAACCC']]);
 			const result = validateCodonAlignment(data);
 			expect(result.valid).toBe(true);
+		});
+
+		it('rejects alignment where column count with gaps is not divisible by 3', () => {
+			// 11 columns (including gaps) = NOT divisible by 3
+			// Even though ungapped length (8) doesn't matter — HyPhy checks site count
+			const data = fasta([['Seq1', 'ATG---AACCC']]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('not divisible by 3');
 		});
 
 		it('defaults to genetic code 0 when not specified', () => {
 			const data = fasta([['Seq1', 'ATGTAACCC']]);
 			const result = validateCodonAlignment(data);
 			expect(result.valid).toBe(false);
+		});
+	});
+
+	describe('NEXUS format support', () => {
+		function nexus(seqs) {
+			const ntax = seqs.length;
+			const nchar = seqs[0]?.[1]?.length || 0;
+			return `#NEXUS\nBEGIN DATA;\n  DIMENSIONS NTAX=${ntax} NCHAR=${nchar};\n  FORMAT DATATYPE=DNA GAP=- MISSING=?;\n  MATRIX\n${seqs.map(([name, seq]) => `    ${name} ${seq}`).join('\n')}\n  ;\nEND;\n`;
+		}
+
+		it('accepts a valid NEXUS codon alignment', () => {
+			const data = nexus([
+				['Seq1', 'ATGAAACCC'],
+				['Seq2', 'ATGAAAGGG']
+			]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(true);
+		});
+
+		it('rejects NEXUS alignment not divisible by 3', () => {
+			const data = nexus([
+				['Seq1', 'ATGAA'],
+				['Seq2', 'ATGCC']
+			]);
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('not divisible by 3');
+		});
+
+		it('detects in-frame stop codon in NEXUS format', () => {
+			const data = nexus([['Seq1', 'ATGTAACCC']]);
+			const result = validateCodonAlignment(data, 0);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('TAA');
+		});
+
+		it('provides clear error for NEXUS without MATRIX block', () => {
+			const data = '#NEXUS\nBEGIN DATA;\nEND;\n';
+			const result = validateCodonAlignment(data);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]).toContain('MATRIX');
+		});
+
+		it('does not produce "Sequence data found before header" for NEXUS', () => {
+			const data = nexus([['Seq1', 'ATGAAACCC']]);
+			const result = validateCodonAlignment(data);
+			expect(result.errors.join(' ')).not.toContain('Sequence data found before header');
+		});
+	});
+
+	describe('parseNexus', () => {
+		it('parses NEXUS MATRIX block into normalized sequence objects', () => {
+			const data = `#NEXUS\nBEGIN DATA;\n  MATRIX\n    Seq1 ATGCCC\n    Seq2 ATGGGG\n  ;\nEND;\n`;
+			const { sequences } = parseNexus(data);
+			expect(sequences).toHaveLength(2);
+			expect(sequences[0].header).toBe('Seq1');
+			expect(sequences[0].sequence).toBe('ATGCCC');
+		});
+
+		it('throws clear error for missing MATRIX', () => {
+			expect(() => parseNexus('#NEXUS\nBEGIN DATA;\nEND;\n')).toThrow('MATRIX');
+		});
+	});
+
+	describe('isNexusFormat', () => {
+		it('detects NEXUS format', () => {
+			expect(isNexusFormat('#NEXUS\nBEGIN DATA;')).toBe(true);
+			expect(isNexusFormat('#nexus\nBEGIN DATA;')).toBe(true);
+		});
+
+		it('rejects non-NEXUS', () => {
+			expect(isNexusFormat('>Seq1\nATGCCC')).toBe(false);
+			expect(isNexusFormat(null)).toBe(false);
+			expect(isNexusFormat('')).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Two bugs in `validateCodonAlignment` that explain why invalid alignments bypass frontend validation and reach SLURM:

### Bug 1: Divisibility check used ungapped length instead of alignment site count
The validation checked `sequences[0].sequence.replace(/[-.]/g, '').length` — stripping gaps before checking divisibility by 3. But HyPhy validates the total alignment site count (column count WITH gaps). So a gapped alignment with a non-divisible-by-3 column count (e.g., 1187 columns, 1185 nucleotides) would pass our check but fail in HyPhy.

**Fix:** Check `sequences[0].sequence.length` (raw column count including gaps) instead of ungapped length.

### Bug 2: NEXUS format produced confusing error
`parseFasta()` can't handle NEXUS input, producing "Sequence data found before header" instead of validating codons.

**Fix:** Add `parseNexus()`, `isNexusFormat()`, and `parseAlignment()` functions. Extract the NEXUS parser from `FastaExport.svelte` into the shared `fastaValidation.js` utility.

Fixes #131

## Test plan
- [x] 32 unit tests passing (was 22, added 10 for NEXUS + gap handling)
- [ ] Upload FASTA alignment with gaps where column count isn't divisible by 3 → blocked
- [ ] Upload NEXUS file with stop codons → blocked with proper error
- [ ] Upload valid NEXUS file → passes validation
- [ ] FastaExport still works for FASTA and NEXUS