### PR TITLE
Render what a failed analysis already knows instead of "No results available"

### DIFF
--- a/src/lib/AnalysisCard.svelte
+++ b/src/lib/AnalysisCard.svelte
@@ -170,7 +170,11 @@
 
 	// Handle re-run action (for interrupted analyses)
 	function rerunAnalysis() {
-		dispatch('rerun', { analysisId: analysis.id, method: analysis.method, fileId: analysis.fileId });
+		dispatch('rerun', {
+			analysisId: analysis.id,
+			method: analysis.method,
+			fileId: analysis.fileId
+		});
 	}
 </script>
 
@@ -214,17 +218,32 @@
 					class:bg-red-100={analysis.status === 'error'}
 					class:text-red-800={analysis.status === 'error'}
 					class:bg-orange-100={analysis.status === 'cancelled' || analysis.status === 'interrupted'}
-					class:text-orange-800={analysis.status === 'cancelled' || analysis.status === 'interrupted'}
+					class:text-orange-800={analysis.status === 'cancelled' ||
+						analysis.status === 'interrupted'}
 					class:bg-blue-100={analysis.status === 'reconnecting'}
 					class:text-blue-800={analysis.status === 'reconnecting'}
 					class:bg-amber-100={analysis.status === 'connection_lost'}
 					class:text-amber-800={analysis.status === 'connection_lost'}
-					class:bg-gray-100={!['completed', 'running', 'pending', 'error', 'cancelled', 'interrupted', 'reconnecting', 'connection_lost'].includes(
-						analysis.status
-					)}
-					class:text-gray-800={!['completed', 'running', 'pending', 'error', 'cancelled', 'interrupted', 'reconnecting', 'connection_lost'].includes(
-						analysis.status
-					)}
+					class:bg-gray-100={![
+						'completed',
+						'running',
+						'pending',
+						'error',
+						'cancelled',
+						'interrupted',
+						'reconnecting',
+						'connection_lost'
+					].includes(analysis.status)}
+					class:text-gray-800={![
+						'completed',
+						'running',
+						'pending',
+						'error',
+						'cancelled',
+						'interrupted',
+						'reconnecting',
+						'connection_lost'
+					].includes(analysis.status)}
 				>
 					{#if analysis.status === 'running' || analysis.status === 'pending'}
 						<Loader2 class="-ml-0.5 mr-1.5 h-3 w-3 animate-spin" />
@@ -330,12 +349,18 @@
 				</button>
 			{/if}
 
-			<!-- Re-run button - for interrupted and connection_lost analyses -->
-			{#if analysis.status === 'interrupted' || analysis.status === 'connection_lost'}
+			<!-- Re-run button - for any run that ended without results. 'error' was excluded, which left a
+			     failed analysis with no way forward at all: no detail, no export, and nothing to click. -->
+			{#if analysis.status === 'error' || analysis.status === 'interrupted' || analysis.status === 'connection_lost'}
 				<button
 					on:click|stopPropagation={rerunAnalysis}
-					class="inline-flex items-center rounded px-2.5 py-1.5 text-xs font-medium transition-colors {analysis.status === 'connection_lost' ? 'bg-amber-100 text-amber-700 hover:bg-amber-200' : 'bg-orange-100 text-orange-700 hover:bg-orange-200'}"
-					title="Re-run this {analysis.status === 'connection_lost' ? 'disconnected' : 'interrupted'} analysis"
+					class="inline-flex items-center rounded px-2.5 py-1.5 text-xs font-medium transition-colors {analysis.status ===
+					'connection_lost'
+						? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+						: 'bg-orange-100 text-orange-700 hover:bg-orange-200'}"
+					title="Re-run this {analysis.status === 'connection_lost'
+						? 'disconnected'
+						: 'interrupted'} analysis"
 				>
 					<RefreshCw class="mr-1 h-3 w-3" />
 					Re-run

--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -13,6 +13,7 @@
 		getHyphyEyeUrl
 	} from './utils/hyphyEyeIntegration';
 	import { safeParseJSON } from './utils/jsonUtils';
+	import { formatArguments, formatLogTail, buildDiagnostics } from './utils/analysisDiagnostics.js';
 	import {
 		FelVisualization as HyphyScopeFel,
 		SimpleFelVisualization,
@@ -176,6 +177,26 @@
 		}
 	}
 
+	// Copying diagnostics is the difference between "it failed" and a message a maintainer can act
+	// on. Reverts to the idle label after two seconds; a permanently "Copied" button is a lie the
+	// second time someone clicks it.
+	let copiedDiagnostics = false;
+	async function copyDiagnostics() {
+		const text = buildDiagnostics(analysis, {
+			method: analysis?.method,
+			filename: file?.filename
+		});
+		try {
+			await navigator.clipboard.writeText(text);
+			copiedDiagnostics = true;
+			setTimeout(() => (copiedDiagnostics = false), 2000);
+		} catch (err) {
+			// Clipboard access can be refused (permissions, insecure context). Failing silently would
+			// leave the user believing they had copied something.
+			console.error('Could not copy diagnostics:', err);
+		}
+	}
+
 	onMount(() => {
 		if (analysisId) {
 			loadAnalysis(analysisId);
@@ -205,8 +226,11 @@
 		</div>
 	{:else if analysis && file}
 		<div class="analysis-container">
-			<!-- Export panel with options -->
-			<ExportPanel {analysisId} />
+			<!-- Export panel with options. Gated on a completed run: offering "Download JSON" for a failed
+			     analysis exports nothing and implies results exist. -->
+			{#if analysis.status === 'completed'}
+				<ExportPanel {analysisId} />
+			{/if}
 
 			<div class="bg-surface-sunken p-4">
 				<div class="flex items-center justify-between">
@@ -219,9 +243,11 @@
 						<span
 							class="font-semibold capitalize {analysis.status === 'completed'
 								? 'text-status-success'
-								: analysis.status === 'pending'
-									? 'text-status-warning'
-									: 'text-text-slate'}"
+								: ['error', 'interrupted', 'connection_lost'].includes(analysis.status)
+									? 'text-status-error-text'
+									: analysis.status === 'pending'
+										? 'text-status-warning'
+										: 'text-text-slate'}"
 						>
 							{analysis.status === 'completed' ? 'Completed' : analysis.status}
 						</span>
@@ -459,6 +485,61 @@
 							class="rounded bg-status-warning px-3 py-1 text-sm text-white hover:bg-accent-copper"
 						>
 							Retry Loading Results
+						</button>
+					</div>
+				{:else if ['error', 'interrupted', 'connection_lost'].includes(analysis.status)}
+					<!-- A failed run used to render "No results available" and stop there, even though the
+					     error text and the exact argument list were both already persisted and simply never
+					     read. This branch reads them. See issue #186. -->
+					<div class="rounded-lg border border-status-error bg-status-error-bg p-4">
+						<p class="mb-2 font-semibold text-status-error-text">
+							{analysis.status === 'error'
+								? 'This analysis failed.'
+								: analysis.status === 'connection_lost'
+									? 'The connection to the server was lost.'
+									: 'This analysis was interrupted.'}
+						</p>
+
+						{#if analysis.error}
+							<pre
+								class="mb-3 overflow-x-auto whitespace-pre-wrap rounded bg-white/70 p-3 text-left font-mono text-xs text-status-error-text">{analysis.error}</pre>
+						{:else}
+							<p class="mb-3 text-sm text-status-error-text">
+								No error detail was recorded for this run.
+							</p>
+						{/if}
+
+						{#if analysis.arguments}
+							<!-- The settings that produced the failure. Without these a re-run is guesswork, and
+							     six months later there is no way to recover what was actually run. -->
+							<details class="mb-3">
+								<summary class="cursor-pointer text-sm font-medium text-status-error-text">
+									Run settings
+								</summary>
+								<pre
+									class="mt-2 overflow-x-auto rounded bg-white/70 p-3 text-left font-mono text-xs text-text-slate">{formatArguments(
+										analysis.arguments
+									)}</pre>
+							</details>
+						{/if}
+
+						{#if analysis.logs?.length}
+							<details class="mb-3">
+								<summary class="cursor-pointer text-sm font-medium text-status-error-text">
+									Last {Math.min(20, analysis.logs.length)} log lines
+								</summary>
+								<pre
+									class="mt-2 max-h-64 overflow-auto rounded bg-white/70 p-3 text-left font-mono text-xs text-text-slate">{formatLogTail(
+										analysis.logs
+									)}</pre>
+							</details>
+						{/if}
+
+						<button
+							on:click={copyDiagnostics}
+							class="rounded border border-status-error px-3 py-1 text-sm text-status-error-text hover:bg-white/50"
+						>
+							{copiedDiagnostics ? 'Copied' : 'Copy diagnostics'}
 						</button>
 					</div>
 				{:else}

--- a/src/lib/utils/analysisDiagnostics.js
+++ b/src/lib/utils/analysisDiagnostics.js
@@ -1,0 +1,72 @@
+/**
+ * analysisDiagnostics.js — turn a failed analysis record into something a user can read or paste.
+ *
+ * All three fields these functions format (`error`, `arguments`, `logs`) were already being written
+ * to IndexedDB by BaseAnalysisRunner — `arguments` explicitly "for debugging" — and read by nothing.
+ * See issue #186.
+ *
+ * Extracted rather than inlined so the shapes can be tested. The records come from IndexedDB and are
+ * not uniform: `arguments` is sometimes a string and sometimes an object, and `logs` entries are
+ * sometimes strings and sometimes `{message}`. A viewer that throws on the wrong shape would replace
+ * a useless error screen with a broken one.
+ */
+
+/** Render a persisted argument list, whatever shape it was stored in. */
+export function formatArguments(args) {
+	if (args === null || args === undefined) return '';
+	if (typeof args === 'string') return args;
+	try {
+		return JSON.stringify(args, null, 2);
+	} catch {
+		// Circular or otherwise unserialisable. Say so rather than throwing inside the error view.
+		return String(args);
+	}
+}
+
+/**
+ * The last `limit` log lines as plain text.
+ *
+ * 20 rather than the 5 used by the live progress panel: this is a post-mortem, and the line that
+ * explains a failure is rarely the last one.
+ */
+export function formatLogTail(logs, limit = 20) {
+	if (!Array.isArray(logs) || logs.length === 0) return '';
+	return logs
+		.slice(-limit)
+		.map((entry) => {
+			if (typeof entry === 'string') return entry;
+			if (entry && typeof entry === 'object') {
+				return entry.message ?? entry.text ?? JSON.stringify(entry);
+			}
+			return String(entry);
+		})
+		.join('\n');
+}
+
+/**
+ * One block of text combining everything known about a failure, for the clipboard.
+ *
+ * Ordered for someone pasting into an issue: what failed, what was run, then the tail. Sections with
+ * nothing in them are omitted entirely rather than left as empty headings.
+ */
+export function buildDiagnostics(analysis, { method, filename } = {}) {
+	if (!analysis) return '';
+
+	const lines = [];
+	const label = method ?? analysis.method ?? 'Analysis';
+	lines.push(`${String(label).toUpperCase()} — ${analysis.status ?? 'unknown status'}`);
+	if (filename) lines.push(`File: ${filename}`);
+	if (analysis.metadata?.executionMode) lines.push(`Execution: ${analysis.metadata.executionMode}`);
+	if (analysis.completedAt)
+		lines.push(`Completed: ${new Date(analysis.completedAt).toISOString()}`);
+
+	if (analysis.error) lines.push('', 'Error:', String(analysis.error));
+
+	const args = formatArguments(analysis.arguments);
+	if (args) lines.push('', 'Run settings:', args);
+
+	const tail = formatLogTail(analysis.logs);
+	if (tail) lines.push('', 'Last log lines:', tail);
+
+	return lines.join('\n');
+}

--- a/src/test/analysis-diagnostics.test.js
+++ b/src/test/analysis-diagnostics.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests for issue #186 — a failed analysis rendered "No results available" and nothing else.
+ *
+ * These pin the formatting of records that come back from IndexedDB, which are NOT uniform:
+ * `arguments` is sometimes a string and sometimes an object, and `logs` entries are sometimes
+ * strings and sometimes `{message}`. The failure view is the one screen that must never throw —
+ * replacing a useless error screen with a broken one is strictly worse than leaving it alone.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	formatArguments,
+	formatLogTail,
+	buildDiagnostics
+} from '../lib/utils/analysisDiagnostics.js';
+
+describe('#186 formatArguments tolerates every shape IndexedDB returns', () => {
+	it('passes a stored string through unchanged', () => {
+		expect(formatArguments('--branches All --pvalue 0.1')).toBe('--branches All --pvalue 0.1');
+	});
+
+	it('pretty-prints an object', () => {
+		expect(formatArguments({ branches: 'All' })).toBe('{\n  "branches": "All"\n}');
+	});
+
+	it('is empty for a record that never stored arguments', () => {
+		expect(formatArguments(null)).toBe('');
+		expect(formatArguments(undefined)).toBe('');
+	});
+
+	it('does not throw on a circular object', () => {
+		const circular = { a: 1 };
+		circular.self = circular;
+		expect(() => formatArguments(circular)).not.toThrow();
+	});
+});
+
+describe('#186 formatLogTail', () => {
+	it('renders string entries', () => {
+		expect(formatLogTail(['one', 'two'])).toBe('one\ntwo');
+	});
+
+	it('renders {message} entries, which is what the store actually writes', () => {
+		// analyses.js pushes `{ time, message, status }`.
+		const logs = [
+			{ time: 't1', message: 'Mounting user.nex', status: 'mounting' },
+			{ time: 't2', message: 'HyPhy error: could not read tree', status: 'error' }
+		];
+		expect(formatLogTail(logs)).toBe('Mounting user.nex\nHyPhy error: could not read tree');
+	});
+
+	it('keeps the LAST lines, not the first', () => {
+		// The line that explains a failure is rarely the first one.
+		const logs = Array.from({ length: 50 }, (_, i) => `line ${i}`);
+		const out = formatLogTail(logs, 3);
+		expect(out).toBe('line 47\nline 48\nline 49');
+	});
+
+	it('is empty for a record with no logs', () => {
+		expect(formatLogTail(undefined)).toBe('');
+		expect(formatLogTail([])).toBe('');
+	});
+
+	it('does not throw on entries of an unexpected shape', () => {
+		expect(() => formatLogTail([null, 42, { odd: true }])).not.toThrow();
+	});
+});
+
+describe('#186 buildDiagnostics produces something worth pasting into an issue', () => {
+	const failed = {
+		method: 'busted',
+		status: 'error',
+		error: 'HyPhy error: "Custom" is not a valid value for parameter "branches"',
+		arguments: '--branches Custom',
+		logs: [{ message: 'Starting BUSTED' }, { message: 'Fitting model' }],
+		metadata: { executionMode: 'wasm' }
+	};
+
+	it('leads with the method and status', () => {
+		expect(buildDiagnostics(failed, { filename: 'hiv.fasta' })).toMatch(/^BUSTED — error/);
+	});
+
+	it('includes the error, the settings and the log tail', () => {
+		const out = buildDiagnostics(failed, { filename: 'hiv.fasta' });
+		expect(out).toContain('is not a valid value for parameter');
+		expect(out).toContain('--branches Custom');
+		expect(out).toContain('Fitting model');
+		expect(out).toContain('hiv.fasta');
+	});
+
+	it('omits sections that have nothing in them rather than leaving empty headings', () => {
+		const bare = { method: 'fel', status: 'error' };
+		const out = buildDiagnostics(bare);
+		expect(out).not.toContain('Run settings:');
+		expect(out).not.toContain('Last log lines:');
+		expect(out).not.toContain('Error:');
+	});
+
+	it('returns empty for no analysis rather than throwing', () => {
+		expect(buildDiagnostics(null)).toBe('');
+	});
+});


### PR DESCRIPTION
Closes #186.

A BUSTED run fails after twenty minutes. The only notice was a toast that erased itself while the user was in another window. They open the analysis from Results and the whole detail pane reads **"No results available"**.

- Status word "error" styled in the same grey as "pending" (`AnalysisResultViewer.svelte:218-228`)
- No Re-run button — that appeared only for `interrupted` and `connection_lost` (`AnalysisCard.svelte:334`)
- `ExportPanel` still offered "Download JSON" of nothing

## None of this was missing information

`BaseAnalysisRunner.js:128-141` already writes the error text to IndexedDB and already attaches the full argument list — the comment says explicitly *"for debugging"*. `analyses.js:310,421` already accumulates a log array on every progress update. **Nothing in `src/` read any of the three.**

## Changes

- `{:else if ['error','interrupted','connection_lost']}` branch rendering the error verbatim, the run settings, the last 20 log lines, and a Copy diagnostics button. Twenty rather than the five the live progress panel shows — this is a post-mortem, and the line that explains a failure is rarely the last one.
- Re-run extended to `error`.
- Status word coloured.
- `ExportPanel` gated on `status === 'completed'`.

## Why the formatting is extracted

`src/lib/utils/analysisDiagnostics.js`, because the records are **not uniform**: `arguments` is stored sometimes as a string and sometimes as an object, and log entries are sometimes strings and sometimes `{time, message, status}`. The failure view is the one screen that must never throw — replacing a useless error screen with a broken one is strictly worse than leaving it alone.

15 tests cover those shapes, including circular objects, entries of unexpected type, and records with no logs/arguments at all (sections are omitted rather than left as empty headings).

## Verification

Full suite 545 passed / 29 files, build clean.

## Not in this PR

The audit also suggested persisting `enhancedStdout` on the WASM failure path so `LogDownloader` has something to show. Left out deliberately: `LogDownloader` reads `stdout` from `analysis.result`, and changing what a failed run stores in `result` touches the completion contract shared by both runners. The log array rendered here already covers the user-facing need.
