### PR TITLE
Capture raw message for invalid-format validation errors

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -908,7 +908,7 @@
 				: /format|valid alignment|valid FASTA|valid NEXUS|valid sequence|FASTA data is empty|partition specification|Sequence data found before header|File is empty/i.test(errorMsg) ? 'invalid-format'
 				: 'unknown';
 			const eventPayload = { errorType };
-			if (errorType === 'unknown') {
+			if (errorType === 'unknown' || errorType === 'invalid-format') {
 				eventPayload.message = errorMsg.slice(0, 500);
 			}
 			trackEvent('file-validation-error', eventPayload);


### PR DESCRIPTION
## Summary

After the previous classifier expansion (#133), telemetry shows `invalid-format` is now the dominant bucket at **52%** (11 of 21 file-validation errors), but the bucket alone doesn't tell us which specific failure mode users are hitting.

The `invalid-format` bucket can catch any of:
- `"This doesn't seem to be a valid alignment file."` (datareader.bf)
- `"File analysis failed. The file may be in an unsupported format..."` (+page.svelte fallback)
- `"File analysis failed. Please check that your file is a valid FASTA or NEXUS alignment."` (+page.svelte fallback)
- `"File analysis produced invalid results..."` (+page.svelte fallback)
- `"FASTA data is empty or invalid"` (BaseAnalysisRunner)
- `"File is empty"` / `"Sequence data found before header"` (FastaValidator)
- `"Partition specification must cover each nucleotide site exactly once..."` (datareader.bf)

Attaches the truncated raw message to `invalid-format` events alongside `unknown` so we can drill in. Plan is to revert this once the bucket is calibrated.

## Test plan

- [ ] Confirm `file-validation-error` events with `errorType: invalid-format` now include a `message` field in analytics
- [ ] After a few days, review the captured messages and either split `invalid-format` into more specific buckets or drop the message capture again