### PR TITLE
Make the results pane follow the selection instead of keeping its own copy

### DIFF
--- a/src/lib/utils/analysisSelection.js
+++ b/src/lib/utils/analysisSelection.js
@@ -1,0 +1,41 @@
+/**
+ * analysisSelection.js — which analysis the results detail pane should show.
+ *
+ * This exists as a module rather than a local function in +page.svelte so it can be tested. The bug
+ * it fixes (#188) is one the UI reports as a contradiction rather than an error: the history list
+ * highlights one analysis while the pane beside it renders another, and nothing throws.
+ */
+
+/**
+ * The job the app runs on every upload to read file statistics. It is filtered out of the history
+ * list on purpose, which is exactly why selecting it is a dead end — there is no card to click to
+ * get back out.
+ */
+const READER_METHOD = 'datareader';
+
+/**
+ * Resolve the id the detail pane should render.
+ *
+ * @param {string|null} currentId - `analysisStore.currentAnalysisId`, the single source of truth.
+ * @param {Array<{id: string, fileId: string, method: string, createdAt: number}>} analyses
+ * @returns {string|null}
+ */
+export function resolveSelectedAnalysis(currentId, analyses) {
+	if (!currentId) return null;
+
+	const selected = (analyses ?? []).find((a) => a.id === currentId);
+
+	// Unknown ids pass through unchanged rather than being nulled: the record may simply not have
+	// loaded yet, and blanking the pane during that window would be its own flicker bug.
+	if (!selected || selected.method !== READER_METHOD) return currentId;
+
+	// The selection is the invisible reader job. Prefer the newest real analysis for the same file —
+	// on a fresh upload that is whatever the user just ran, which is what they were asking to see.
+	const newestReal = (analyses ?? [])
+		.filter((a) => a.fileId === selected.fileId && a.method !== READER_METHOD)
+		.sort((a, b) => b.createdAt - a.createdAt)[0];
+
+	// If the file genuinely has no real analysis yet, keep the reader job. It is the honest answer:
+	// the file statistics are the only thing there is to show.
+	return newestReal?.id ?? currentId;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
 	import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
 	import { treeStore, addTree, updateTaggedTree, resetTrees } from '../stores/tree';
 	import { syncDescriptorStoresForFile as syncDescriptorStores } from '../lib/utils/descriptorSync.js';
+	import { resolveSelectedAnalysis } from '../lib/utils/analysisSelection.js';
 	import { trackEvent } from '../lib/utils/analytics.js';
 	import Aioli from '@biowasm/aioli';
 	import TreeSelector from '../lib/TreeSelector.svelte';
@@ -52,7 +53,6 @@
 	let cliObj;
 	let result;
 	let fileMetricsJSON;
-	let selectedAnalysisId = null;
 	let showAllHistory = false;
 	let activeTab = 'data'; // 'data', 'analyze', or 'results'
 	let selectedTree = 'nj';
@@ -196,9 +196,25 @@
 		}
 	};
 
+	// WHICH ANALYSIS THE DETAIL PANE SHOWS.
+	//
+	// This is derived from the store, not held locally. There used to be a second copy —
+	// `let selectedAnalysisId = null` — that only `selectAnalysis()` ever wrote, while the history
+	// list highlighted `$analysisStore.currentAnalysisId`. Every path that creates an analysis
+	// WITHOUT going through `selectAnalysis` — which is every real run — left the two disagreeing:
+	// the new run was highlighted blue in the list while the pane beside it still showed the previous
+	// selection, on a fresh upload the invisible `datareader` job. The user clicked "View Results" on
+	// their MEME run and got a screen headed "DATAREADER Analysis". See issue #188.
+	//
+	// Deriving it means the pane follows every `createAnalysis()` by construction, and the two can no
+	// longer drift apart, because there is only one of them.
+	$: selectedAnalysisId = resolveSelectedAnalysis(
+		$analysisStore.currentAnalysisId,
+		$analysisStore.analyses
+	);
+
 	// Select an analysis to view
 	function selectAnalysis(analysisId) {
-		selectedAnalysisId = analysisId;
 		analysisStore.setCurrentAnalysis(analysisId);
 	}
 

--- a/src/test/analysis-selection.test.js
+++ b/src/test/analysis-selection.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for issue #188 — "View Results" opened the wrong analysis.
+ *
+ * The failure mode is a contradiction, not an exception: the history list highlights the new run
+ * while the detail pane beside it renders a different one, usually the invisible `datareader` job
+ * from the upload. Nothing throws, nothing is logged, and the screen is internally inconsistent at
+ * the exact moment the product exists for. Only a test catches a reintroduction.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveSelectedAnalysis } from '../lib/utils/analysisSelection.js';
+
+const reader = (id, fileId, createdAt) => ({
+	id,
+	fileId,
+	method: 'datareader',
+	createdAt
+});
+const run = (id, fileId, method, createdAt) => ({ id, fileId, method, createdAt });
+
+describe('#188 the detail pane resolves to a real analysis', () => {
+	it('passes a normal selection straight through', () => {
+		const analyses = [run('a1', 'f1', 'meme', 200)];
+		expect(resolveSelectedAnalysis('a1', analyses)).toBe('a1');
+	});
+
+	it('redirects away from the invisible datareader job to the newest real run', () => {
+		// The bug in one line. On a fresh upload the current selection is the reader job, which is
+		// filtered out of the history list — so the user sees "DATAREADER Analysis" with file
+		// statistics, beside their own MEME card highlighted blue, and no card to click to escape.
+		const analyses = [reader('r1', 'f1', 100), run('a1', 'f1', 'meme', 200)];
+		expect(resolveSelectedAnalysis('r1', analyses)).toBe('a1');
+	});
+
+	it('picks the most recent real analysis, not the first', () => {
+		const analyses = [
+			reader('r1', 'f1', 100),
+			run('old', 'f1', 'fel', 200),
+			run('new', 'f1', 'meme', 300)
+		];
+		expect(resolveSelectedAnalysis('r1', analyses)).toBe('new');
+	});
+
+	it('does not cross files when redirecting', () => {
+		// A different file's analysis is not an answer to "show me this file's results".
+		const analyses = [reader('r1', 'f1', 100), run('other', 'f2', 'meme', 500)];
+		expect(resolveSelectedAnalysis('r1', analyses)).toBe('r1');
+	});
+
+	it('keeps the reader job when the file genuinely has no real analysis yet', () => {
+		// Honest answer: file statistics are the only thing there is to show. Blanking the pane
+		// would be worse than showing the one record that exists.
+		const analyses = [reader('r1', 'f1', 100)];
+		expect(resolveSelectedAnalysis('r1', analyses)).toBe('r1');
+	});
+
+	it('returns null when nothing is selected', () => {
+		expect(resolveSelectedAnalysis(null, [run('a1', 'f1', 'meme', 1)])).toBeNull();
+		expect(resolveSelectedAnalysis(undefined, [])).toBeNull();
+	});
+
+	it('passes an unknown id through rather than blanking the pane', () => {
+		// The record may not have loaded yet. Nulling here would produce a flicker to an empty pane
+		// on every fresh selection, trading one bug for another.
+		expect(resolveSelectedAnalysis('not-loaded-yet', [])).toBe('not-loaded-yet');
+	});
+
+	it('tolerates a missing analyses array', () => {
+		expect(() => resolveSelectedAnalysis('a1', undefined)).not.toThrow();
+		expect(resolveSelectedAnalysis('a1', undefined)).toBe('a1');
+	});
+});


### PR DESCRIPTION
Closes #188.

Clicking "View Results" on a finished MEME run opened the Results tab with the detail pane still showing whatever was selected before — on a fresh upload, the invisible `datareader` job. The user got a screen headed "DATAREADER Analysis" showing file statistics, while beside it their own MEME card sat highlighted blue in the history list.

A directly self-contradictory screen at the exact moment the product exists for, and nothing anywhere reported a problem. The project's own spec documents the workaround: `e2e/19-axomeme.spec.js:130-137` notes that selecting the run explicitly is required.

## Cause

Two copies of one piece of state. `selectedAnalysisId` was a local that only `selectAnalysis()` wrote; the list highlight read `$analysisStore.currentAnalysisId`. Every path that creates an analysis without going through `selectAnalysis` — which is every real run — left the two disagreeing.

## Change

- Derive `selectedAnalysisId` from the store. The pane follows every `createAnalysis()` by construction, and the two cannot drift apart because there is only one of them.
- Redirect away from the reader job: it is filtered out of the history list on purpose, so selecting it leaves the user with no card to click to escape. Prefer the newest real analysis for the same file — but never cross files, and keep the reader job when the file genuinely has no real analysis yet, since file statistics are then the honest answer.
- Extracted to `src/lib/utils/analysisSelection.js` so it can be tested. As a local function in `+page.svelte` it had no seam, the same problem that left #168 untestable.

## Verification

8 tests, verified to fail with the redirect removed:

```
REVERT: pass-through only
  × redirects away from the invisible datareader job to the newest real run
  × picks the most recent real analysis, not the first
  Tests  2 failed | 6 passed (8)
```

Full suite 540 passed / 29 files, build clean.

Note: touches `+page.svelte` near #193's change to `handleNavigateToResults`, so whichever merges second may need a trivial rebase.
