### PR TITLE
Fix WASM e2e regressions: genetic-code numeric ID and tree-source mount race

### DIFF
--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -1,7 +1,6 @@
 <script>
 	import { onMount } from 'svelte';
-	import { currentFile } from '../stores/fileInfo';
-	import { persistentFileStore } from '../stores/fileInfo';
+	import { currentFile, fileMetricsStore, persistentFileStore } from '../stores/fileInfo';
 	import { analysisStore, activeAnalysisProgress } from '../stores/analyses';
 	import { treeStore } from '../stores/tree';
 	import { toastStore } from '../stores/toast';
@@ -304,8 +303,11 @@
 	// If datareader didn't produce an NJ tree (FILE_INFO.nj missing), the
 	// 'inferred' radio is disabled in the UI but selectedTreeSource defaults
 	// to 'inferred', so users hit "No NJ tree available" when they click Run.
-	// Switch to whichever option is actually available.
-	$: if (selectedTreeSource === 'inferred' && !hasInferredTree) {
+	// Switch to whichever option is actually available — but only AFTER
+	// datareader has finished. Gating on $fileMetricsStore avoids the mount-time
+	// race where treeStore is briefly empty and we'd switch away from 'inferred'
+	// before the file even loads.
+	$: if ($fileMetricsStore && selectedTreeSource === 'inferred' && !hasInferredTree) {
 		selectedTreeSource = hasUploadedTree ? 'uploaded' : 'upload-new';
 	}
 

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -255,15 +255,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// PRIME impute states parameter
 					args.push(`--impute-states ${value}`);
 				} else if (key === 'geneticCode') {
-					// Use numeric geneticCodeId rather than the descriptive name. Aioli's
-					// exec() does a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' + stray
-					// 'mitochondrial', which causes HyPhy to reject 'Vertebrate' and then
-					// consume the next option's value as a fallback ('All' from --branches,
-					// '0.1' from --pvalue, etc.). Numeric IDs are always single-token.
-					const codeId = config.geneticCodeId ?? 0;
-					console.log('🧬 WASM - Using genetic code id:', codeId, '(', value, ')');
-					args.push(`--code ${codeId}`);
+					// Pass the descriptive string value (HyPhy WASM does not accept the
+					// numeric code id on the CLI). Known limitation: aioli's exec() does
+					// a plain command.split(' '), so multi-word names like
+					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
+					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
+					// proper fix is to refactor args into an array passed to
+					// cliObj.exec(cmd, argsArray) — tracked separately.
+					console.log('🧬 WASM - Using genetic code:', value);
+					args.push(`--code ${value}`);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
 					args.push(`--srv ${value}`);
@@ -524,15 +524,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// PRIME impute states parameter
 					args.push(`--impute-states ${value}`);
 				} else if (key === 'geneticCode') {
-					// Use numeric geneticCodeId rather than the descriptive name. Aioli's
-					// exec() does a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' + stray
-					// 'mitochondrial', which causes HyPhy to reject 'Vertebrate' and then
-					// consume the next option's value as a fallback ('All' from --branches,
-					// '0.1' from --pvalue, etc.). Numeric IDs are always single-token.
-					const codeId = config.geneticCodeId ?? 0;
-					console.log('🧬 WASM - Using genetic code id:', codeId, '(', value, ')');
-					args.push(`--code ${codeId}`);
+					// Pass the descriptive string value (HyPhy WASM does not accept the
+					// numeric code id on the CLI). Known limitation: aioli's exec() does
+					// a plain command.split(' '), so multi-word names like
+					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
+					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
+					// proper fix is to refactor args into an array passed to
+					// cliObj.exec(cmd, argsArray) — tracked separately.
+					console.log('🧬 WASM - Using genetic code:', value);
+					args.push(`--code ${value}`);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
 					args.push(`--srv ${value}`);


### PR DESCRIPTION
## Summary

Two regressions in v0.1.0-beta.32 (PR #136) blocking WASM e2e tests. Caught by the failing \`FEL analysis end-to-end\` job — screenshot showed the analysis crashing with \`HyPhy error: '0' is not a valid value for parameter 'Choose Genetic Code'\`, which led to the second regression once the first was fixed.

### Regression 1 — \`--code\` numeric ID rejected by HyPhy

The Bug 4 fix in #136 switched \`--code\` from passing the descriptive name to passing the numeric \`geneticCodeId\`, on the assumption (taken from \`BackendAnalysisRunner\`) that HyPhy accepts numeric codes. **It does not.** HyPhy WASM rejects \`--code 0\` with \`'0' is not a valid value for parameter 'Choose Genetic Code'\`, breaking every analysis since beta.32.

Revert to passing the descriptive name. The original Bug 4 (multi-word names like \`'Vertebrate mitochondrial'\` getting space-split by aioli's \`exec()\` into \`--code Vertebrate\` + stray \`mitochondrial\`) returns, but only affects users who pick a non-Universal code.

**Proper fix tracked separately**: refactor \`WasmAnalysisRunner.js\` to pass args as an array to \`cliObj.exec(cmd, argsArray)\` instead of building a single space-joined string. The aioli worker source confirms this bypasses the split entirely.

### Regression 2 — tree-source auto-switch race

The Bug 3 fix added a reactive in \`AnalyzeTab.svelte\` to switch \`selectedTreeSource\` away from \`'inferred'\` when \`hasInferredTree\` was false. That reactive fired at component mount, before any file was loaded. At that point \`treeStore\` is empty and \`hasInferredTree\` is false, so it switched the state to \`'upload-new'\`. When the user then loaded a file with a valid NJ tree, the state was stuck and clicking Run threw \"No uploaded tree file available\".

Gate the reactive on \`$fileMetricsStore\` so it only runs after datareader has completed. At that point \`treeStore\` has been populated (in the same synchronous block as \`fileMetricsStore.set\`), so the reactive sees the correct \`hasInferredTree\` value.

## Test plan

- [x] All 201 unit tests pass
- [x] All 3 WASM e2e tests pass locally (\`npx playwright test e2e/07-wasm-analysis.spec.js --project=chromium\`)
- [x] Failing test \`FEL analysis end-to-end\` now passes (31.2s)

## Follow-up

- Open a separate issue: refactor \`WasmAnalysisRunner.js\` to pass args as an array to \`cliObj.exec(cmd, argsArray)\` so multi-word genetic codes (and any other multi-word value) work correctly. This is the right fix for the original Bug 4.