### PR TITLE
Resolve all four file-validation bugs from #135

### DIFF
--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -171,12 +171,13 @@
 					console.log('🌳 Using interactive tree instead:', treeData.substring(0, 100) + '...');
 				}
 				if (!treeData) {
+					if (selectedTreeSource === 'inferred') {
+						throw new Error(
+							'No neighbor-joining tree was inferred for this alignment. Please upload your own tree file.'
+						);
+					}
 					const treeSourceName =
-						selectedTreeSource === 'uploaded'
-							? 'uploaded tree'
-							: selectedTreeSource === 'inferred'
-								? 'neighbor-joining tree'
-								: 'uploaded tree file';
+						selectedTreeSource === 'uploaded' ? 'uploaded tree' : 'uploaded tree file';
 					throw new Error(
 						`No ${treeSourceName} available. Please select a different tree source or upload a tree.`
 					);
@@ -219,12 +220,13 @@
 				}
 
 				if (!treeData) {
+					if (selectedTreeSource === 'inferred') {
+						throw new Error(
+							'No neighbor-joining tree was inferred for this alignment. Please upload your own tree file.'
+						);
+					}
 					const treeSourceName =
-						selectedTreeSource === 'uploaded'
-							? 'uploaded tree'
-							: selectedTreeSource === 'inferred'
-								? 'neighbor-joining tree'
-								: 'uploaded tree file';
+						selectedTreeSource === 'uploaded' ? 'uploaded tree' : 'uploaded tree file';
 					throw new Error(
 						`No ${treeSourceName} available. Please select a different tree source or upload a tree.`
 					);
@@ -298,6 +300,14 @@
 	// Calculate tree state for TreeSourceSelector
 	$: hasUploadedTree = $treeStore && $treeStore.usertree;
 	$: hasInferredTree = $treeStore && $treeStore.nj;
+
+	// If datareader didn't produce an NJ tree (FILE_INFO.nj missing), the
+	// 'inferred' radio is disabled in the UI but selectedTreeSource defaults
+	// to 'inferred', so users hit "No NJ tree available" when they click Run.
+	// Switch to whichever option is actually available.
+	$: if (selectedTreeSource === 'inferred' && !hasInferredTree) {
+		selectedTreeSource = hasUploadedTree ? 'uploaded' : 'upload-new';
+	}
 
 	// Get tree data based on user's selection
 	function getSelectedTreeData() {

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1085,6 +1085,7 @@
 			const analysisConfig = {
 				method: selectedMethod,
 				geneticCode,
+				geneticCodeId,
 				executionMode,
 				...(methodOptions[selectedMethod] || {})
 			};

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -255,9 +255,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// PRIME impute states parameter
 					args.push(`--impute-states ${value}`);
 				} else if (key === 'geneticCode') {
-					// Use genetic code string value directly for HyPhy
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// Use numeric geneticCodeId rather than the descriptive name. Aioli's
+					// exec() does a plain command.split(' '), so multi-word names like
+					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' + stray
+					// 'mitochondrial', which causes HyPhy to reject 'Vertebrate' and then
+					// consume the next option's value as a fallback ('All' from --branches,
+					// '0.1' from --pvalue, etc.). Numeric IDs are always single-token.
+					const codeId = config.geneticCodeId ?? 0;
+					console.log('🧬 WASM - Using genetic code id:', codeId, '(', value, ')');
+					args.push(`--code ${codeId}`);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
 					args.push(`--srv ${value}`);
@@ -518,9 +524,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// PRIME impute states parameter
 					args.push(`--impute-states ${value}`);
 				} else if (key === 'geneticCode') {
-					// Use genetic code string value directly for HyPhy
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// Use numeric geneticCodeId rather than the descriptive name. Aioli's
+					// exec() does a plain command.split(' '), so multi-word names like
+					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' + stray
+					// 'mitochondrial', which causes HyPhy to reject 'Vertebrate' and then
+					// consume the next option's value as a fallback ('All' from --branches,
+					// '0.1' from --pvalue, etc.). Numeric IDs are always single-token.
+					const codeId = config.geneticCodeId ?? 0;
+					console.log('🧬 WASM - Using genetic code id:', codeId, '(', value, ')');
+					args.push(`--code ${codeId}`);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
 					args.push(`--srv ${value}`);

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -445,6 +445,16 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		const response = await fetch(jsonBlob);
 		const blob = await response.blob();
 		const jsonText = await blob.text();
+
+		// Guard against HTML responses (e.g. dev-server 404 when HyPhy produced no result file).
+		// Without this, safeParseJSON surfaces the raw V8 message ("Unexpected token '<', \"<!doctype...\"")
+		// which is meaningless to users and noisy in telemetry.
+		if (jsonText.trim().startsWith('<!') || jsonText.trim().startsWith('<html')) {
+			throw new Error(
+				`HyPhy ${method} analysis did not produce a result file. Check the analysis output for errors.`
+			);
+		}
+
 		const jsonData = safeParseJSON(jsonText);
 
 		this.updateProgress(analysisId, 'saving', 95, 'Saving results...');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -909,7 +909,11 @@
 				: 'unknown';
 			const eventPayload = { errorType };
 			if (errorType === 'unknown' || errorType === 'invalid-format') {
-				eventPayload.message = errorMsg.slice(0, 500);
+				// Defensive fallback: 338/342 unknown events had no message field in
+				// telemetry because error.message was falsy (bare throw, throw {},
+				// throw new Error() with no arg). Keep digging until we find a string.
+				const fallback = errorMsg || error?.name || error?.toString() || 'No message available';
+				eventPayload.message = String(fallback).slice(0, 500);
 			}
 			trackEvent('file-validation-error', eventPayload);
 


### PR DESCRIPTION
## Summary

Addresses all four bugs from #135 — fixes the actual user-facing failures (Bugs 3 + 4) and the two telemetry gaps that surfaced them (Bugs 1 + 2).

### Bug 1 — Unknown errors missing message field (`+page.svelte`)

338 of 342 \`unknown\` file-validation-error events had no \`message\` field in telemetry because \`errorMsg = error.message || ''\` was empty when something threw without a string. Replace the empty-string fallback with a defensive chain (\`error.message → error.name → error.toString() → sentinel\`) so the analytics payload always has something to work with.

### Bug 2 — HTML responses parsed as JSON (`WasmAnalysisRunner.js`)

~290 \`analysis-start-blocked\` events surfaced raw V8 parse errors like \`Unexpected token '<', '<!doctype'... is not valid JSON\`. The actual culprit was \`WasmAnalysisRunner.js:448\` calling \`safeParseJSON\` without first checking whether \`fetch(jsonBlob)\` had returned HTML (which happens when HyPhy fails to produce a result file and the path resolves to a 404 page). Mirror the existing guard from \`+page.svelte:805\` so the user sees an actionable message instead of a parser error.

(The issue suggested \`BackendAnalysisRunner.js\` was at fault, but the backend uses socket.io — there's no \`response.json()\` there to guard. The real source was the WASM result fetch.)

### Bug 3 — Neighbor-joining tree blocked without fallback (`AnalyzeTab.svelte`)

177 \`analysis-start-blocked\` events with \`No neighbor-joining tree available. Please select a different tree source or upload a tree.\` Root cause: \`selectedTreeSource\` defaults to \`'inferred'\`, but if datareader didn't produce an NJ tree (\`FILE_INFO.nj\` missing), the TreeSourceSelector disables the radio button while the underlying state stays \`'inferred'\`. Users then click Run and \`getSelectedTreeData()\` returns empty.

Add a reactive guard that switches \`selectedTreeSource\` to whichever source is actually available (\`'uploaded'\` if present, otherwise \`'upload-new'\`). Also tighten the error message when no fallback exists so users understand what to do.

### Bug 4 — Genetic code parameter receiving invalid values (`MethodSelector.svelte` + `WasmAnalysisRunner.js`)

19+ \`'X' is not a valid value for parameter 'Choose Genetic Code'\` events with values like \`Vertebrate\`, \`All\`, \`Source\`, \`0.1\`. Root cause: aioli's \`exec()\` does a plain \`command.split(' ')\` with no quote awareness (confirmed by reading the aioli worker source). Multi-word genetic code names like \`'Vertebrate mitochondrial'\` get split into \`--code Vertebrate\` + a stray \`mitochondrial\`, which causes HyPhy to reject \`Vertebrate\` and then consume the next option's value as a fallback — explaining \`'All'\` (from \`--branches All\`), \`'0.1'\` (from \`--pvalue 0.1\`), and \`'Source'\` (from RELAX branch labels).

Pass the numeric \`geneticCodeId\` (always single-token) as \`--code\` instead of the descriptive name. The backend already does this via socket params.

## Test plan

- [x] All 201 existing tests pass
- [ ] Smoke test: trigger a HyPhy failure that produces no result file → confirm \"HyPhy X analysis did not produce a result file\" toast instead of the parser error
- [ ] Smoke test: throw something without a message string → confirm \`file-validation-error\` events include a \`message\` field
- [ ] Smoke test: upload an alignment where NJ inference fails → confirm \`selectedTreeSource\` auto-switches and the error message is helpful
- [ ] Smoke test: run a method with a multi-word genetic code (e.g. \"Vertebrate mitochondrial\") → confirm HyPhy now receives the numeric code and accepts it

## Follow-ups (out of scope)

- \`WasmAnalysisRunner.js\` builds args as a space-joined string. The space-split issue affects more than just \`--code\` — any arg with a multi-word value (file paths, branch labels) is vulnerable. A larger refactor to pass \`args\` as an array to \`aioli.exec(command, argsArray)\` would eliminate the entire class of bug.
- Bug 3's deeper question is *why* the NJ tree fails to build for some inputs. The current fix routes around the problem; understanding the root cause (small alignments? non-standard characters? specific datatypes?) would be its own investigation.