### PR TITLE
Expand file-validation-error classifier and capture unknown messages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -896,15 +896,22 @@
 
 			// Determine error type and provide appropriate message
 			const errorMsg = error.message || '';
-			const isTreeError = errorMsg.includes('Tree') || errorMsg.includes('tree') ||
-				errorMsg.includes('Topology') || errorMsg.includes('Newick');
+			const isTreeError = /Tree|tree|Topology|Newick/.test(errorMsg);
 
 			const errorType = isTreeError ? 'invalid-tree'
 				: errorMsg.includes('divisible by 3') ? 'not-codon-aligned'
 				: errorMsg.includes('stop codon') ? 'stop-codons'
-				: errorMsg.includes('format') ? 'invalid-format'
+				: /nucleotide alignment|protein alignment|character states/.test(errorMsg) ? 'wrong-alphabet'
+				: /too large|must include prebuilt/.test(errorMsg) ? 'dataset-too-large'
+				: /at least \d+ unique sequences|No sequences found|No MATRIX block/.test(errorMsg) ? 'insufficient-sequences'
+				: /Aioli|not a valid value for parameter|Invalid parameter choice/.test(errorMsg) ? 'runtime-error'
+				: /format|valid alignment|valid FASTA|valid NEXUS|valid sequence|FASTA data is empty|partition specification|Sequence data found before header|File is empty/i.test(errorMsg) ? 'invalid-format'
 				: 'unknown';
-			trackEvent('file-validation-error', { errorType });
+			const eventPayload = { errorType };
+			if (errorType === 'unknown') {
+				eventPayload.message = errorMsg.slice(0, 500);
+			}
+			trackEvent('file-validation-error', eventPayload);
 
 			// Set validation error for display
 			validationError = {


### PR DESCRIPTION
## Summary

Telemetry showed **43% of `file-validation-error` events were landing in the `unknown` bucket** (398 of ~919 events over the last 30 days), hiding the actual failure modes from analytics.

This expands the classifier in `src/routes/+page.svelte` to bucket the messages that were slipping through, and captures the raw message for any remaining `unknown` so we can keep tightening over time.

### Changes

- New buckets:
  - `wrong-alphabet` — nucleotide ↔ protein mismatches (datareader.bf alphabet errors)
  - `dataset-too-large` — size limits and "must include prebuilt trees"
  - `insufficient-sequences` — "at least N unique sequences", "No sequences found", missing NEXUS MATRIX block
  - `runtime-error` — Aioli/WASM init failures, invalid parameter values (separates infrastructure problems from user-data problems)
- Broadened `invalid-format` to match datareader.bf and FastaValidator messages that don't contain the literal word "format" (e.g. "valid alignment file", "FASTA data is empty", "File is empty", "Sequence data found before header", "partition specification")
- Simplified the tree check to a single regex (same semantics)
- Added a truncated `message` field (≤500 chars) to the event payload **only when `errorType === 'unknown'`**, so the remaining slip-throughs are debuggable without bloating known buckets

## Test plan

- [ ] Verify the upload error path still renders the same `validationError` UI for tree errors and FASTA errors
- [ ] Confirm `file-validation-error` events arrive in analytics with the new `errorType` values
- [ ] After a few days, check that the `unknown` bucket has shrunk and inspect any `message` samples that remain