### PR TITLE
Require ≥2 branch groups before submitting Contrast-FEL (#144)

### DIFF
--- a/e2e/16-contrast-fel-min-groups.spec.js
+++ b/e2e/16-contrast-fel-min-groups.spec.js
@@ -1,0 +1,42 @@
+/**
+ * E2E test for issue #144: Contrast-FEL must require >= 2 branch groups before
+ * submission. With fewer than two groups the downstream HyPhy job core-dumps, so
+ * the UI blocks submission (disabled Run button + a clear warning message).
+ *
+ * This test exercises the actual component wiring (not just the pure validation
+ * helper), so it guards against key-casing / reactivity mistakes in the guard.
+ */
+
+import { test, expect } from '@playwright/test';
+import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+
+test.describe('Contrast-FEL requires two branch groups (#144)', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'CD2-slim.fna');
+		await goToAnalyzeTab(page);
+	});
+
+	test('Run is blocked and a warning shows when no branch groups are tagged', async ({ page }) => {
+		await selectMethod(page, 'Contrast-FEL');
+
+		// With no groups tagged, submission must be blocked.
+		const runButton = page.locator('[data-testid="run-analysis-btn"]');
+		await expect(runButton).toBeDisabled();
+
+		// And a clear, actionable warning must be visible (not just a console log).
+		const warning = page.locator('[data-testid="contrast-fel-groups-warning"]');
+		await expect(warning).toBeVisible();
+		await expect(warning).toContainText(/two or more groups/i);
+	});
+
+	test('other methods (FEL) are not affected by the contrast-FEL guard', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+
+		// FEL has no such requirement — its Run button should be enabled and no
+		// contrast-FEL warning should appear.
+		const runButton = page.locator('[data-testid="run-analysis-btn"]');
+		await expect(runButton).toBeEnabled();
+		await expect(page.locator('[data-testid="contrast-fel-groups-warning"]')).toHaveCount(0);
+	});
+});

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -8,6 +8,10 @@
 	import AnalysisTimingEstimate from './AnalysisTimingEstimate.svelte';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
+	import {
+		countBranchGroups,
+		contrastFelHasEnoughGroups
+	} from './utils/branchGroupValidation.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -1050,6 +1054,15 @@
 	$: relaxBranchesValid = selectedMethod?.toLowerCase() !== 'relax' ||
 		(relaxHasTestBranches && relaxHasReferenceBranches);
 
+	// Contrast-FEL branch validation - compares two or more groups, so at least two
+	// distinct branch groups must be defined before submission. A single group core-dumps
+	// downstream in HyPhy (subtracting an empty matrix from the rate matrix), so gate it here.
+	//   - Interactive mode: count distinct groups tagged on the tree (selectionSetCount).
+	//   - Custom mode: require the first two branch-set text fields to be non-empty.
+	$: contrastFelBranchesValid =
+		selectedMethod?.toLowerCase() !== 'contrast-fel' ||
+		contrastFelHasEnoughGroups(methodOptions?.[selectedMethod] || {});
+
 	// Update a single method option (avoids bind:value inside {#each} which breaks in Svelte 5.23+)
 	function updateMethodOption(key, value) {
 		if (selectedMethod && methodOptions[selectedMethod]) {
@@ -1084,6 +1097,15 @@
 
 	// Run analysis
 	function runAnalysis() {
+		// Safety net: never submit Contrast-FEL with fewer than two branch groups —
+		// the button is also disabled in this state, but guard the handler directly too.
+		if (selectedMethod?.toLowerCase() === 'contrast-fel' && !contrastFelBranchesValid) {
+			console.warn(
+				'🚫 METHODSELECTOR - Blocked Contrast-FEL submission: needs at least two branch groups'
+			);
+			return;
+		}
+
 		if (selectedMethod && runMethod && !isSubmitting) {
 			isSubmitting = true;
 
@@ -1137,6 +1159,10 @@
 			methodOptions[selectedMethod].interactiveTree = taggedNewick || '';
 			methodOptions[selectedMethod].selectedBranchCount = count || 0;
 			methodOptions[selectedMethod].selectedBranchNames = selectedBranches || [];
+
+			// Track the number of distinct, non-empty branch groups tagged on the tree.
+			// Contrast-FEL requires >= 2 to be a valid comparison (see contrastFelBranchesValid).
+			methodOptions[selectedMethod].selectionSetCount = countBranchGroups(selectionSets);
 
 			// For Contrast-FEL multi-set mode, use the actual set names as branch-set parameters
 			console.log('🌳🔥 METHODSELECTOR - Checking Contrast-FEL conditions:', {
@@ -1474,11 +1500,29 @@
 					<span>Please select TEST and REFERENCE branches on the tree before running RELAX.</span>
 				</div>
 			{/if}
+			{#if selectedMethod?.toLowerCase() === 'contrast-fel' && !contrastFelBranchesValid}
+				<div class="branch-validation-warning" data-testid="contrast-fel-groups-warning">
+					<AlertTriangle class="warning-icon" />
+					<span>
+						{#if methodOptions?.[selectedMethod]?.branchesToTest === 'Custom'}
+							Contrast-FEL compares two or more groups — please define at least two branch
+							sets.
+						{:else}
+							Contrast-FEL compares two or more groups — please tag at least two branch
+							groups on the tree.
+						{/if}
+					</span>
+				</div>
+			{/if}
 			<button
 				class="run-button-large"
 				class:submitting={isSubmitting}
 				on:click={runAnalysis}
-				disabled={!selectedMethod || !currentMethod?.info.supported || isSubmitting || !relaxBranchesValid}
+				disabled={!selectedMethod ||
+					!currentMethod?.info.supported ||
+					isSubmitting ||
+					!relaxBranchesValid ||
+					!contrastFelBranchesValid}
 				data-testid="run-analysis-btn"
 			>
 				{#if isSubmitting}

--- a/src/lib/utils/branchGroupValidation.js
+++ b/src/lib/utils/branchGroupValidation.js
@@ -1,0 +1,47 @@
+/**
+ * Branch-group validation for methods that compare multiple branch groups.
+ *
+ * Contrast-FEL compares two or more groups. Submitting with fewer than two groups
+ * makes HyPhy core-dump downstream (it subtracts an empty 0x0 matrix from the rate
+ * matrix). We gate submission in the UI so the user gets immediate, understandable
+ * feedback instead of a job that fails minutes later. See issue #144.
+ */
+
+/**
+ * Count distinct, non-empty branch-group names.
+ * @param {unknown} selectionSets - array of group names emitted by the branch selector
+ * @returns {number}
+ */
+export function countBranchGroups(selectionSets) {
+	if (!Array.isArray(selectionSets)) return 0;
+	return new Set(
+		selectionSets
+			.filter((s) => typeof s === 'string' && s.trim().length > 0)
+			.map((s) => s.trim())
+	).size;
+}
+
+/**
+ * Whether a Contrast-FEL configuration has enough branch groups to submit.
+ *
+ * Two input modes:
+ *  - Interactive (default): at least two distinct groups tagged on the tree.
+ *  - Custom: the first two branch-set text fields must both be non-empty.
+ *
+ * @param {object} opts - the contrast-fel method options
+ * @param {string} [opts.branchesToTest] - 'Interactive' | 'Custom'
+ * @param {number} [opts.selectionSetCount] - distinct groups tagged in Interactive mode
+ * @param {string} [opts.branchSet1]
+ * @param {string} [opts.branchSet2]
+ * @returns {boolean}
+ */
+export function contrastFelHasEnoughGroups(opts = {}) {
+	if (opts.branchesToTest === 'Custom') {
+		return (
+			(opts.branchSet1 || '').trim().length > 0 &&
+			(opts.branchSet2 || '').trim().length > 0
+		);
+	}
+	// Interactive (default)
+	return (opts.selectionSetCount || 0) >= 2;
+}

--- a/src/test/branch-group-validation.test.js
+++ b/src/test/branch-group-validation.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+	countBranchGroups,
+	contrastFelHasEnoughGroups
+} from '../lib/utils/branchGroupValidation.js';
+
+// Coverage for issue #144: Contrast-FEL must require >= 2 branch groups before
+// submission. A single group core-dumps HyPhy downstream, so the UI blocks it.
+
+describe('countBranchGroups', () => {
+	it('counts distinct non-empty group names', () => {
+		expect(countBranchGroups(['Set1', 'Set2'])).toBe(2);
+		expect(countBranchGroups(['Set1', 'Set2', 'Set3'])).toBe(3);
+	});
+
+	it('deduplicates repeated names', () => {
+		expect(countBranchGroups(['Set1', 'Set1'])).toBe(1);
+		expect(countBranchGroups(['Set1', ' Set1 '])).toBe(1); // trimmed
+	});
+
+	it('ignores empty / whitespace-only / non-string entries', () => {
+		expect(countBranchGroups(['Set1', '', '   ', null, undefined, 5])).toBe(1);
+		expect(countBranchGroups([])).toBe(0);
+	});
+
+	it('returns 0 for non-array input', () => {
+		expect(countBranchGroups(undefined)).toBe(0);
+		expect(countBranchGroups(null)).toBe(0);
+		expect(countBranchGroups('Set1')).toBe(0);
+	});
+});
+
+describe('contrastFelHasEnoughGroups — Interactive mode', () => {
+	const interactive = (count) => ({
+		branchesToTest: 'Interactive',
+		selectionSetCount: count
+	});
+
+	it('blocks with zero or one tagged group', () => {
+		expect(contrastFelHasEnoughGroups(interactive(0))).toBe(false);
+		expect(contrastFelHasEnoughGroups(interactive(1))).toBe(false);
+		// No interaction yet => selectionSetCount undefined
+		expect(contrastFelHasEnoughGroups({ branchesToTest: 'Interactive' })).toBe(false);
+		// Default mode is Interactive when unspecified
+		expect(contrastFelHasEnoughGroups({})).toBe(false);
+	});
+
+	it('allows with two or more tagged groups', () => {
+		expect(contrastFelHasEnoughGroups(interactive(2))).toBe(true);
+		expect(contrastFelHasEnoughGroups(interactive(3))).toBe(true);
+	});
+});
+
+describe('contrastFelHasEnoughGroups — Custom mode', () => {
+	it('requires both branch-set text fields to be non-empty', () => {
+		expect(
+			contrastFelHasEnoughGroups({ branchesToTest: 'Custom', branchSet1: 'Source', branchSet2: 'Test' })
+		).toBe(true);
+		expect(
+			contrastFelHasEnoughGroups({ branchesToTest: 'Custom', branchSet1: 'Source', branchSet2: '' })
+		).toBe(false);
+		expect(
+			contrastFelHasEnoughGroups({ branchesToTest: 'Custom', branchSet1: '   ', branchSet2: 'Test' })
+		).toBe(false);
+		expect(contrastFelHasEnoughGroups({ branchesToTest: 'Custom' })).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #144. The Contrast-FEL submission UI allowed a job to be submitted with only **one** branch group tagged. Contrast-FEL compares two or more groups; with a single group the downstream HyPhy job core-dumps (it subtracts an empty 0×0 matrix from the 61×61 rate matrix), and the user sees a failed job minutes later with no actionable explanation.

## Fix

`MethodSelector.svelte` now gates Contrast-FEL submission on having **at least two branch groups**, handling both input modes:
- **Interactive** (tree tagging): at least two distinct, non-empty tagged groups (`selectionSetCount`).
- **Custom** (text fields): both branch-set fields non-empty.

When the requirement isn't met:
- the **Run button is disabled**, and
- `runAnalysis()` **early-returns** as a safety net, and
- a clear inline warning is shown near the Run button: *"Contrast-FEL compares two or more groups — please tag at least two branch groups on the tree."* (mode-aware wording).

The guard is **scoped strictly to Contrast-FEL** — FEL / SLAC / RELAX / BUSTED / etc. are unaffected. It mirrors the existing RELAX branch-validation pattern already in this component.

## Tests

- `src/lib/utils/branchGroupValidation.js` — pure decision helpers (`countBranchGroups`, `contrastFelHasEnoughGroups`).
- `src/test/branch-group-validation.test.js` — unit tests for group counting (dedup, trim, empty/whitespace/non-string) and both-mode validation (0/1 blocked, 2+ allowed).
- `e2e/16-contrast-fel-min-groups.spec.js` — drives the real component: asserts the Run button is disabled + the warning is shown with no groups, and that FEL is unaffected. This exercises the component wiring, not just the helper.

Full unit suite: **252 passing**. New e2e: **2/2 passing**. Production build (adapter-node): clean.

> Note: this is the user-facing complement to the backend validation. The backend GARD/`--code` issue (#143) is being handled separately by the backend team and is intentionally not touched here.