### PR TITLE
Stop a cancelled analysis from un-cancelling itself

### DIFF
--- a/src/lib/services/BaseAnalysisRunner.js
+++ b/src/lib/services/BaseAnalysisRunner.js
@@ -55,6 +55,10 @@ export class BaseAnalysisRunner {
 	constructor() {
 		this.isRunning = false;
 		this.activeAnalyses = new Map(); // Track running analyses: jobId -> analysisId
+
+		// Analyses the user cancelled whose computation may still be in flight. Consulted by
+		// completeAnalysis so a run that was called off cannot report itself finished. Issue #201.
+		this.cancelledAnalyses = new Set();
 	}
 
 	/**
@@ -144,6 +148,21 @@ export class BaseAnalysisRunner {
 	async completeAnalysis(analysisId, success = true, result = null, message = null) {
 		const defaultMessage = success ? 'Analysis completed successfully' : 'Analysis failed';
 
+		// A cancelled run must not announce itself later.
+		//
+		// The store now refuses to overwrite a cancelled record, but that alone would still fire a
+		// "FEL analysis complete!" toast and a result write for work the user called off minutes
+		// earlier. Stop at the source instead: if this analysis was cancelled, there is nothing to
+		// report. Issue #201.
+		if (this.cancelledAnalyses?.has(analysisId)) {
+			this.cancelledAnalyses.delete(analysisId);
+			this.activeAnalyses.forEach((aId, jobId) => {
+				if (aId === analysisId) this.activeAnalyses.delete(jobId);
+			});
+			console.warn(`Suppressing completion for cancelled analysis ${analysisId.slice(0, 8)}...`);
+			return;
+		}
+
 		// Get the arguments metadata from the active analysis progress
 		const currentState = get(analysisStore);
 		const activeAnalysis = currentState?.activeAnalyses?.find((a) => a.id === analysisId);
@@ -221,6 +240,9 @@ export class BaseAnalysisRunner {
 	 * Cancel a running analysis
 	 */
 	async cancelAnalysis(analysisId) {
+		// Record the cancellation BEFORE touching the store, so a completion racing us is suppressed.
+		this.cancelledAnalyses.add(analysisId);
+
 		// Remove from active analyses
 		for (const [jobId, aId] of this.activeAnalyses.entries()) {
 			if (aId === analysisId) {

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -5,6 +5,7 @@
 
 import { BaseAnalysisRunner } from './BaseAnalysisRunner.js';
 import { aioliStore } from '../../stores/aioli.js';
+import { toastStore } from '../../stores/toast.js';
 import { get } from 'svelte/store';
 import { getCachedOrCompute, generateAnalysisKey } from '../utils/cacheUtils.js';
 import { sanitizeSequenceNames } from '../utils/fastaValidation.js';
@@ -181,10 +182,7 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		const cleanedFastaData = stripEmbeddedTrees(fastaData);
 
 		// Sanitize sequence names to remove characters invalid in Newick format
-		const { sanitizedFasta, sanitizedTree } = sanitizeSequenceNames(
-			cleanedFastaData,
-			treeData
-		);
+		const { sanitizedFasta, sanitizedTree } = sanitizeSequenceNames(cleanedFastaData, treeData);
 
 		// Create temporary file from cleaned FASTA data
 		const inputFile = new File([sanitizedFasta], 'user.nex', { type: 'text/plain' });
@@ -351,10 +349,9 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				} else if (key === 'rates') {
 					// Multi-Hit rate classes parameter
 					args.push(`--rates ${value}`);
-			} else if (key === 'rate_classes') {
-				// NRM rate classes parameter (convert underscore to hyphen)
-				args.push(`--rate-classes ${value}`);
-
+				} else if (key === 'rate_classes') {
+					// NRM rate classes parameter (convert underscore to hyphen)
+					args.push(`--rate-classes ${value}`);
 				} else if (key === 'triple_islands') {
 					// Multi-Hit triple islands parameter (convert underscore to hyphen)
 					args.push(`--triple-islands ${value}`);
@@ -477,9 +474,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		}
 
 		// Check for tree-related errors
-		if (stdout.includes('Illegal right hand side in call to Topology') ||
+		if (
+			stdout.includes('Illegal right hand side in call to Topology') ||
 			stdout.includes('tree string is invalid') ||
-			stdout.includes('Newick tree spec')) {
+			stdout.includes('Newick tree spec')
+		) {
 			throw new Error(
 				'Tree format error. Please select "Inferred NJ tree" in the Analyze tab, or upload a valid Newick tree file.'
 			);
@@ -684,7 +683,7 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		}
 
 		return {
-			command: `hyphy LIBPATH=/res/ ${method.toLowerCase()} ${args.join(' ')}`,  // Preview shows method name for readability
+			command: `hyphy LIBPATH=/res/ ${method.toLowerCase()} ${args.join(' ')}`, // Preview shows method name for readability
 			method: method.toUpperCase(),
 			parameters: config,
 			treeData: treeData
@@ -707,6 +706,35 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 	destroy() {
 		super.destroy();
 		this.isInitialized = false;
+	}
+
+	/**
+	 * Cancel a local run.
+	 *
+	 * WHAT THIS DOES AND DOES NOT DO, stated plainly because the previous behaviour was a lie.
+	 *
+	 * It marks the analysis cancelled and suppresses its completion, so the record stays cancelled
+	 * and no success toast or result arrives later. Before this, completeAnalysis wrote
+	 * status:'completed' over the cancelled record minutes afterwards and the card visibly
+	 * un-cancelled itself, presenting a result produced by settings the user had rejected.
+	 *
+	 * It does NOT stop the computation. hyphy.wasm keeps running to completion in Aioli's Web
+	 * Worker, so the tab stays busy. Terminating it is not reachable through Aioli's public API:
+	 * Aioli.init() creates the Worker as a local (`new v()` in aioli.mjs), wraps it with Comlink and
+	 * returns only the proxy -- the Worker handle is never retained, and the bundle exports no
+	 * `terminate`. Fixing that needs an upstream change, or capturing the Worker at construction
+	 * time where the instance is built. Tracked in issue #201.
+	 *
+	 * The user is told, rather than left to wonder why the tab is still busy.
+	 */
+	async cancelAnalysis(analysisId) {
+		await super.cancelAnalysis(analysisId);
+
+		toastStore.info(
+			'Analysis cancelled. Its results will not be saved or reported, but the computation ' +
+				'already running in this tab cannot be interrupted and will finish in the background.',
+			{ duration: 12000 }
+		);
 	}
 }
 

--- a/src/stores/analyses.js
+++ b/src/stores/analyses.js
@@ -128,6 +128,24 @@ function createAnalysisStore() {
 				// clobber a terminal record that a live completed/error event already wrote.
 				// Since getAnalysis() and saveAnalysis() are separate transactions, a
 				// concurrent completed-write can land in between; treat terminal states as final.
+				// CANCELLATION IS FINAL, and is checked before anything else.
+				//
+				// A cancelled local run keeps computing -- WasmAnalysisRunner cannot terminate the Aioli
+				// worker -- and minutes later writes 'completed' over the cancelled record. 'completed'
+				// is terminal, so the guard below (which only rejects NON-terminal incoming states) let
+				// it through, and the card visibly changed from Cancelled back to Completed on its own.
+				// The user was then shown a result produced by settings they had explicitly rejected,
+				// with nothing anywhere reporting the contradiction. See issue #201.
+				//
+				// Cancelling is a user decision. No later machine event may undo it.
+				if (currentAnalysis?.status === 'cancelled' && data.status && data.status !== 'cancelled') {
+					console.warn(
+						`📊 [AnalysisStore] Ignoring '${data.status}' for ${analysisId.slice(0, 8)}...; it was cancelled`
+					);
+					update((state) => ({ ...state, isLoading: false }));
+					return currentAnalysis;
+				}
+
 				const TERMINAL_STATES = ['completed', 'error', 'cancelled'];
 				const NON_TERMINAL_INCOMING = [
 					'running',

--- a/src/test/cancel-is-final.test.js
+++ b/src/test/cancel-is-final.test.js
@@ -1,0 +1,135 @@
+/**
+ * Regression tests for issue #201 — a cancelled local analysis un-cancelled itself.
+ *
+ * The sequence: the user cancels, the record goes to 'cancelled', hyphy.wasm keeps running because
+ * nothing terminates the worker, and minutes later completeAnalysis writes 'completed' over the
+ * cancelled record. The #170 terminal-state guard did not stop it, because that guard only rejects
+ * NON-terminal incoming states and 'completed' is terminal.
+ *
+ * The user is then shown a result produced by settings they explicitly rejected, on a card that
+ * visibly changed itself from Cancelled to Completed. Nothing throws, nothing is logged, and the
+ * result looks exactly like a real one — which is why this needs a test rather than a code comment.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { analysisStore } from '../stores/analyses.js';
+
+// The store persists through this module; stub it so the tests exercise the guard, not IndexedDB.
+vi.mock('../lib/utils/indexedDBStorage', () => {
+	const records = new Map();
+	return {
+		analysisStorage: {
+			getAnalysis: vi.fn(async (id) => records.get(id) ?? null),
+			saveAnalysis: vi.fn(async (a) => {
+				records.set(a.id, a);
+				return a;
+			}),
+			getAllAnalyses: vi.fn(async () => [...records.values()]),
+			deleteAnalysis: vi.fn(async (id) => records.delete(id)),
+			clearAllAnalyses: vi.fn(async () => records.clear()),
+			__records: records
+		}
+	};
+});
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const { analysisStorage } = await import('../lib/utils/indexedDBStorage');
+
+describe('#201 cancellation is final', () => {
+	beforeEach(() => {
+		analysisStorage.__records.clear();
+	});
+
+	async function seedCancelled(id = 'a1') {
+		await analysisStorage.saveAnalysis({
+			id,
+			fileId: 'f1',
+			method: 'busted',
+			status: 'cancelled',
+			createdAt: 1
+		});
+		return id;
+	}
+
+	it("does not let a late 'completed' overwrite a cancelled record", async () => {
+		// The bug, exactly. WASM finishes after the user cancelled and reports success.
+		const id = await seedCancelled();
+		await analysisStore.updateAnalysis(id, { status: 'completed', result: '{"MLE":{}}' });
+
+		const stored = await analysisStorage.getAnalysis(id);
+		expect(stored.status, 'a cancelled analysis un-cancelled itself').toBe('cancelled');
+	});
+
+	it('does not attach a result to a cancelled record', async () => {
+		// Even if the status were somehow preserved, attaching the payload would leave a cancelled
+		// card that renders real-looking results.
+		const id = await seedCancelled();
+		await analysisStore.updateAnalysis(id, { status: 'completed', result: '{"MLE":{}}' });
+
+		const stored = await analysisStorage.getAnalysis(id);
+		expect(stored.result).toBeUndefined();
+	});
+
+	it("does not let a late 'error' overwrite it either", async () => {
+		const id = await seedCancelled();
+		await analysisStore.updateAnalysis(id, { status: 'error', error: 'boom' });
+		expect((await analysisStorage.getAnalysis(id)).status).toBe('cancelled');
+	});
+
+	it('still allows unrelated terminal records to be written normally', async () => {
+		// The guard must be about cancellation, not about freezing every record.
+		await analysisStorage.saveAnalysis({
+			id: 'a2',
+			fileId: 'f1',
+			method: 'fel',
+			status: 'running',
+			createdAt: 2
+		});
+		await analysisStore.updateAnalysis('a2', { status: 'completed', result: '{}' });
+		expect((await analysisStorage.getAnalysis('a2')).status).toBe('completed');
+	});
+});
+
+describe('#201 a cancelled run does not announce itself', () => {
+	let runner;
+	let toasts;
+
+	beforeEach(async () => {
+		const { BaseAnalysisRunner } = await import('../lib/services/BaseAnalysisRunner.js');
+		runner = new BaseAnalysisRunner();
+		toasts = [];
+		const { toastStore } = await import('../stores/toast.js');
+		toastStore.dismissAll();
+		toasts = toastStore;
+	});
+
+	afterEach(async () => {
+		const { toastStore } = await import('../stores/toast.js');
+		toastStore.dismissAll();
+	});
+
+	it('suppresses completeAnalysis entirely for a cancelled analysis', async () => {
+		const { get } = await import('svelte/store');
+		runner.cancelledAnalyses.add('a9');
+
+		await runner.completeAnalysis('a9', true, { MLE: {} });
+
+		// No success toast: "FEL analysis complete!" for work called off minutes ago is the visible
+		// half of the bug.
+		expect(get(toasts), 'a cancelled run popped a completion toast').toHaveLength(0);
+		// And the marker is consumed, so a later legitimate run of the same id is unaffected.
+		expect(runner.cancelledAnalyses.has('a9')).toBe(false);
+	});
+
+	it('still reports a normal completion', async () => {
+		const { get } = await import('svelte/store');
+		await runner.completeAnalysis('a10', true, { MLE: {} });
+		expect(get(toasts).length, 'a normal completion was suppressed').toBeGreaterThan(0);
+	});
+
+	it('marks the analysis cancelled before touching the store, so a race is covered', async () => {
+		// cancelAnalysis records the id first; a completion arriving concurrently then finds it.
+		await runner.cancelAnalysis('a11').catch(() => {});
+		expect(runner.cancelledAnalyses.has('a11')).toBe(true);
+	});
+});


### PR DESCRIPTION
Refs #201. Fixes the visible defect; the underlying inability to terminate the worker is documented and left open on the issue.

## The bug

A user cancels a local run. The card shows Cancelled. Minutes later it **visibly changes back to Completed on its own**, presenting a result produced by the settings the user had just rejected. Nothing anywhere reports the contradiction.

Nothing terminates the WASM worker, so hyphy.wasm runs to completion and `completeAnalysis` writes `status: 'completed'` over the cancelled record. The terminal-state guard from #170 did **not** stop it — that guard only rejects *non-terminal* incoming states, and `completed` is terminal.

## Two changes, either alone leaving a hole

**1. The store treats cancellation as final.** Once a record is `cancelled`, no later status overwrites it. Cancelling is a user decision; no subsequent machine event may undo it.

**2. The runner stops at the source.** A cancelled analysis is recorded *before* the store is touched, and `completeAnalysis` returns immediately for it. Without this the record would stay correct while a `"BUSTED analysis complete!"` toast still announced work called off ten minutes earlier, and the result payload would still be written.

This also closes a residual race in `AxomemeAnalysisRunner`, which checks for cancellation between batches but could still reach `completeAnalysis` if the user cancelled during the final one.

## What this does NOT do

**It does not stop the computation.** hyphy.wasm keeps running in Aioli's Web Worker and the tab stays busy.

Terminating it is not reachable through Aioli's public API. `Aioli.init()` creates the Worker as a local (`new v()` in `aioli.mjs`), wraps it with Comlink, and returns only the proxy — the handle is never retained, and the bundle exports no `terminate` (verified: the string does not appear in `dist/aioli.mjs`).

Rather than leave the user wondering why their tab is still busy, cancelling a local run now says so plainly: *"Its results will not be saved or reported, but the computation already running in this tab cannot be interrupted and will finish in the background."*

Real termination needs an upstream change, or capturing the Worker at construction time where the instance is built. That remains open on #201 — which is why this PR says `Refs` rather than `Closes`.

## Verification

7 new tests, each half verified to fail independently:

```
REVERT A: remove the store's cancelled-is-final guard
  × does not let a late 'completed' overwrite a cancelled record
  × does not attach a result to a cancelled record
  × does not let a late 'error' overwrite it either

REVERT B: remove the runner's completion suppression
  × suppresses completeAnalysis entirely for a cancelled analysis
```

Full suite **585 passed / 33 files**, build clean. E2E on the cancellation-adjacent paths (`19-axomeme`, `20-run-strip`, `09-analysis-history`, `12-toast`) — **20 passed**.
