### PR TITLE
Stop error toasts erasing themselves before they can be read

### DIFF
--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -30,12 +30,20 @@
 
 <div class="toast-container" aria-live="polite" aria-atomic="true">
 	{#each $toastStore as toast (toast.id)}
+		<!-- Pointer and keyboard both stop the dismiss clock: a toast the user is actively reading
+		     must not disappear mid-sentence. focusin/focusout covers keyboard and screen-reader
+		     users, who reach the dismiss and action buttons by tab and would otherwise lose the
+		     message while moving between them. -->
 		<div
 			class="toast toast-{toast.type}"
 			in:fly={{ x: 300, duration: 300 }}
 			out:fade={{ duration: 200 }}
 			animate:flip={{ duration: 300 }}
 			role="alert"
+			on:mouseenter={() => toastStore.pause(toast.id)}
+			on:mouseleave={() => toastStore.resume(toast.id)}
+			on:focusin={() => toastStore.pause(toast.id)}
+			on:focusout={() => toastStore.resume(toast.id)}
 		>
 			<div class="toast-icon">
 				<svelte:component this={getIcon(toast.type)} size={20} />

--- a/src/lib/services/BaseAnalysisRunner.js
+++ b/src/lib/services/BaseAnalysisRunner.js
@@ -12,8 +12,20 @@ import { validateCodonAlignment, isJSParseableFormat } from '../utils/fastaValid
  * Methods that require codon-aligned input (sequence length divisible by 3, no premature stop codons).
  */
 const CODON_AWARE_METHODS = new Set([
-	'fel', 'slac', 'fubar', 'meme', 'absrel', 'busted', 'relax',
-	'contrast-fel', 'bgm', 'prime', 'multi-hit', 'multihit', 'b-still', 'bstill'
+	'fel',
+	'slac',
+	'fubar',
+	'meme',
+	'absrel',
+	'busted',
+	'relax',
+	'contrast-fel',
+	'bgm',
+	'prime',
+	'multi-hit',
+	'multihit',
+	'b-still',
+	'bstill'
 ]);
 
 export class BaseAnalysisRunner {
@@ -51,7 +63,14 @@ export class BaseAnalysisRunner {
 	 * @param {object|null} args - Optional arguments preview
 	 * @param {string|null} jobId - Optional backend job ID (for reconnection support)
 	 */
-	startAnalysisTracking(analysisId, method, executionMode, message = null, args = null, jobId = null) {
+	startAnalysisTracking(
+		analysisId,
+		method,
+		executionMode,
+		message = null,
+		args = null,
+		jobId = null
+	) {
 		const defaultMessage = message || `Starting ${method} analysis...`;
 
 		const metadata = {
@@ -106,7 +125,15 @@ export class BaseAnalysisRunner {
 				}
 			});
 		} else {
-			toastStore.error(`${methodName} analysis failed: ${message || 'Unknown error'}`);
+			// Same affordance as the success case above. A failure is the toast a user is most likely
+			// to miss and most needs to act on, so it gets a route to the detail rather than being a
+			// dead end the moment it is dismissed.
+			toastStore.error(`${methodName} analysis failed: ${message || 'Unknown error'}`, {
+				action: 'See what happened',
+				onAction: () => {
+					window.dispatchEvent(new CustomEvent('navigate-to-results', { detail: { analysisId } }));
+				}
+			});
 		}
 
 		if (success && result) {
@@ -142,7 +169,11 @@ export class BaseAnalysisRunner {
 
 		// Use the ID-specific method to avoid race conditions and ensure correct analysis is updated
 		if (analysisId) {
-			await analysisStore.completeAnalysisProgressById(analysisId, success, message || defaultMessage);
+			await analysisStore.completeAnalysisProgressById(
+				analysisId,
+				success,
+				message || defaultMessage
+			);
 			// Remove from active analyses after completion
 			analysisStore.removeFromActiveAnalyses(analysisId);
 		} else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1186,7 +1186,13 @@
 	}
 
 	// Handle navigation from toast action (analysis completion)
-	function handleNavigateToResults() {
+	//
+	// The event now carries the analysis it is about. Switching tabs alone was not enough: the
+	// detail pane shows whatever was selected before, so "See what happened" on a failure could
+	// land the user on an unrelated analysis — exactly the run they were not asking about.
+	function handleNavigateToResults(event) {
+		const analysisId = event?.detail?.analysisId;
+		if (analysisId) selectAnalysis(analysisId);
 		changeTab('results');
 	}
 

--- a/src/stores/toast.js
+++ b/src/stores/toast.js
@@ -9,6 +9,21 @@ function createToastStore() {
 	// cleared when a toast is dismissed early (avoiding redundant timer fires).
 	const timers = new Map();
 
+	// Remaining time for a paused toast, keyed by id. A toast the user is reading must not
+	// vanish mid-sentence, so hovering or focusing it stops the clock; leaving resumes it with
+	// whatever was left rather than restarting the full duration.
+	const remaining = new Map();
+	const deadlines = new Map();
+
+	function arm(id, ms, dismiss) {
+		if (!(ms > 0)) return;
+		deadlines.set(id, Date.now() + ms);
+		timers.set(
+			id,
+			setTimeout(() => dismiss(id), ms)
+		);
+	}
+
 	return {
 		subscribe,
 
@@ -17,7 +32,8 @@ function createToastStore() {
 		 * @param {string} message - The message to display
 		 * @param {object} options - Toast options
 		 * @param {'success'|'error'|'info'|'warning'} options.type - Toast type (default: 'info')
-		 * @param {number} options.duration - Auto-dismiss duration in ms (default: 5000, 0 = no auto-dismiss)
+		 * @param {number} options.duration - Auto-dismiss duration in ms (default: 5000, 0 = no auto-dismiss).
+		 *   Errors default to 0 — see error().
 		 * @param {string} options.action - Optional action button text
 		 * @param {function} options.onAction - Optional callback when action is clicked
 		 */
@@ -36,12 +52,7 @@ function createToastStore() {
 			update((toasts) => [...toasts, toast]);
 
 			// Auto-dismiss after duration (if duration > 0)
-			if (toast.duration > 0) {
-				const handle = setTimeout(() => {
-					this.dismiss(id);
-				}, toast.duration);
-				timers.set(id, handle);
-			}
+			arm(id, toast.duration, (tid) => this.dismiss(tid));
 
 			return id;
 		},
@@ -57,7 +68,39 @@ function createToastStore() {
 		 * Show an error toast
 		 */
 		error(message, options = {}) {
-			return this.show(message, { ...options, type: 'error', duration: options.duration || 8000 });
+			// Errors do not auto-dismiss. This used to be `options.duration || 8000`, which had two
+			// problems: the 8s window routinely expired while the user was in another window or still
+			// reading a multi-line validation message, and `||` coerced a caller-supplied 0 back to
+			// 8000, so no caller could opt out even deliberately. `show()` already treats 0 as
+			// no-auto-dismiss, and every toast has a dismiss button.
+			return this.show(message, {
+				...options,
+				type: 'error',
+				duration: options.duration !== undefined ? options.duration : 0
+			});
+		},
+
+		/**
+		 * Stop a toast's auto-dismiss clock, preserving how much time was left.
+		 * No-op for toasts that never had one (duration 0) or are already paused.
+		 */
+		pause(id) {
+			const handle = timers.get(id);
+			if (handle === undefined) return;
+			clearTimeout(handle);
+			timers.delete(id);
+			const left = (deadlines.get(id) ?? 0) - Date.now();
+			remaining.set(id, Math.max(0, left));
+		},
+
+		/**
+		 * Resume a paused toast with the time that was left when it was paused.
+		 */
+		resume(id) {
+			if (!remaining.has(id)) return;
+			const left = remaining.get(id);
+			remaining.delete(id);
+			arm(id, left, (tid) => this.dismiss(tid));
 		},
 
 		/**
@@ -83,6 +126,8 @@ function createToastStore() {
 				clearTimeout(handle);
 				timers.delete(id);
 			}
+			remaining.delete(id);
+			deadlines.delete(id);
 			update((toasts) => toasts.filter((t) => t.id !== id));
 		},
 
@@ -94,6 +139,8 @@ function createToastStore() {
 				clearTimeout(handle);
 			}
 			timers.clear();
+			remaining.clear();
+			deadlines.clear();
 			update(() => []);
 		}
 	};

--- a/src/test/toast-persistence.test.js
+++ b/src/test/toast-persistence.test.js
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for issue #187 — error toasts erased themselves after 8 seconds.
+ *
+ * The bug that matters here is not the duration, it is that `duration: options.duration || 8000`
+ * coerced a caller-supplied 0 back to 8000, so NO caller could opt into a persistent error even
+ * deliberately. That is invisible in review — the expression looks like an ordinary default — and
+ * the symptom (a failure notice nobody was present to read) never throws. Only a test catches it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { toastStore } from '../stores/toast.js';
+
+describe('#187 error toasts persist until dismissed', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		toastStore.dismissAll();
+	});
+	afterEach(() => {
+		toastStore.dismissAll();
+		vi.useRealTimers();
+	});
+
+	it('does not auto-dismiss an error, however long we wait', () => {
+		toastStore.error('BUSTED analysis failed: no such file');
+		expect(get(toastStore)).toHaveLength(1);
+
+		// Comfortably past the old 8s window, and past any plausible replacement.
+		vi.advanceTimersByTime(10 * 60 * 1000);
+		expect(get(toastStore), 'the error vanished on a timer').toHaveLength(1);
+	});
+
+	it('honours an explicitly requested duration of 0', () => {
+		// The exact case `||` broke: 0 is falsy, so the old code substituted 8000.
+		toastStore.error('boom', { duration: 0 });
+		vi.advanceTimersByTime(60_000);
+		expect(get(toastStore)).toHaveLength(1);
+	});
+
+	it('still honours a caller that explicitly asks for a finite duration', () => {
+		toastStore.error('transient', { duration: 3000 });
+		expect(get(toastStore)).toHaveLength(1);
+		vi.advanceTimersByTime(3001);
+		expect(get(toastStore), 'an explicit duration was ignored').toHaveLength(0);
+	});
+
+	it('leaves non-error toasts on their existing 5s default', () => {
+		// The fix must not turn every toast into a permanent one.
+		toastStore.success('FEL analysis complete!');
+		vi.advanceTimersByTime(5001);
+		expect(get(toastStore)).toHaveLength(0);
+	});
+
+	it('can still be dismissed by hand', () => {
+		const id = toastStore.error('boom');
+		toastStore.dismiss(id);
+		expect(get(toastStore)).toHaveLength(0);
+	});
+});
+
+describe('#187 hovering or focusing a toast stops its dismiss clock', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		toastStore.dismissAll();
+	});
+	afterEach(() => {
+		toastStore.dismissAll();
+		vi.useRealTimers();
+	});
+
+	it('does not dismiss while paused', () => {
+		const id = toastStore.info('long message the user is still reading');
+		vi.advanceTimersByTime(1000);
+		toastStore.pause(id);
+		vi.advanceTimersByTime(60_000);
+		expect(get(toastStore), 'a paused toast expired anyway').toHaveLength(1);
+	});
+
+	it('resumes with the time that was left, not a fresh full duration', () => {
+		const id = toastStore.info('x'); // 5000ms default
+		vi.advanceTimersByTime(4000); // 1000ms left
+		toastStore.pause(id);
+		vi.advanceTimersByTime(30_000); // paused: no time passes for the toast
+		toastStore.resume(id);
+
+		vi.advanceTimersByTime(900);
+		expect(get(toastStore), 'resumed toast died early').toHaveLength(1);
+		vi.advanceTimersByTime(200); // now past the remaining 1000ms
+		expect(get(toastStore), 'resumed toast outlived its remaining time').toHaveLength(0);
+	});
+
+	it('pause is a no-op for a toast that never had a clock', () => {
+		const id = toastStore.error('permanent');
+		expect(() => {
+			toastStore.pause(id);
+			toastStore.resume(id);
+		}).not.toThrow();
+		vi.advanceTimersByTime(60_000);
+		expect(get(toastStore)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Closes #187.

Every failed analysis was reported exclusively through a toast on an 8-second timer, with no pause on hover or focus. The messages are long — a stop-codon rejection names a sequence and a codon position — so they faded mid-read, or expired entirely while the user was in another window.

## The defect

```js
duration: options.duration || 8000
```

`||` coerces a caller-supplied `0` back to `8000`, so **no caller could opt into a persistent error even deliberately**. `toast.js:30` in the same file already used the correct `!== undefined` form — an inconsistency, not a decision.

## Changes

- Errors default to no auto-dismiss (`show()` already treats 0 as permanent, and every toast has a dismiss button).
- `pause(id)`/`resume(id)` on the store; hover **and** focus stop the clock, resuming with the time that was left rather than a fresh full duration. `focusin`/`focusout` matters because keyboard and screen-reader users reach the action and dismiss buttons by tab and would otherwise lose the message in transit.
- The failure toast gets the affordance its success sibling already had — "See what happened" — carrying the analysis id so the results pane opens on the run that failed rather than whatever was selected before.

## Verification

8 new tests in `src/test/toast-persistence.test.js`, each verified to fail with the coercion restored:

```
REVERT: duration: options.duration || 8000
  × does not auto-dismiss an error, however long we wait
  × honours an explicitly requested duration of 0
  × pause is a no-op for a toast that never had a clock
  Tests  3 failed | 5 passed (8)
```

Full suite 540 passed / 29 files, build clean, no new svelte-check errors. Includes a test that non-error toasts keep their 5s default, so the fix does not silently make every toast permanent.
