### PR TITLE
Raise alignment size limits (HyPhyGlobals.ibf)

### DIFF
--- a/src/data/shared/HyPhyGlobals.ibf
+++ b/src/data/shared/HyPhyGlobals.ibf
@@ -12,25 +12,25 @@ maxToggleSites		 = 50;
 
 
 
-maxSLACSize		     = 500;
-maxFELSize		     = 500;
-maxMEMESize			   = maxFELSize;
-maxPRIMESize		   = maxFELSize;
-maxFUBARSize		   = 5000;
+maxSLACSize		     = 10000;
+maxFELSize		     = 25000;
+maxMEMESize        = 10000;
+maxPRIMESize       = 5000;
+maxFUBARSize		   = 25000;
 maxFADESize	       = maxFUBARSize;
-maxRELSize		     = 75;
+maxRELSize		     = 2000;
 maxBSRSize			   = maxRELSize;
 maxGABranchSize		 = 30;
 maxBGMSize		     = maxSLACSize;
 maxASRSize		     = maxSLACSize;
 maxSBPSize		     = maxSLACSize;
-maxGARDSize		     = 300;
+maxGARDSize		     = 500;
 maxSCUEALSize		   = 500;
 maxCMSSize		 	   = 120;
 maxEVFSize			   = 120;
 maxToggleSize		   = 150;
 maxDEPSSize		 	   = 100;
-maxUploadSize      = 5000;
+maxUploadSize      = 25000;
 
 alignmentSizeLimits		 = {
 {"SLAC",""+maxSLACSize}


### PR DESCRIPTION
## Summary
Raises the alignment size limits in `HyPhyGlobals.ibf`. The previous caps were very restrictive — `maxRELSize=75`, `maxFELSize=maxSLACSize=500` sequences — and were the practical ceiling on what users could submit in DM3.

New values were derived from the DM3 timing calculator (`timingEstimates.js` power-law fits), targeting a ~12h budget at 1000 sites on the 32-core backend.

| Var | Old | New | Methods |
|---|---:|---:|---|
| maxSLACSize | 500 | 10000 | SLAC, BGM, ASR, SBP |
| maxFELSize | 500 | 25000 | FEL |
| maxMEMESize | =FEL | 10000 | MEME (un-aliased) |
| maxPRIMESize | =FEL | 5000 | PRIME (un-aliased; costlier than FEL) |
| maxFUBARSize | 5000 | 25000 | FUBAR, FADE |
| maxRELSize | 75 | 2000 | RELAX, aBSREL (via maxBSRSize) |
| maxGARDSize | 300 | 500 | GARD (small; superlinear in taxa) |
| maxUploadSize | 5000 | 25000 | global species ceiling |

`maxDMSites` (12000) unchanged.

**Note:** these values are compiled into the built SvelteKit client bundle, so a rebuild (`BUILD_TARGET=node`) is required for them to take effect at runtime — editing the source alone does not change the running limits.
