### PR TITLE
Cut the e2e suite from ~10.6m to ~4.9m

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,11 +1,41 @@
 import { defineConfig, devices } from '@playwright/test';
 
+/**
+ * Specs that genuinely depend on the Pixel 5 viewport.
+ *
+ * Before this, neither project set a filter, so every spec ran twice — measured at 46.4m of 89.3m
+ * total CPU-time for mobile-chrome, i.e. half the suite, to re-run desktop tests at a narrower
+ * width. Only these two exercise anything viewport-dependent:
+ *
+ *   14-responsive       — explicitly a mobile spec; its own header says so.
+ *   10-branch-selector  — carries a mobile-only workaround (force:true, because the advanced-options
+ *                         panel overlaps the r=3 SVG node and intercepts pointer events at narrow
+ *                         width), so it tests something desktop cannot reach.
+ *
+ * 14-responsive is additionally excluded from chromium: at desktop width its assertions are
+ * trivially satisfied and prove nothing.
+ */
+const MOBILE_SPECS = /(10-branch-selector|14-responsive)\.spec\.js$/;
+const DESKTOP_ONLY_EXCLUDE = /14-responsive\.spec\.js$/;
+
 export default defineConfig({
 	testDir: './e2e',
-	fullyParallel: false,
+
+	// File-level parallelism only was the binding constraint: measured speedup was 2.4x on 4 workers,
+	// because a 10-test spec ran as one serial chain. No spec uses describe.serial or shares state
+	// through beforeAll — every heavy one has its own beforeEach — so per-test distribution is safe.
+	fullyParallel: true,
+
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 1,
-	workers: process.env.CI ? 1 : 4,
+
+	// Locally you want the fast red: a retry doubles the cost of a genuine failure, and a suite that
+	// hides flakes behind a retry is worse than one that shows them. CI keeps its retries.
+	retries: process.env.CI ? 2 : 0,
+
+	// 50% of logical cores. Deliberately not higher: several specs run WASM/ONNX inference under
+	// wall-clock timeouts, and oversubscribing turns those into timeout flakes rather than speed.
+	workers: process.env.CI ? 1 : '50%',
+
 	reporter:
 		process.env.E2E_COVERAGE === '1'
 			? [
@@ -33,19 +63,31 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
+			use: { ...devices['Desktop Chrome'] },
+			testIgnore: DESKTOP_ONLY_EXCLUDE
 		},
 		{
 			name: 'mobile-chrome',
-			use: { ...devices['Pixel 5'] }
+			use: { ...devices['Pixel 5'] },
+			testMatch: MOBILE_SPECS
 		}
 	],
+	// A built app served statically, rather than `vite dev` transforming modules on demand. Nearly
+	// every test calls freshStart(), so the dev server re-pays module-graph cost on each navigation.
+	// Verified that `vite preview` serves the adapter-cloudflare build correctly (200 + app HTML).
+	//
+	// E2E_DEV=1 opts back into `vite dev` when you want HMR while debugging a spec. Note that
+	// reuseExistingServer means an already-running dev server on 5173 is used either way, so this
+	// only changes what happens on a clean run.
 	webServer: process.env.E2E_NO_WEBSERVER
 		? undefined
 		: {
-				command: 'npm run dev',
+				command: process.env.E2E_DEV
+					? 'npm run dev'
+					: 'npm run build && npm run preview -- --port 5173 --strictPort',
 				url: 'http://localhost:5173',
 				reuseExistingServer: !process.env.CI,
-				timeout: 120000
+				// Raised from 120s: the default path now builds before it serves.
+				timeout: 240000
 			}
 });


### PR DESCRIPTION
Four Playwright config changes, each backed by a measurement from a JSON-reporter run of the full suite rather than a guess about what looked slow.

## Measured result

| | Before | After |
|---|---|---|
| Wall clock (`npm run test:e2e`) | 10.6m | **4:53** |
| Tests | 206 (every spec duplicated across both projects) | 106 |
| Fast set | — | 96 passed, 3.5m / 3.6m over two runs |
| `@slow` set | — | 10 passed, 1.3m |
| Workers | 4 | 7 (`50%`) |
| Flakes across two back-to-back runs | — | none, no count drift |

## The changes

**Project matrix — the big one.** Neither project set a filter, so all 103 tests ran on `chromium` and again on `mobile-chrome`: **46.4m of 89.3m total CPU-time**, half the suite, re-running desktop tests at Pixel 5 width. Only two specs depend on the viewport:

- `14-responsive` says so in its own header — but nothing enforced it, so it was *also* running at desktop width where its assertions prove nothing. Now mobile-only.
- `10-branch-selector` carries a mobile-only `force:true` workaround for the advanced-options panel intercepting pointer events over the `r=3` SVG node. Runs on both.

**`fullyParallel: true`.** Measured speedup was only 2.4x on 4 workers, because parallelism was at file granularity and a 10-test spec ran as one serial chain. Checked the thing that usually justifies `false`: no spec uses `describe.serial`, none shares state through `beforeAll`, and every heavy one has its own `beforeEach`.

**`workers: '50%'`** (was a hardcoded 4 on a 14-core machine). Deliberately not 75% — several specs run WASM/ONNX under wall-clock timeouts, where oversubscription buys timeout flakes rather than speed.

**`retries: 0` locally.** A retry doubles the cost of a genuine failure — 56.8m in the baseline run — and a suite that hides flakes behind a retry is worse than one that shows them. CI keeps its 2.

**Webserver serves a built app** instead of transforming modules on demand; nearly every test calls `freshStart()`, so `vite dev` re-paid module-graph cost per navigation. Verified `vite preview` serves the adapter-cloudflare build correctly (200 + app HTML) before wiring it in. `E2E_DEV=1` opts back into `vite dev` for HMR while debugging a spec. Because `reuseExistingServer` is on locally, an already-running dev server is still used either way — this only changes clean runs.

## One caveat, stated plainly

The suite is now green **partly because three long-failing mobile-chrome tests no longer run**: `13-url-navigation:28` and `concurrent-analyses:28,:50`, all status-indicator assertions. They fail on `main` too — verified in an isolated worktree on a separate port — so this is not a regression. But restricting the matrix *hides* them rather than fixing them.

The open question is whether the analysis status indicator is genuinely broken at Pixel 5 width (a real mobile bug) or intentionally not rendered there (in which case those assertions were never applicable). Worth a follow-up issue either way.