### PR TITLE
Add file-format parity with dm2 (FASTA/NEXUS/PHYLIP/MEGA/CLUSTAL)

### DIFF
--- a/src/data/datareader.bf
+++ b/src/data/datareader.bf
@@ -593,6 +593,16 @@ file_info_record ["sites"] = filteredData.sites;
 
 DataSetFilter filteredData = CreateFilter (ds,1);
 
+/* Always emit a canonical FASTA so the JS layer has a single known format
+   to submit downstream, regardless of what the user uploaded (PHYLIP, MEGA,
+   CLUSTAL, NEXUS, FASTA all collapse to the same shape here).
+   DATA_FILE_PRINT_FORMAT = 9 is "FASTA sequential" per HyPhy's ConvertDataFile.bf
+   (note: 6 is NEXUS sequential, not FASTA — the legacy rewrite at line 583
+   above uses 6 because it re-reads with ReadDataFile's autodetection, but
+   we need real FASTA for the JS layer that doesn't autodetect). */
+DATA_FILE_PRINT_FORMAT = 9;
+fprintf("/shared/data/user.fasta", CLEAR_FILE, filteredData);
+
 if (buildNJtree) {
   InferTreeTopology(1.0);
   treeString 		= TreeMatrix2TreeString (1);

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -142,20 +142,25 @@
 					throw new Error('No file selected for analysis');
 				}
 
-				// Get full file data including content from storage
-				const fullFileData = await persistentFileStore.getFile($currentFile.id);
-				if (!fullFileData) {
-					throw new Error('Unable to load file data');
+				// Prefer the canonical FASTA emitted by datareader.bf on upload. It
+				// collapses PHYLIP, MEGA, CLUSTAL, NEXUS, FASTA all to a single
+				// known shape, so downstream submission and validation don't have
+				// to handle the matrix of formats. Fall back to reading the user's
+				// original blob if the canonical wasn't cached (older analyses).
+				let fastaData = $fileMetricsStore?.canonicalFasta;
+				if (!fastaData) {
+					const fullFileData = await persistentFileStore.getFile($currentFile.id);
+					if (!fullFileData) {
+						throw new Error('Unable to load file data');
+					}
+					fastaData = await fullFileData.text();
+					if (!fastaData || !fastaData.trim()) {
+						throw new Error('No sequence data available in selected file');
+					}
+					// Only the user's raw upload can have embedded trees; the
+					// canonical FASTA from datareader is already clean.
+					fastaData = stripEmbeddedTrees(fastaData);
 				}
-
-				// Convert file to text to get FASTA data
-				let fastaData = await fullFileData.text();
-				if (!fastaData || !fastaData.trim()) {
-					throw new Error('No sequence data available in selected file');
-				}
-
-				// Strip embedded trees from alignment files (NEXUS or FASTA)
-				fastaData = stripEmbeddedTrees(fastaData);
 
 				// Get tree data based on user's selection
 				let treeData = getSelectedTreeData();
@@ -195,20 +200,25 @@
 					throw new Error('No file selected for analysis');
 				}
 
-				// Get full file data including content from storage
-				const fullFileData = await persistentFileStore.getFile($currentFile.id);
-				if (!fullFileData) {
-					throw new Error('Unable to load file data');
+				// Prefer the canonical FASTA emitted by datareader.bf on upload. It
+				// collapses PHYLIP, MEGA, CLUSTAL, NEXUS, FASTA all to a single
+				// known shape, so downstream submission and validation don't have
+				// to handle the matrix of formats. Fall back to reading the user's
+				// original blob if the canonical wasn't cached (older analyses).
+				let fastaData = $fileMetricsStore?.canonicalFasta;
+				if (!fastaData) {
+					const fullFileData = await persistentFileStore.getFile($currentFile.id);
+					if (!fullFileData) {
+						throw new Error('Unable to load file data');
+					}
+					fastaData = await fullFileData.text();
+					if (!fastaData || !fastaData.trim()) {
+						throw new Error('No sequence data available in selected file');
+					}
+					// Only the user's raw upload can have embedded trees; the
+					// canonical FASTA from datareader is already clean.
+					fastaData = stripEmbeddedTrees(fastaData);
 				}
-
-				// Convert file to text to get FASTA data
-				let fastaData = await fullFileData.text();
-				if (!fastaData || !fastaData.trim()) {
-					throw new Error('No sequence data available in selected file');
-				}
-
-				// Strip embedded trees from alignment files (NEXUS or FASTA)
-				fastaData = stripEmbeddedTrees(fastaData);
 
 				// Get tree data based on user's selection
 				let treeData = getSelectedTreeData();

--- a/src/lib/services/BaseAnalysisRunner.js
+++ b/src/lib/services/BaseAnalysisRunner.js
@@ -6,7 +6,7 @@
 import { analysisStore } from '../../stores/analyses.js';
 import { toastStore } from '../../stores/toast.js';
 import { get } from 'svelte/store';
-import { validateCodonAlignment } from '../utils/fastaValidation.js';
+import { validateCodonAlignment, isJSParseableFormat } from '../utils/fastaValidation.js';
 
 /**
  * Methods that require codon-aligned input (sequence length divisible by 3, no premature stop codons).
@@ -194,8 +194,13 @@ export class BaseAnalysisRunner {
 			throw new Error('Analysis method is required');
 		}
 
-		// For codon-aware methods, validate alignment is proper codon data
-		if (CODON_AWARE_METHODS.has(method.toLowerCase())) {
+		// For codon-aware methods, validate alignment is proper codon data — but
+		// only for formats our JS parser recognizes (FASTA + NEXUS). PHYLIP,
+		// MEGA, CLUSTAL files upload fine via HyPhy's datareader.bf but our JS
+		// parseAlignment would reject them with confusing "Sequence data found
+		// before header" errors. In those cases, defer validation to HyPhy on
+		// the analysis run — matching dm2's behavior.
+		if (CODON_AWARE_METHODS.has(method.toLowerCase()) && isJSParseableFormat(fastaData)) {
 			const geneticCodeId = config.geneticCodeId !== undefined ? config.geneticCodeId : 0;
 			const result = validateCodonAlignment(fastaData, geneticCodeId);
 			if (!result.valid) {

--- a/src/lib/utils/fastaValidation.js
+++ b/src/lib/utils/fastaValidation.js
@@ -299,6 +299,38 @@ export function isNexusFormat(content) {
 }
 
 /**
+ * Detect whether content is FASTA format.
+ * @param {string} content - Raw file content
+ * @returns {boolean}
+ */
+export function isFastaFormat(content) {
+	const trimmed = content?.trim() ?? '';
+	if (!trimmed) return false;
+	// FASTA headers start with '>'. We also accept '#' (sequential) per HyPhy/dm2's
+	// autodetect rules, but only when it's NOT '#nexus' or '#mega'.
+	if (trimmed.startsWith('>')) return true;
+	const lower = trimmed.toLowerCase();
+	if (trimmed.startsWith('#') && !lower.startsWith('#nexus') && !lower.startsWith('#mega')) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Detect whether the content is in a format JS-side validators can parse
+ * (currently FASTA + NEXUS). Used to gate codon validation: PHYLIP, MEGA,
+ * CLUSTAL files all upload successfully (HyPhy's datareader.bf accepts them)
+ * but our JS parsers don't recognize them. We skip JS-side codon validation
+ * in those cases and let HyPhy validate on the analysis run instead, matching
+ * dm2's behavior.
+ * @param {string} content - Raw file content
+ * @returns {boolean}
+ */
+export function isJSParseableFormat(content) {
+	return isFastaFormat(content) || isNexusFormat(content);
+}
+
+/**
  * Parse NEXUS format string into sequences.
  * @param {string} nexusContent - Raw NEXUS content
  * @returns {Object} { sequences: [{header, sequence}], warnings: [] }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -822,6 +822,27 @@
 				throw new Error(cleanedError);
 			}
 
+			// Datareader.bf always emits a canonical FASTA alongside its JSON so the
+			// JS layer can submit a known format downstream regardless of what the
+			// user uploaded (PHYLIP, MEGA, CLUSTAL, NEXUS, FASTA). Download and
+			// attach it to fileMetricsJSON so it survives IndexedDB caching.
+			try {
+				const fastaBlobPath = await cliObj.download('/shared/data/user.fasta');
+				if (fastaBlobPath && typeof fastaBlobPath === 'string') {
+					const fastaResponse = await fetch(fastaBlobPath);
+					const fastaBlob = await fastaResponse.blob();
+					const canonicalFasta = await fastaBlob.text();
+					const trimmed = canonicalFasta?.trim().toLowerCase() ?? '';
+					if (canonicalFasta && !trimmed.startsWith('<!') && !trimmed.startsWith('<html')) {
+						fileMetricsJSON.canonicalFasta = canonicalFasta;
+					}
+				}
+			} catch (canonicalErr) {
+				// Non-fatal: older cached files or a failed write just means downstream
+				// code falls back to reading the user's original blob.
+				console.warn('Failed to read canonical FASTA from datareader output:', canonicalErr);
+			}
+
 			// Set the file and its metrics in the store
 			fileMetricsStore.set(fileMetricsJSON);
 			alignmentFileStore.set(file);

--- a/src/test/format-detection.test.js
+++ b/src/test/format-detection.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests for format-detection helpers in fastaValidation.js.
+ *
+ * These gate JS-side codon validation: PHYLIP, MEGA, CLUSTAL files upload
+ * fine via HyPhy's datareader.bf but our JS parsers don't understand them,
+ * so the gate keeps us from blocking codon-aware methods on those formats.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	isFastaFormat,
+	isNexusFormat,
+	isJSParseableFormat
+} from '../lib/utils/fastaValidation.js';
+
+const FASTA_SAMPLE = `>Seq1
+ATGAAACCC
+>Seq2
+ATGAAAGGG`;
+
+const NEXUS_SAMPLE = `#nexus
+BEGIN DATA;
+DIMENSIONS NTAX=2 NCHAR=9;
+FORMAT DATATYPE=DNA;
+MATRIX
+Seq1 ATGAAACCC
+Seq2 ATGAAAGGG
+;
+END;`;
+
+const PHYLIP_SAMPLE = ` 2 9
+Seq1      ATGAAACCC
+Seq2      ATGAAAGGG`;
+
+const MEGA_SAMPLE = `#mega
+!Title: Sample;
+#Seq1
+ATGAAACCC
+#Seq2
+ATGAAAGGG`;
+
+const CLUSTAL_SAMPLE = `CLUSTAL W (1.83) multiple sequence alignment
+
+Seq1            ATGAAACCC
+Seq2            ATGAAAGGG`;
+
+describe('isNexusFormat', () => {
+	it('detects #nexus header (lowercase)', () => {
+		expect(isNexusFormat(NEXUS_SAMPLE)).toBe(true);
+	});
+
+	it('detects #NEXUS header (uppercase, case-insensitive)', () => {
+		expect(isNexusFormat('#NEXUS\nBEGIN DATA;')).toBe(true);
+	});
+
+	it('ignores leading whitespace', () => {
+		expect(isNexusFormat('   \n#nexus\n')).toBe(true);
+	});
+
+	it('rejects FASTA', () => {
+		expect(isNexusFormat(FASTA_SAMPLE)).toBe(false);
+	});
+
+	it('rejects MEGA (also starts with #)', () => {
+		expect(isNexusFormat(MEGA_SAMPLE)).toBe(false);
+	});
+
+	it('rejects empty input', () => {
+		expect(isNexusFormat('')).toBe(false);
+		expect(isNexusFormat(null)).toBe(false);
+		expect(isNexusFormat(undefined)).toBe(false);
+	});
+});
+
+describe('isFastaFormat', () => {
+	it('detects standard > headers', () => {
+		expect(isFastaFormat(FASTA_SAMPLE)).toBe(true);
+	});
+
+	it("detects HyPhy's # header variant for FASTA", () => {
+		expect(isFastaFormat('#Seq1\nATG\n#Seq2\nGGG')).toBe(true);
+	});
+
+	it('rejects NEXUS even though it starts with #', () => {
+		expect(isFastaFormat(NEXUS_SAMPLE)).toBe(false);
+	});
+
+	it('rejects MEGA even though it starts with #', () => {
+		expect(isFastaFormat(MEGA_SAMPLE)).toBe(false);
+	});
+
+	it('rejects PHYLIP (starts with a digit count)', () => {
+		expect(isFastaFormat(PHYLIP_SAMPLE)).toBe(false);
+	});
+
+	it('rejects CLUSTAL', () => {
+		expect(isFastaFormat(CLUSTAL_SAMPLE)).toBe(false);
+	});
+
+	it('rejects empty input', () => {
+		expect(isFastaFormat('')).toBe(false);
+		expect(isFastaFormat(null)).toBe(false);
+		expect(isFastaFormat(undefined)).toBe(false);
+	});
+});
+
+describe('isJSParseableFormat', () => {
+	it('returns true for FASTA', () => {
+		expect(isJSParseableFormat(FASTA_SAMPLE)).toBe(true);
+	});
+
+	it('returns true for NEXUS', () => {
+		expect(isJSParseableFormat(NEXUS_SAMPLE)).toBe(true);
+	});
+
+	it('returns false for PHYLIP', () => {
+		expect(isJSParseableFormat(PHYLIP_SAMPLE)).toBe(false);
+	});
+
+	it('returns false for MEGA', () => {
+		expect(isJSParseableFormat(MEGA_SAMPLE)).toBe(false);
+	});
+
+	it('returns false for CLUSTAL', () => {
+		expect(isJSParseableFormat(CLUSTAL_SAMPLE)).toBe(false);
+	});
+
+	it('returns false for empty input', () => {
+		expect(isJSParseableFormat('')).toBe(false);
+		expect(isJSParseableFormat(null)).toBe(false);
+	});
+});

--- a/src/test/validate-input-format-gate.test.js
+++ b/src/test/validate-input-format-gate.test.js
@@ -1,0 +1,65 @@
+/**
+ * Tests for BaseAnalysisRunner.validateInput format gating.
+ *
+ * Codon-aware methods (FEL, MEME, BUSTED, etc.) require the alignment to be
+ * divisible by 3 with no premature stop codons. The JS-side check
+ * (validateCodonAlignment) parses the alignment as FASTA or NEXUS — anything
+ * else (PHYLIP, MEGA, CLUSTAL) is rejected by parseFasta with a confusing
+ * "Sequence data found before header" error. Per dm2 parity, we skip JS
+ * codon validation for non-FASTA/NEXUS formats and trust HyPhy to validate
+ * on the analysis run.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BaseAnalysisRunner } from '../lib/services/BaseAnalysisRunner.js';
+
+const TREE = '((Seq1:0.1,Seq2:0.1):0.1);';
+
+const VALID_FASTA = `>Seq1\nATGAAACCC\n>Seq2\nATGAAAGGG`;
+const STOP_FASTA = `>Seq1\nATGTAACCC\n>Seq2\nATGAAAGGG`; // TAA stop codon
+const BAD_LENGTH_FASTA = `>Seq1\nATGA\n>Seq2\nATGA`; // not divisible by 3
+
+const PHYLIP = ` 2 9\nSeq1      ATGTAACCC\nSeq2      ATGAAAGGG`; // has stop codon
+const MEGA = `#mega\n!Title: Sample;\n#Seq1\nATGTAACCC\n#Seq2\nATGAAAGGG`; // has stop codon
+const CLUSTAL = `CLUSTAL W (1.83) multiple sequence alignment\n\nSeq1            ATGTAACCC\nSeq2            ATGAAAGGG`;
+
+describe('BaseAnalysisRunner.validateInput format gating', () => {
+	const runner = new BaseAnalysisRunner();
+
+	it('runs codon validation for FASTA + codon-aware method', () => {
+		expect(() => runner.validateInput(STOP_FASTA, TREE, 'fel')).toThrow(/stop codon/i);
+	});
+
+	it('runs codon validation for FASTA, catches bad length', () => {
+		expect(() => runner.validateInput(BAD_LENGTH_FASTA, TREE, 'fel')).toThrow(/divisible by 3/i);
+	});
+
+	it('accepts a clean FASTA for codon-aware method', () => {
+		expect(() => runner.validateInput(VALID_FASTA, TREE, 'fel')).not.toThrow();
+	});
+
+	it('skips codon validation for PHYLIP (would otherwise be parsed as FASTA and fail)', () => {
+		expect(() => runner.validateInput(PHYLIP, TREE, 'fel')).not.toThrow();
+	});
+
+	it('skips codon validation for MEGA', () => {
+		expect(() => runner.validateInput(MEGA, TREE, 'fel')).not.toThrow();
+	});
+
+	it('skips codon validation for CLUSTAL', () => {
+		expect(() => runner.validateInput(CLUSTAL, TREE, 'fel')).not.toThrow();
+	});
+
+	it('skips codon validation for non-codon-aware methods regardless of format', () => {
+		expect(() => runner.validateInput(STOP_FASTA, TREE, 'gard')).not.toThrow();
+		expect(() => runner.validateInput(PHYLIP, TREE, 'gard')).not.toThrow();
+	});
+
+	it('still requires fastaData', () => {
+		expect(() => runner.validateInput('', TREE, 'fel')).toThrow(/FASTA data is empty/i);
+	});
+
+	it('still requires treeData', () => {
+		expect(() => runner.validateInput(VALID_FASTA, '', 'fel')).toThrow(/Tree data is empty/i);
+	});
+});


### PR DESCRIPTION
## Summary

dm2's UI claims support for **5 alignment formats** (FASTA, NEXUS, PHYLIP sequential+interleaved, MEGA, CLUSTAL — see \`datamonkey-js/src/jsx/data_files.jsx:546\`) and dm2 lets HyPhy's \`datareader.bf\` auto-detect on the server. dm3 inherits the same \`datareader.bf\` for upload validation, but \`BaseAnalysisRunner.validateInput\` runs a JS-side codon check via \`parseAlignment()\`, which only handles FASTA and NEXUS. **PHYLIP, MEGA, and CLUSTAL files upload fine but fail at analysis-start with a confusing \"Sequence data found before header\" error thrown from \`parseFasta\`.**

This PR ships both fixes from the earlier discussion:

### Option 1 — gate JS codon validation on format

- New helpers \`isFastaFormat()\` and \`isJSParseableFormat()\` in \`fastaValidation.js\`.
- \`BaseAnalysisRunner.validateInput\` now skips \`validateCodonAlignment\` for non-FASTA/NEXUS input. Matches dm2's \"trust HyPhy\" behavior for those formats and stops blocking valid PHYLIP/MEGA/CLUSTAL submissions.

### Option 2 — canonical FASTA from datareader.bf

- \`datareader.bf\` now always emits a canonical FASTA at \`/shared/data/user.fasta\`.
- **Important detail**: \`DATA_FILE_PRINT_FORMAT = 9\` is \"FASTA sequential\" per HyPhy's \`ConvertDataFile.bf\`. The legacy rewrite at line 583 uses \`6\` (NEXUS sequential, despite the variable name suggesting otherwise) because it re-reads with \`ReadDataFile\`'s autodetection — but we need real FASTA for the JS layer that doesn't autodetect. I caught this the hard way: my first attempt used \`6\` and the WASM e2e tests failed with \"No sequences found in NEXUS MATRIX block\" because parseAlignment ran parseNexus on what was actually a NEXUS-formatted output.
- \`handleFileUpload\` in \`+page.svelte\` downloads the canonical FASTA and stashes it on \`fileMetricsJSON.canonicalFasta\` so it survives the IndexedDB cache.
- \`AnalyzeTab.svelte\` prefers \`\$fileMetricsStore.canonicalFasta\` over the raw blob when running analyses, falling back to the original file for legacy cached analyses.

Together, downstream submission (BackendAnalysisRunner emit, WASM exec) always sees FASTA regardless of what the user uploaded.

## Test plan

- [x] 28 new unit tests: format detection edge cases (\`format-detection.test.js\`) and \`BaseAnalysisRunner.validateInput\` gating behavior including PHYLIP/MEGA/CLUSTAL skip (\`validate-input-format-gate.test.js\`)
- [x] All 229 unit tests pass (was 201 + 28 new)
- [x] All 3 WASM e2e tests pass locally (\`07-wasm-analysis.spec.js\`)
- [ ] Manual: upload a PHYLIP file → confirm it now runs a codon-aware analysis instead of blocking with \"Sequence data found before header\"
- [ ] Manual: upload a NEXUS file → confirm existing behavior preserved, and confirm \`canonicalFasta\` is set in the cached \`fileMetricsJSON\`
- [ ] Manual: backend-mode analysis → confirm the alignment sent to the socket is FASTA (\`stripEmbeddedTrees\` + \`sanitizeSequenceNames\` apply to canonical FASTA)

## Base branch

Stacked on \`fix/analyze-tab-tree-source-race\` (PR #138) to inherit the regression fixes. Will rebase to main once that lands.

## Follow-ups

- Consider exposing the detected format (\`fileMetricsJSON.FILE_INFO.format\` if datareader can be made to emit it) so the backend can also see what the user actually uploaded.
- The format-handling glue (\`parseNexus\`, \`stripEmbeddedTrees\`, \`sanitizeSequenceNames\`) still has no direct unit tests; that's worth a separate small PR.