### PR TITLE
Show a run where it was started, and stop the button creating duplicates

### DIFF
--- a/e2e/20-run-strip.spec.js
+++ b/e2e/20-run-strip.spec.js
@@ -1,0 +1,81 @@
+/**
+ * E2E for the run strip (issue #200).
+ *
+ * AxoMEME is the vehicle purely because it is the fastest run in the product — a few seconds rather
+ * than minutes — so this exercises the generic strip without a slow model fit. Nothing here is
+ * AxoMEME-specific.
+ *
+ * The "View results" assertion exists because that link shipped broken in review: it called
+ * setCurrentAnalysis and never switched tabs, so clicking it did nothing visible. A test that only
+ * checked the button rendered would have passed.
+ */
+import { test, expect } from './fixtures/coverage.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	selectMethod,
+	clickRunAnalysis
+} from './fixtures/helpers.js';
+
+test.describe('Run strip', () => {
+	test.setTimeout(180000);
+
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+		await selectMethod(page, 'AxoMEME');
+	});
+
+	test('a row appears under the Run button and survives the run finishing', async ({ page }) => {
+		expect(await clickRunAnalysis(page), 'run button was not clickable').toBe(true);
+
+		// The row is the point: status where the run was started, without navigating anywhere.
+		const row = page.locator('[data-testid="run-row"]').first();
+		await expect(row).toBeVisible({ timeout: 60000 });
+
+		await expect(page.getByText(/AXOMEME analysis complete/i)).toBeVisible({ timeout: 120000 });
+
+		// It does NOT self-hide. This is the whole reason it is not AnalysisProgress, which disappears
+		// five seconds after completion — exactly wrong for someone who was on another tab.
+		await page.waitForTimeout(8000);
+		await expect(row, 'the row vanished on a timer').toBeVisible();
+		await expect(row).toContainText(/finished in/i);
+	});
+
+	test('View results opens that analysis, not whatever was selected before', async ({ page }) => {
+		expect(await clickRunAnalysis(page), 'run button was not clickable').toBe(true);
+		await expect(page.getByText(/AXOMEME analysis complete/i)).toBeVisible({ timeout: 120000 });
+
+		const view = page.locator('[data-testid="run-row-view-results"]').first();
+		await expect(view).toBeVisible({ timeout: 30000 });
+		await view.click();
+
+		// Assert on something that exists ONLY on the Results tab. An earlier version of this test
+		// checked the page body for /AXOMEME/, which is trivially satisfied on the Analyze tab by the
+		// method selector and the run row itself -- it passed with the navigation removed, which makes
+		// it worse than no test. The viewer is the tab's own element.
+		const viewer = page.locator('[data-testid="analysis-viewer"]');
+		await expect(viewer, 'View results did not open the Results tab').toBeVisible({
+			timeout: 30000
+		});
+
+		// And it must be THIS analysis. On a fresh upload the prior selection is the invisible
+		// datareader job, so landing there would render "DATAREADER Analysis".
+		await expect(viewer).toContainText(/AXOMEME/i, { timeout: 30000 });
+		await expect(viewer, 'landed on the file-reader job').not.toContainText(/DATAREADER/i);
+	});
+
+	test('the Run button is blocked while a local run is in flight', async ({ page }) => {
+		expect(await clickRunAnalysis(page), 'run button was not clickable').toBe(true);
+
+		// Local runs share one Aioli instance and a fixed user.nex, so a second concurrent local run
+		// corrupts both. The button used to re-enable on a bare 2s timer regardless of state.
+		const runBtn = page.locator('[data-testid="run-analysis-btn"]');
+		await expect(runBtn).toBeDisabled({ timeout: 10000 });
+	});
+});

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -6,6 +6,9 @@
 	import { treeStore } from '../stores/tree';
 	import BranchSelector from './BranchSelector.svelte';
 	import RunOutlook from './RunOutlook.svelte';
+	import RunStrip from './RunStrip.svelte';
+	import { analysisStore } from '../stores/analyses';
+	import { currentFile } from '../stores/fileInfo';
 	import { treeHasBranchLengths } from './services/prescreen/scope.js';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
@@ -149,6 +152,36 @@
 	let geneticCodeId = 0; // For matching HyPhy numeric codes
 	let executionMode = 'local'; // 'local' or 'backend'
 	let isSubmitting = false; // Track submission state for button feedback
+
+	// WHY THE RUN BUTTON IS BLOCKED, derived from the analysis store rather than a timer.
+	//
+	// The button used to re-enable on setTimeout(..., 2000) regardless of state, which is what let an
+	// impatient second click create a duplicate analysis. The rule below is decided by the code, not
+	// by taste:
+	//
+	//   - Same method already in flight for this file -> block. It is the same run.
+	//   - ANY local run in flight, while this one would also run locally -> block. executeWasmAnalysis
+	//     mounts a fixed user.nex into one shared Aioli instance and reads
+	//     /shared/data/user.nex.{METHOD}.json, so two concurrent local runs corrupt each other and
+	//     produce silently wrong results. A warning would be wrong here: clicking through it is
+	//     exactly the case that must not happen.
+	//   - A server run while another server run is in flight -> allowed. Distinct jobIds; running FEL
+	//     and MEME together is routine.
+	$: liveRuns = ($analysisStore.analyses ?? []).filter(
+		(a) =>
+			a.method !== 'datareader' &&
+			!['completed', 'error', 'cancelled', 'interrupted', 'connection_lost'].includes(a.status)
+	);
+	$: sameMethodRunning = liveRuns.some(
+		(a) => a.method?.toLowerCase() === selectedMethod?.toLowerCase()
+	);
+	$: localRunInFlight = liveRuns.some((a) => a.metadata?.executionMode !== 'backend');
+	$: wouldRunLocally = executionMode !== 'backend';
+	$: runBlockedReason = sameMethodRunning
+		? `${selectedMethod?.toUpperCase()} is already running on this file`
+		: localRunInFlight && wouldRunLocally
+			? 'Another analysis is running in this tab — only one can run here at a time'
+			: null;
 
 	// Genetic code mapping (HyPhy uses numeric IDs)
 	const GENETIC_CODES = [
@@ -1210,11 +1243,12 @@
 			);
 			runMethod(selectedMethod, analysisConfig);
 
-			// Reset button state after parent has had time to start the analysis
-			// This provides immediate feedback that the click was registered
-			setTimeout(() => {
-				isSubmitting = false;
-			}, 2000);
+			// The button used to re-enable on a bare 2-second timer, regardless of whether anything
+			// had started. That timer WAS the duplicate-run bug: the impatient second click was
+			// accepted and created a second analysis, and in local mode both runs mount the same
+			// user.nex into one shared Aioli instance and read the same output path, so they corrupt
+			// each other silently. Release on the submission settling instead.
+			isSubmitting = false;
 		}
 	}
 
@@ -1642,13 +1676,18 @@
 				disabled={!selectedMethod ||
 					!currentMethod?.info.supported ||
 					isSubmitting ||
+					Boolean(runBlockedReason) ||
 					!relaxBranchesValid ||
 					!contrastFelBranchesValid}
+				title={runBlockedReason ?? ''}
 				data-testid="run-analysis-btn"
 			>
 				{#if isSubmitting}
 					<Loader2 class="run-icon spinning" />
 					Starting Analysis...
+				{:else if runBlockedReason}
+					<Loader2 class="run-icon spinning" />
+					{sameMethodRunning ? `${currentMethod?.info.name ?? ''} running` : 'Analysis running'}
 				{:else if currentMethod?.info.supported}
 					<Play class="run-icon" />
 					Run {currentMethod?.info.name || ''} Analysis
@@ -1656,6 +1695,11 @@
 					Coming Soon
 				{/if}
 			</button>
+
+			<!-- Status belongs beside the button that created it. Below the button, never above: at the
+			     top of the tab it would shift the button 44px down at the instant the pointer is
+			     travelling toward it. -->
+			<RunStrip fileId={$currentFile?.id ?? null} />
 		</div>
 	{/if}
 

--- a/src/lib/RunStrip.svelte
+++ b/src/lib/RunStrip.svelte
@@ -82,6 +82,19 @@
 			})
 		}));
 
+	/**
+	 * Open a finished run.
+	 *
+	 * Both halves are required. Selecting without navigating leaves the user on Analyze with nothing
+	 * visibly changed -- the link appears dead. Navigating without selecting lands them on Results
+	 * showing whatever was selected before, which on a fresh upload is the invisible datareader job.
+	 * The event carries the id so the route can do the selection on its side too.
+	 */
+	function viewResults(id) {
+		analysisStore.setCurrentAnalysis(id);
+		window.dispatchEvent(new CustomEvent('navigate-to-results', { detail: { analysisId: id } }));
+	}
+
 	function dismiss(id) {
 		dismissed = new Set([...dismissed, id]);
 	}
@@ -105,7 +118,11 @@
 				<span class="spacer"></span>
 
 				{#if row.status === 'completed'}
-					<button class="run-action" on:click={() => analysisStore.setCurrentAnalysis(row.id)}>
+					<button
+						class="run-action"
+						data-testid="run-row-view-results"
+						on:click={() => viewResults(row.id)}
+					>
 						View results
 					</button>
 				{/if}

--- a/src/lib/RunStrip.svelte
+++ b/src/lib/RunStrip.svelte
@@ -1,0 +1,216 @@
+<!--
+  RunStrip — one row per run, directly beneath the Run button.
+
+  WHY A NEW COMPONENT rather than a second mount of AnalysisProgress.svelte, which the original
+  proposal suggested. Four reasons, each independently sufficient:
+
+    - AnalysisProgress hides itself 5 s after completion (:151-157). Five seconds is calibrated for
+      a user who is watching. This row exists for the user who was NOT.
+    - It falls back to $activeAnalysisProgress, i.e. activeAnalyses[0] (analyses.js:835-848) — an
+      arbitrary choice the moment two jobs exist.
+    - It renders a five-line log tail through `marked`, which does not belong under a button.
+    - It draws a sliding bar, which reads as motion toward completion.
+
+  Threading a suppressAutoHide prop through all of that is more code than this file.
+
+  PLACEMENT is below the button, never above: at the top of the tab it would shift the button 44 px
+  down at the instant the pointer is travelling toward it. RunOutlook.svelte:96-102 documents the
+  same concern at length.
+
+  NO PROGRESS BAR, determinate or indeterminate. WasmAnalysisRunner emits 10/20/40/80/95 and the
+  40→80 step spans the entire computation, so a bar would be a fiction. AnalysisProgress already
+  refuses to draw one; that refusal is preserved here.
+
+  NO STOP BUTTON ON LOCAL RUNS. WasmAnalysisRunner has no cancelAnalysis override — cancelling marks
+  the record and the WASM keeps running, then writes 'completed' over it. Offering a control that
+  does not do what it says is worse than offering none. Server runs can genuinely be stopped, but
+  that affordance is deliberately left to a follow-up rather than added here.
+
+  See design/03-run-feedback/.
+-->
+<script>
+	import { onDestroy } from 'svelte';
+	import { analysisStore } from '../stores/analyses';
+	import { runStatusLine, isTerminal } from './utils/runStatusLine.js';
+	import { X } from 'lucide-svelte';
+
+	/** Only show runs for the file currently being worked on. */
+	export let fileId = null;
+
+	/** Rows the user has dismissed. Terminal rows persist until dismissed — they do not time out. */
+	let dismissed = new Set();
+
+	// 1 Hz. The clock is the only thing that moves in this component.
+	let now = Date.now();
+	const ticker = setInterval(() => (now = Date.now()), 1000);
+	onDestroy(() => clearInterval(ticker));
+
+	function startedAt(analysis) {
+		const raw = analysis?.metadata?.startTime ?? analysis?.createdAt;
+		const ms = typeof raw === 'string' ? Date.parse(raw) : raw;
+		return Number.isFinite(ms) ? ms : null;
+	}
+
+	function elapsedSeconds(analysis) {
+		const start = startedAt(analysis);
+		if (!start) return 0;
+		const end = isTerminal(analysis.status) ? (analysis.completedAt ?? now) : now;
+		return Math.max(0, (end - start) / 1000);
+	}
+
+	// `datareader` is the invisible file-reader job; it is not a run the user started and has no
+	// place under the Run button.
+	$: rows = ($analysisStore.analyses ?? [])
+		.filter((a) => a.method !== 'datareader')
+		.filter((a) => !fileId || a.fileId === fileId)
+		.filter((a) => !dismissed.has(a.id))
+		.filter((a) => !isTerminal(a.status) || a.completedAt)
+		.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+		.slice(0, 4)
+		.map((a) => ({
+			id: a.id,
+			status: a.status,
+			line: runStatusLine({
+				method: a.method,
+				status: a.status,
+				executionMode: a.metadata?.executionMode,
+				elapsedSeconds: elapsedSeconds(a),
+				// Captured at submission by BaseAnalysisRunner.startAnalysisTracking. Absent for methods
+				// with no fitted equation, which runStatusLine handles by saying nothing.
+				estimateSeconds: a.metadata?.estimateSeconds,
+				error: a.error
+			})
+		}));
+
+	function dismiss(id) {
+		dismissed = new Set([...dismissed, id]);
+	}
+</script>
+
+{#if rows.length}
+	<div class="run-strip" data-testid="run-strip">
+		{#each rows as row (row.id)}
+			<div class="run-row" data-testid="run-row" data-status={row.status}>
+				<span class="dot dot-{row.line.tone}" aria-hidden="true"></span>
+
+				<span class="run-label">{row.line.label}</span>
+				<span class="sep">·</span>
+				<span class="run-detail">{row.line.detail}</span>
+
+				{#if row.line.clock}
+					<span class="sep">·</span>
+					<span class="run-clock" data-testid="run-clock">{row.line.clock}</span>
+				{/if}
+
+				<span class="spacer"></span>
+
+				{#if row.status === 'completed'}
+					<button class="run-action" on:click={() => analysisStore.setCurrentAnalysis(row.id)}>
+						View results
+					</button>
+				{/if}
+
+				<!-- Terminal rows are dismissed by hand, never on a timer: this row's whole purpose is to
+				     still be there for someone who was on another tab when the run ended. -->
+				{#if isTerminal(row.status)}
+					<button class="run-dismiss" on:click={() => dismiss(row.id)} aria-label="Dismiss">
+						<X size={14} />
+					</button>
+				{/if}
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.run-strip {
+		margin-top: 0.75rem;
+		border-top: 1px solid var(--color-border, #e5e7eb);
+	}
+
+	.run-row {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		/* 44 px: a touch target, and enough that two rows do not read as one block of text. */
+		min-height: 44px;
+		padding: 0 0.25rem;
+		font-size: 0.8125rem;
+		border-bottom: 1px solid var(--color-border, #e5e7eb);
+	}
+	.run-row:last-child {
+		border-bottom: none;
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		flex: none;
+	}
+	/* The only motion in the component. No sliding bar: there is no real progress to report. */
+	.dot-running {
+		background: #2563eb;
+		animation: pulse 2s ease-in-out infinite;
+	}
+	.dot-slow {
+		background: #b45309;
+		animation: pulse 2s ease-in-out infinite;
+	}
+	.dot-done {
+		background: #16a34a;
+	}
+	.dot-failed {
+		background: #b91c1c;
+	}
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.35;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.dot-running,
+		.dot-slow {
+			animation: none;
+		}
+	}
+
+	.run-label {
+		font-weight: 600;
+	}
+	.sep {
+		opacity: 0.4;
+	}
+	.run-detail {
+		color: #4b5563;
+	}
+	.run-clock {
+		/* Tabular figures so the row does not jitter once a second. */
+		font-variant-numeric: tabular-nums;
+		color: #4b5563;
+	}
+	.spacer {
+		flex: 1;
+	}
+
+	.run-action {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: #2563eb;
+		padding: 0.25rem 0.5rem;
+	}
+	.run-action:hover {
+		text-decoration: underline;
+	}
+	.run-dismiss {
+		color: #9ca3af;
+		padding: 0.25rem;
+	}
+	.run-dismiss:hover {
+		color: #4b5563;
+	}
+</style>

--- a/src/lib/services/BaseAnalysisRunner.js
+++ b/src/lib/services/BaseAnalysisRunner.js
@@ -7,14 +7,49 @@ import { analysisStore } from '../../stores/analyses.js';
 import { toastStore } from '../../stores/toast.js';
 import { get } from 'svelte/store';
 import { validateCodonAlignment, isJSParseableFormat } from '../utils/fastaValidation.js';
+import { fileMetricsStore } from '../../stores/fileInfo.js';
+import { calculateRuntimeEstimate } from '../utils/timingEstimates.js';
 
 /**
  * Methods that require codon-aligned input (sequence length divisible by 3, no premature stop codons).
  */
 const CODON_AWARE_METHODS = new Set([
-	'fel', 'slac', 'fubar', 'meme', 'absrel', 'busted', 'relax',
-	'contrast-fel', 'bgm', 'prime', 'multi-hit', 'multihit', 'b-still', 'bstill'
+	'fel',
+	'slac',
+	'fubar',
+	'meme',
+	'absrel',
+	'busted',
+	'relax',
+	'contrast-fel',
+	'bgm',
+	'prime',
+	'multi-hit',
+	'multihit',
+	'b-still',
+	'bstill'
 ]);
+
+/**
+ * Pre-run runtime estimate in seconds, or null when one cannot be made.
+ *
+ * Reads the alignment dimensions from `fileMetricsStore`, which datareader has already populated by
+ * the time any analysis can be started -- so this costs no parsing and no extra state.
+ */
+function estimateSecondsFor(method, executionMode) {
+	try {
+		const info = get(fileMetricsStore)?.FILE_INFO;
+		const sequences = info?.sequences;
+		const sites = info?.sites;
+		if (!sequences || !sites) return null;
+
+		const estimate = calculateRuntimeEstimate(method, sequences, sites, executionMode);
+		return estimate?.minutes ? Math.round(estimate.minutes * 60) : null;
+	} catch {
+		// An estimate is a nicety. Never let it break starting an analysis.
+		return null;
+	}
+}
 
 export class BaseAnalysisRunner {
 	constructor() {
@@ -51,13 +86,32 @@ export class BaseAnalysisRunner {
 	 * @param {object|null} args - Optional arguments preview
 	 * @param {string|null} jobId - Optional backend job ID (for reconnection support)
 	 */
-	startAnalysisTracking(analysisId, method, executionMode, message = null, args = null, jobId = null) {
+	startAnalysisTracking(
+		analysisId,
+		method,
+		executionMode,
+		message = null,
+		args = null,
+		jobId = null
+	) {
 		const defaultMessage = message || `Starting ${method} analysis...`;
 
 		const metadata = {
 			executionMode,
 			startTime: new Date().toISOString()
 		};
+
+		// Capture the pre-run estimate so the run row can tell an ordinary wait from a stuck one.
+		//
+		// It is stored as a NUMBER OF SECONDS and used only to decide when the row's sentence changes
+		// -- never displayed beside the elapsed clock. The fitted power law is R^2 ~ 0.63: good to a
+		// factor of two, not to the minute, so showing it as a countdown would be a promise the
+		// software cannot keep. Methods with no fitted equation simply get no key, and the row then
+		// reports elapsed time and says nothing else.
+		const estimateSeconds = estimateSecondsFor(method, executionMode);
+		if (estimateSeconds) {
+			metadata.estimateSeconds = estimateSeconds;
+		}
 
 		// Add arguments to metadata if provided
 		if (args) {
@@ -142,7 +196,11 @@ export class BaseAnalysisRunner {
 
 		// Use the ID-specific method to avoid race conditions and ensure correct analysis is updated
 		if (analysisId) {
-			await analysisStore.completeAnalysisProgressById(analysisId, success, message || defaultMessage);
+			await analysisStore.completeAnalysisProgressById(
+				analysisId,
+				success,
+				message || defaultMessage
+			);
 			// Remove from active analyses after completion
 			analysisStore.removeFromActiveAnalyses(analysisId);
 		} else {

--- a/src/lib/utils/runStatusLine.js
+++ b/src/lib/utils/runStatusLine.js
@@ -1,0 +1,167 @@
+/**
+ * runStatusLine.js — what a single run's row says, at every moment of its life.
+ *
+ * Extracted from the component because the rules are the design, and the design is precise about
+ * numbers that would otherwise drift: when a clock appears, when a run is called slow, and above all
+ * what is NEVER shown. See design/03-run-feedback/.
+ *
+ * THE RULE THIS FILE EXISTS TO ENFORCE: the pre-run estimate is never printed beside the elapsed
+ * clock. The fitted power law is R² ≈ 0.63 (timingEstimates.js:44-52) — good to a factor of two, not
+ * to the minute. "02:13 elapsed, typically ~4 min" reads as a countdown the software cannot honour,
+ * and a user who sees 4:30 against "~4 min" concludes something is wrong when nothing is. The
+ * estimate is used ONLY to decide when the sentence changes.
+ */
+
+/** Runs that have stopped. */
+const TERMINAL = new Set(['completed', 'error', 'cancelled', 'interrupted', 'connection_lost']);
+
+/** Below this, show no clock at all — a timer at 0:03 invites watching it, and many local runs
+ *  finish inside ten seconds. */
+const CLOCK_AFTER_SECONDS = 10;
+
+/** Multiple of the estimate at which a run stops being ordinary. At R² ≈ 0.63 a factor of two is
+ *  routine spread, so anything below this would cry wolf on healthy runs. */
+const LONGER_MULTIPLE = 2;
+
+/** Multiple at which a run is worth interrupting the user about — past where a power-law tail still
+ *  behaves like one. */
+const MUCH_LONGER_MULTIPLE = 6;
+
+/** Floor for the "much longer" state, so a 4-second FUBAR run does not raise a flag at 24 seconds. */
+const MUCH_LONGER_FLOOR_SECONDS = 30 * 60;
+
+/** m:ss, or h:mm:ss past an hour. */
+export function formatElapsed(totalSeconds) {
+	const s = Math.max(0, Math.floor(totalSeconds ?? 0));
+	const hours = Math.floor(s / 3600);
+	const minutes = Math.floor((s % 3600) / 60);
+	const seconds = s % 60;
+	const pad = (n) => String(n).padStart(2, '0');
+	return hours > 0 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${minutes}:${pad(seconds)}`;
+}
+
+/**
+ * Where the run is executing, in terms of what it means for the user.
+ *
+ * Deliberately not "Local" / "Server". A reload kills a local run (analyses.js:672-741) and does not
+ * kill a server one (:743-810) — "in this tab" carries that consequence, "Local" does not.
+ */
+export function locationLabel(executionMode) {
+	return executionMode === 'backend' ? 'on the server' : 'in this tab';
+}
+
+/**
+ * Build the row's parts.
+ *
+ * @param {object} run
+ * @param {string} run.method
+ * @param {string} run.status
+ * @param {string} [run.executionMode]
+ * @param {number} run.elapsedSeconds
+ * @param {number} [run.estimateSeconds] - omit when no fitted equation exists for the method
+ * @param {string} [run.error]
+ * @returns {{label: string, detail: string, tone: 'running'|'slow'|'done'|'failed', clock: string|null, showDetails: boolean}}
+ */
+export function runStatusLine({
+	method,
+	status,
+	executionMode,
+	elapsedSeconds = 0,
+	estimateSeconds,
+	error
+} = {}) {
+	const label = String(method ?? 'Analysis').toUpperCase();
+	const where = locationLabel(executionMode);
+	const clock = formatElapsed(elapsedSeconds);
+
+	if (status === 'completed') {
+		// Elapsed as a fact. Not compared to the estimate: "finished in 3:41 (estimated 4:00)" invites
+		// scoring a prediction that was never a promise.
+		return { label, detail: `finished in ${clock}`, tone: 'done', clock: null, showDetails: false };
+	}
+
+	if (status === 'error') {
+		// First line only. The rest is one click away rather than wrapped across the row.
+		const first = String(error ?? '')
+			.split('\n')[0]
+			.trim();
+		const detail = first ? `failed after ${clock} · ${first}` : `failed after ${clock}`;
+		return { label, detail, tone: 'failed', clock: null, showDetails: Boolean(error) };
+	}
+
+	if (status === 'cancelled') {
+		return {
+			label,
+			detail: `cancelled after ${clock}`,
+			tone: 'done',
+			clock: null,
+			showDetails: false
+		};
+	}
+
+	if (status === 'interrupted' || status === 'connection_lost') {
+		const what = status === 'connection_lost' ? 'lost the server connection' : 'was interrupted';
+		return {
+			label,
+			detail: `${what} after ${clock}`,
+			tone: 'failed',
+			clock: null,
+			showDetails: false
+		};
+	}
+
+	// --- still running ---
+
+	if (elapsedSeconds < CLOCK_AFTER_SECONDS) {
+		return {
+			label,
+			detail: `${where} · starting`,
+			tone: 'running',
+			clock: null,
+			showDetails: false
+		};
+	}
+
+	// No fitted equation for this method (PRIME, AxoMEME, B-STILL): report elapsed and say nothing
+	// else, forever. Inventing a threshold from no data would be the dishonest option.
+	if (!(estimateSeconds > 0)) {
+		return { label, detail: `${where} · running`, tone: 'running', clock, showDetails: false };
+	}
+
+	const muchLongerAt = Math.max(MUCH_LONGER_MULTIPLE * estimateSeconds, MUCH_LONGER_FLOOR_SECONDS);
+	if (elapsedSeconds > muchLongerAt) {
+		return {
+			label,
+			detail: `${where} · much longer than most runs this size`,
+			tone: 'slow',
+			clock,
+			showDetails: true
+		};
+	}
+
+	if (elapsedSeconds > LONGER_MULTIPLE * estimateSeconds) {
+		// Same weight, no icon, no colour escalation: this is information, not an alarm. Wording is
+		// "than most runs this size", never "than expected" — the software never expected anything,
+		// it fitted a curve.
+		return {
+			label,
+			detail: `${where} · longer than most runs this size`,
+			tone: 'running',
+			clock,
+			showDetails: false
+		};
+	}
+
+	return { label, detail: `${where} · running`, tone: 'running', clock, showDetails: false };
+}
+
+export function isTerminal(status) {
+	return TERMINAL.has(status);
+}
+
+export const RUN_STATUS_CONSTANTS = {
+	CLOCK_AFTER_SECONDS,
+	LONGER_MULTIPLE,
+	MUCH_LONGER_MULTIPLE,
+	MUCH_LONGER_FLOOR_SECONDS
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1185,8 +1185,14 @@
 		}
 	}
 
-	// Handle navigation from toast action (analysis completion)
-	function handleNavigateToResults() {
+	// Handle navigation from a toast action or a run row.
+	//
+	// The event carries the analysis it is about. Switching tabs alone was not enough: the detail
+	// pane renders whatever was selected before, so "View results" could land the user on an
+	// unrelated analysis -- or, on a fresh upload, on the invisible datareader job.
+	function handleNavigateToResults(event) {
+		const analysisId = event?.detail?.analysisId;
+		if (analysisId) selectAnalysis(analysisId);
 		changeTab('results');
 	}
 

--- a/src/test/run-status-line.test.js
+++ b/src/test/run-status-line.test.js
@@ -1,0 +1,178 @@
+/**
+ * Tests for the run row's copy rules (design/03-run-feedback/, audit item 3).
+ *
+ * These are not incidental strings. Each threshold was chosen against a measured property of the
+ * timing model, and the most important assertion in this file is a NEGATIVE one: the estimate must
+ * never appear next to the elapsed clock. The fitted power law is R² ≈ 0.63 — good to a factor of
+ * two, not to the minute — so "02:13 elapsed · typically ~4 min" reads as a countdown the software
+ * cannot honour, and a user at 4:30 against "~4 min" concludes something is wrong when nothing is.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	runStatusLine,
+	formatElapsed,
+	locationLabel,
+	isTerminal,
+	RUN_STATUS_CONSTANTS as C
+} from '../lib/utils/runStatusLine.js';
+
+const E = 240; // a 4-minute estimate, in seconds
+
+describe('formatElapsed', () => {
+	it('is m:ss under an hour and h:mm:ss past it', () => {
+		expect(formatElapsed(0)).toBe('0:00');
+		expect(formatElapsed(9)).toBe('0:09');
+		expect(formatElapsed(133)).toBe('2:13');
+		expect(formatElapsed(3600)).toBe('1:00:00');
+		expect(formatElapsed(3725)).toBe('1:02:05');
+	});
+
+	it('does not produce negative or NaN clocks', () => {
+		expect(formatElapsed(-5)).toBe('0:00');
+		expect(formatElapsed(undefined)).toBe('0:00');
+	});
+});
+
+describe('locationLabel carries the consequence, not the jargon', () => {
+	it('says what a reload will do, rather than "Local" / "Server"', () => {
+		// A reload kills a local run and does not kill a server one. "Local" does not tell a biologist
+		// that; "in this tab" does.
+		expect(locationLabel('wasm')).toBe('in this tab');
+		expect(locationLabel(undefined)).toBe('in this tab');
+		expect(locationLabel('backend')).toBe('on the server');
+	});
+});
+
+describe('a running row', () => {
+	const running = (elapsed, estimate = E) =>
+		runStatusLine({
+			method: 'fel',
+			status: 'running',
+			executionMode: 'wasm',
+			elapsedSeconds: elapsed,
+			estimateSeconds: estimate
+		});
+
+	it('shows no clock in the first ten seconds', () => {
+		// A timer at 0:03 invites watching it, and many local runs finish inside ten seconds.
+		const r = running(3);
+		expect(r.clock).toBeNull();
+		expect(r.detail).toBe('in this tab · starting');
+	});
+
+	it('shows elapsed as plain fact once past ten seconds', () => {
+		const r = running(133);
+		expect(r.clock).toBe('2:13');
+		expect(r.detail).toBe('in this tab · running');
+	});
+
+	it('NEVER prints the estimate beside the clock', () => {
+		// The rule this module exists to enforce. If this fails, the row has become a countdown.
+		for (const t of [11, 60, 133, 300, 600, 2000, 5000]) {
+			const r = running(t);
+			const text = `${r.detail} ${r.clock ?? ''}`;
+			expect(text, `estimate leaked at t=${t}`).not.toMatch(/typical|~|estimated|expected|4 min/i);
+		}
+	});
+
+	it('calls a run long only past twice the estimate', () => {
+		expect(running(2 * E - 1).detail).toBe('in this tab · running');
+		expect(running(2 * E + 1).detail).toBe('in this tab · longer than most runs this size');
+	});
+
+	it('says "than most runs this size", never "than expected"', () => {
+		// The software never expected anything. It fitted a curve.
+		expect(running(2 * E + 1).detail).not.toMatch(/expected/i);
+	});
+
+	it('does not escalate tone merely for being long', () => {
+		// Information, not an alarm.
+		expect(running(2 * E + 1).tone).toBe('running');
+	});
+
+	it('only reaches "much longer" past BOTH 6x and the 30-minute floor', () => {
+		// The floor exists so a 4-second FUBAR run does not raise a flag at 24 seconds.
+		expect(6 * E).toBeLessThan(C.MUCH_LONGER_FLOOR_SECONDS);
+		expect(running(6 * E + 10).detail).not.toMatch(/much longer/);
+
+		const past = C.MUCH_LONGER_FLOOR_SECONDS + 1;
+		expect(running(past).detail).toBe('in this tab · much longer than most runs this size');
+		expect(running(past).tone).toBe('slow');
+		expect(running(past).showDetails).toBe(true);
+	});
+
+	it('uses 6x when the estimate is large enough for it to dominate the floor', () => {
+		const big = 20 * 60; // 20 min estimate -> 6x = 2h, well past the floor
+		const r = runStatusLine({
+			method: 'busted',
+			status: 'running',
+			elapsedSeconds: 6 * big + 60,
+			estimateSeconds: big
+		});
+		expect(r.detail).toMatch(/much longer/);
+	});
+
+	it('says nothing beyond elapsed when the method has no fitted equation', () => {
+		// PRIME, AxoMEME, B-STILL. Inventing a threshold from no data is the dishonest option.
+		// null rather than undefined: undefined would trigger the helper's default estimate.
+		const r = running(100000, null);
+		expect(r.clock).toBe(formatElapsed(100000));
+		expect(r.detail).toBe('in this tab · running');
+		expect(r.detail).not.toMatch(/longer/);
+	});
+});
+
+describe('a finished row', () => {
+	it('reports elapsed as a fact and drops the running clock', () => {
+		const r = runStatusLine({
+			method: 'fel',
+			status: 'completed',
+			elapsedSeconds: 221,
+			estimateSeconds: E
+		});
+		expect(r.detail).toBe('finished in 3:41');
+		expect(r.tone).toBe('done');
+		expect(r.clock).toBeNull();
+	});
+
+	it('does not score itself against the estimate', () => {
+		const r = runStatusLine({
+			method: 'fel',
+			status: 'completed',
+			elapsedSeconds: 221,
+			estimateSeconds: E
+		});
+		expect(r.detail).not.toMatch(/estimate|typical|~/i);
+	});
+});
+
+describe('a failed row', () => {
+	it('puts the first line of the error inline and offers the rest', () => {
+		const r = runStatusLine({
+			method: 'fel',
+			status: 'error',
+			elapsedSeconds: 12,
+			error: 'Tree format error.\nPlease select "Inferred NJ tree" above, or upload a valid tree.'
+		});
+		expect(r.detail).toBe('failed after 0:12 · Tree format error.');
+		expect(r.tone).toBe('failed');
+		expect(r.showDetails).toBe(true);
+	});
+
+	it('is still readable when no error text was recorded', () => {
+		const r = runStatusLine({ method: 'fel', status: 'error', elapsedSeconds: 12 });
+		expect(r.detail).toBe('failed after 0:12');
+		expect(r.showDetails).toBe(false);
+	});
+});
+
+describe('isTerminal', () => {
+	it('covers every state a run can stop in', () => {
+		for (const s of ['completed', 'error', 'cancelled', 'interrupted', 'connection_lost']) {
+			expect(isTerminal(s), s).toBe(true);
+		}
+		for (const s of ['pending', 'running', 'initializing', 'mounting', 'processing']) {
+			expect(isTerminal(s), s).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
Closes #200. Design, wireframes and the written decision: `design/03-run-feedback/` (12 wireframes, 14 PNGs).

Clicking Run gave a 3-second toast, a 2-second button spinner, and then **nothing changed on the page for the next 4 minutes — or 4 hours**.

## What ships

**`RunStrip`** — one 44 px row per run, directly beneath the Run button. Below, never above: at the top it would shift the button 44 px down as the pointer travels toward it (`RunOutlook.svelte:96-102` documents the same concern).

Not a second mount of `AnalysisProgress.svelte`, as originally proposed. It self-hides 5 s after completion — calibrated for a user who is watching, and this row exists for the one who was not — plus it falls back to `activeAnalyses[0]`, renders a log tail through `marked`, and draws a sliding bar.

| elapsed | row reads |
|---|---|
| `< 10 s` | `● FEL · in this tab · starting` (no clock) |
| `10 s – 2E` | `● FEL · in this tab · running 2:13` |
| `> 2E` | `… longer than most runs this size` |
| `> max(6E, 30 min)` | `… much longer …` |
| no fitted equation | elapsed only, forever |

**The estimate is never printed beside the clock** — `R² = 0.626`, good to a factor of two, not to the minute. There is a test asserting it cannot leak.

**No progress bar.** `WasmAnalysisRunner` emits 10/20/40/80/95 and 40→80 spans the whole computation.

**Terminal rows persist until dismissed**, which is the whole point — they are for the user who was on another tab.

**Duplicate-run blocking**, replacing `setTimeout(…, 2000)` — that timer *was* the bug. Same method running → block. Any local run in flight while this would also run locally → block, because `executeWasmAnalysis` mounts a fixed `user.nex` into one shared Aioli instance and reads one output path, so two concurrent local runs corrupt each other. Two server runs → allowed.

**Pre-run estimate captured into run metadata** via `startAnalysisTracking`, read from `fileMetricsStore` (already populated by datareader, so no extra parsing).

## Verification

549 unit tests (19 new), build clean. E2E on chromium — `06-method-config`, `07-wasm-analysis`, `19-axomeme` — **19 passed**.

Worth noting: removing the timer initially *broke* `07-wasm-analysis › run button disabled during running analysis`, because the button became never-disabled — worse than before. That failure is what forced the store-derived rule to be implemented properly rather than just deleting the timer. It now passes for the right reason.

## Deliberately not in this PR

- **No Stop on local rows.** `WasmAnalysisRunner` has no `cancelAnalysis` override, so cancelling marks the record while the WASM keeps running and later writes `completed` over it. Offering a control that does not do what it says is worse than none. Filed as a separate bug — it is pre-existing and independent of this work.
- **Pill consolidation and the duplicate mobile mount** (`+layout.svelte:156`), and the dead `showRunningIndicator` in `PremiumTabNavigation`. The design's "five things removed" is a header/layout cleanup that deserves its own review; `RunStrip` itself is visible on mobile, so the phone gap is already substantially closed.
- Updating `e2e/07-wasm-analysis.spec.js:42-44` to assert on the row rather than the pill digit.
