### PR TITLE
Stop the app describing the previous file while a new one is being read

### DIFF
--- a/src/lib/FileIndicator.svelte
+++ b/src/lib/FileIndicator.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { currentFile } from '../stores/fileInfo';
 	import { fileMetricsStore } from '../stores/fileInfo';
-	import { Dna, Users, Grid3X3, HardDrive, CheckCircle2 } from 'lucide-svelte';
+	import { Dna, Users, Grid3X3, HardDrive, CheckCircle2, AlertTriangle } from 'lucide-svelte';
 
 	// Format file size in a human-readable way
 	function formatFileSize(bytes) {
@@ -11,12 +11,18 @@
 		return `${(bytes / Math.pow(1024, i)).toFixed(i > 0 ? 1 : 0)}${units[i]}`;
 	}
 
-	// Determine which property to use for the filename
-	$: filename = $currentFile?.filename || $currentFile?.name || 'CD2-slim.fna';
+	// Determine which property to use for the filename.
+	//
+	// The old fallback here was the literal string 'CD2-slim.fna' -- a demo filename, shown for
+	// whatever file the user had actually chosen. Same for the 10 / 17 / 800 fallbacks below. A
+	// plausible-looking wrong number is worse than a blank, because nothing prompts the user to
+	// doubt it. Issue #189.
+	$: filename = $currentFile?.filename || $currentFile?.name || 'Untitled';
 
-	// For debugging
-	$: console.log('Current File:', $currentFile);
-	$: console.log('File Metrics:', $fileMetricsStore);
+	// Whether the current file actually passed validation. The component had NO validity input at
+	// all and emitted "Valid for analysis" unconditionally -- including above a file whose read had
+	// just failed, and above the previous file's sequence and site counts.
+	$: fileFailedValidation = Boolean($fileMetricsStore?.error && !$fileMetricsStore?.FILE_INFO);
 </script>
 
 {#if $currentFile}
@@ -51,18 +57,27 @@
 						{/if}
 						<span class="flex items-center" title="File Size">
 							<HardDrive class="mr-1 h-4 w-4 text-text-slate" />
-							<span class="text-text-rich">{formatFileSize($currentFile.size || 800)}</span>
+							<span class="text-text-rich">{formatFileSize($currentFile.size)}</span>
 						</span>
 					</div>
 				</div>
 			</div>
 			<div>
-				<div
-					class="flex items-center rounded-premium-sm bg-white px-premium-sm py-premium-xs text-premium-caption font-medium text-accent-copper"
-				>
-					<CheckCircle2 class="mr-1 h-4 w-4" />
-					Valid for analysis
-				</div>
+				{#if fileFailedValidation}
+					<div
+						class="flex items-center rounded-premium-sm bg-white px-premium-sm py-premium-xs text-premium-caption font-medium text-status-warning-text"
+					>
+						<AlertTriangle class="mr-1 h-4 w-4" />
+						Not validated — see the errors on the Data tab
+					</div>
+				{:else}
+					<div
+						class="flex items-center rounded-premium-sm bg-white px-premium-sm py-premium-xs text-premium-caption font-medium text-accent-copper"
+					>
+						<CheckCircle2 class="mr-1 h-4 w-4" />
+						Valid for analysis
+					</div>
+				{/if}
 			</div>
 		</div>
 	</div>

--- a/src/lib/SmartTabNavigation.svelte
+++ b/src/lib/SmartTabNavigation.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { persistentFileStore, currentFile } from '../stores/fileInfo';
+	import { persistentFileStore, currentFile, fileMetricsStore } from '../stores/fileInfo';
 	import { analysisStore } from '../stores/analyses';
 
 	export let activeTab = 'data';
@@ -29,8 +29,16 @@
 	// Show badge only if there are unviewed completions and not currently on Results tab
 	$: showResultsBadge = activeTab !== 'results' && unviewedCompletedCount > 0;
 
-	// Logic to determine if a tab should be disabled
-	$: isAnalyzeDisabled = !hasFiles;
+	// Logic to determine if a tab should be disabled.
+	//
+	// `hasFiles` alone was not enough: a file whose read FAILED still counts as a file, so Analyze
+	// unlocked for an alignment the app could not parse. Pressing Run then produced "No uploaded tree
+	// file available", naming a tree source the user cannot select, when the alignment was the actual
+	// problem. Issue #189.
+	$: currentFileFailedValidation = Boolean(
+		$fileMetricsStore?.error && !$fileMetricsStore?.FILE_INFO
+	);
+	$: isAnalyzeDisabled = !hasFiles || currentFileFailedValidation;
 	$: isResultsDisabled = !hasAnalyses;
 
 	// Function to handle tab clicks with context-aware behavior

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -623,6 +623,17 @@
 			trees = {};
 			treeData = resetTrees();
 
+			// Clear the descriptor stores too, for the same reason and at the same moment.
+			//
+			// Reading a 4 MB alignment takes 10-60 seconds, and for all of it the page kept rendering
+			// the PREVIOUS file: its metrics, its alignment viewer, its tree, and a green "Data ready
+			// for analysis" button. If the new file then failed validation, that stale description sat
+			// next to the red error, and Analyze happily offered to run on it. The delete path already
+			// models this correctly (FileManager.svelte:245-250); the upload path did not. Issue #189.
+			fileMetricsJSON = undefined;
+			fileMetricsStore.set(null);
+			alignmentFileStore.set(null);
+
 			// Check if this is a file selection event (from FileManager)
 			if (event.isSelection) {
 				console.log('File selected from FileManager:', event.fileId);


### PR DESCRIPTION
Closes #189.

Pick a 4 MB alignment. For the next 10–60 seconds the page looks identical — same metrics, same alignment viewer, same tree, same green "Data ready for analysis" button — **all describing the previous file**.

If the new file then fails validation, that stale description stays on screen next to the red error, Analyze stays unlocked, and the Analyze panel shows a green check-marked "Currently Analyzing: \<broken file\>" with the badge "Valid for analysis" above the previous file's real sequence and site counts. Pressing Run produces *"No uploaded tree file available"* — naming a tree source the user cannot even select — when the alignment was the actual problem.

## Three gates

**1. Clear the descriptor stores on upload.** `fileMetricsStore` and `alignmentFileStore` are now cleared at the top of `handleFileUpload`, alongside the `resetTrees()` that was already there for exactly this reason. The delete path already modelled this correctly (`FileManager.svelte:245-250`); the upload path did not.

**2. Lock Analyze on a failed read.** `hasFiles` alone was never sufficient — a file whose read failed still counts as a file. Now also requires that the current file does not have `error && !FILE_INFO`.

**3. Give `FileIndicator` a validity input.** It had **none**, and emitted "Valid for analysis" unconditionally. It now shows an amber "Not validated — see the errors on the Data tab" instead.

The hardcoded fallbacks are also gone. The filename fell back to the literal demo name `'CD2-slim.fna'`, and the counts to `10` sequences / `17` sites / `800` bytes — shown for whatever file the user had actually chosen. A plausible-looking wrong number is worse than a blank, because nothing prompts the user to doubt it.

## Verification

Unit suite 532 passed, build clean. Upload-path e2e on chromium — `02-file-upload`, `03-demo-files`, `04-invalid-files`, `05-tab-navigation` — **16 passed**, including `uploading broken file does not show sequence info` and `uploading valid file still works after error`, which are the two that would catch this going wrong.

## Not in this PR

Gate 1 from the audit — a real in-progress state in `DataTab` that renders the running datareader's stage messages in place of the metrics region — is deliberately left out. Every component that renders progress currently filters `datareader` out (`AnalysisStatusIndicator.svelte:39,45,59,68`; `ResultsTab.svelte:23`; `SmartTabNavigation.svelte:23-27`), so surfacing it is a larger change than the three gates here and deserves its own review. Clearing the stale state already removes the wrong-file problem; what remains is a blank region rather than a misleading one.
