### PR TITLE
Report in-frame stop codons in coordinates that mean something

### DIFF
--- a/src/lib/utils/fastaValidation.js
+++ b/src/lib/utils/fastaValidation.js
@@ -275,18 +275,18 @@ export function sanitizeSequenceNames(fastaData, treeData) {
  * Only entries that differ from Universal (0) are listed separately.
  */
 const STOP_CODONS_BY_GENETIC_CODE = {
-	0: ['TAA', 'TAG', 'TGA'],  // Universal
-	1: ['TAA', 'TAG', 'AGA', 'AGG'],  // Vertebrate mitochondrial
-	2: ['TAA', 'TAG'],  // Yeast mitochondrial
-	3: ['TAA', 'TAG'],  // Mold mitochondrial
-	4: ['TAA', 'TAG'],  // Invertebrate mitochondrial
-	5: ['TGA'],  // Ciliate nuclear (TAA/TAG code for Gln)
-	6: ['TAA', 'TAG'],  // Echinoderm mitochondrial
-	7: ['TAA', 'TAG'],  // Euplotid nuclear
-	8: ['TAA', 'TAG', 'TGA'],  // Alternative yeast nuclear
-	9: ['TAA', 'TAG'],  // Ascidian mitochondrial
-	10: ['TAA', 'TAG'],  // Flatworm mitochondrial
-	11: ['TAA', 'TGA']  // Blepharisma nuclear
+	0: ['TAA', 'TAG', 'TGA'], // Universal
+	1: ['TAA', 'TAG', 'AGA', 'AGG'], // Vertebrate mitochondrial
+	2: ['TAA', 'TAG'], // Yeast mitochondrial
+	3: ['TAA', 'TAG'], // Mold mitochondrial
+	4: ['TAA', 'TAG'], // Invertebrate mitochondrial
+	5: ['TGA'], // Ciliate nuclear (TAA/TAG code for Gln)
+	6: ['TAA', 'TAG'], // Echinoderm mitochondrial
+	7: ['TAA', 'TAG'], // Euplotid nuclear
+	8: ['TAA', 'TAG', 'TGA'], // Alternative yeast nuclear
+	9: ['TAA', 'TAG'], // Ascidian mitochondrial
+	10: ['TAA', 'TAG'], // Flatworm mitochondrial
+	11: ['TAA', 'TGA'] // Blepharisma nuclear
 };
 
 /**
@@ -392,6 +392,163 @@ export function parseAlignment(content) {
  * @param {number} [geneticCodeId=0] - Genetic code ID (0 = Universal)
  * @returns {{ valid: boolean, errors: string[] }}
  */
+/**
+ * Human-readable names for the genetic codes above, so a report can say which one it used.
+ * Ids match HyPhy's numbering and the selector in MethodSelector.
+ */
+const GENETIC_CODE_NAMES = {
+	0: 'Universal',
+	1: 'Vertebrate mitochondrial',
+	2: 'Yeast mitochondrial',
+	3: 'Mold mitochondrial',
+	4: 'Invertebrate mitochondrial',
+	5: 'Ciliate nuclear',
+	6: 'Echinoderm mitochondrial',
+	7: 'Euplotid nuclear',
+	8: 'Alternative yeast nuclear',
+	9: 'Ascidian mitochondrial',
+	10: 'Flatworm mitochondrial',
+	11: 'Blepharisma nuclear'
+};
+
+/** Characters treated as a gap or missing data. */
+const GAP_CHARS = /[-.?~]/;
+
+/**
+ * Locate in-frame stop codons, in ALIGNMENT coordinates.
+ *
+ * This reports what is in the file. It draws no conclusion about what the file should be, and
+ * nothing here suggests an edit: which of several very different causes produced a premature stop
+ * -- a frameshift, a pseudogene, a sequencing error, a genuine nonsense mutation, or simply the
+ * wrong genetic code -- is a question about the data, and the answer is not the software's to give.
+ *
+ * FOUR DECISIONS THAT MAKE THE NUMBERS MEAN SOMETHING:
+ *
+ * 1. Positions are codon COLUMNS OF THE ALIGNMENT, counting from 1. The previous implementation
+ *    stripped gaps first and reported positions in ungapped coordinates, which correspond to no
+ *    column the user can look at -- in a gapped alignment they point somewhere else entirely.
+ *    HyPhy works in alignment columns and so does the alignment viewer.
+ *
+ * 2. Nothing is scanned unless the alignment length is a multiple of three. Without that, codon
+ *    columns are not defined, and any stop codon "found" would be an artefact of an arbitrary
+ *    frame rather than a fact about the data.
+ *
+ * 3. Each sequence's own last non-gap codon is skipped. A terminal stop is ordinary, and sequences
+ *    end at different columns when there are trailing gaps.
+ *
+ * 4. Only unambiguous ACGT codons are called. A codon containing a gap or an ambiguity code is not
+ *    a codon we can read, so it is passed over rather than guessed at.
+ *
+ * @param {string} alignmentData
+ * @param {number} geneticCodeId
+ * @returns {{scanned: boolean, reason?: string, geneticCode: string, totalSequences: number,
+ *   affected: Array<{header: string, hits: Array<{position: number, codon: string}>}>}}
+ */
+export function findStopCodons(alignmentData, geneticCodeId = 0) {
+	const geneticCode = GENETIC_CODE_NAMES[geneticCodeId] ?? `code ${geneticCodeId}`;
+	const empty = { scanned: false, geneticCode, totalSequences: 0, affected: [] };
+
+	if (!alignmentData || !alignmentData.trim()) {
+		return { ...empty, reason: 'no alignment data' };
+	}
+
+	let parsed;
+	try {
+		parsed = parseAlignment(alignmentData);
+	} catch (e) {
+		return { ...empty, reason: e.message };
+	}
+
+	const sequences = parsed?.sequences ?? [];
+	if (sequences.length === 0) return { ...empty, reason: 'no sequences found' };
+
+	const columns = sequences[0].sequence.length;
+	if (columns % 3 !== 0) {
+		// Decision 2. Say why nothing was scanned rather than silently reporting nothing.
+		return {
+			...empty,
+			totalSequences: sequences.length,
+			reason: `alignment length (${columns}) is not a multiple of 3, so codon positions are undefined`
+		};
+	}
+
+	const stopSet = new Set(
+		STOP_CODONS_BY_GENETIC_CODE[geneticCodeId] || STOP_CODONS_BY_GENETIC_CODE[0]
+	);
+
+	const affected = [];
+	for (const seq of sequences) {
+		const raw = String(seq.sequence ?? '').toUpperCase();
+		const codons = [];
+		for (let c = 0; c + 3 <= raw.length; c += 3) codons.push(raw.substring(c, c + 3));
+
+		// Decision 3: the sequence's own last codon that is not entirely gap.
+		let lastReal = -1;
+		for (let i = codons.length - 1; i >= 0; i--) {
+			if (!/^[-.?~]{3}$/.test(codons[i])) {
+				lastReal = i;
+				break;
+			}
+		}
+
+		const hits = [];
+		for (let i = 0; i < codons.length; i++) {
+			if (i === lastReal) continue;
+			const codon = codons[i];
+			// Decision 4.
+			if (GAP_CHARS.test(codon) || !/^[ACGT]{3}$/.test(codon)) continue;
+			if (stopSet.has(codon)) hits.push({ position: i + 1, codon });
+		}
+
+		if (hits.length) affected.push({ header: seq.header, hits });
+	}
+
+	return { scanned: true, geneticCode, totalSequences: sequences.length, affected };
+}
+
+/**
+ * Render a stop-codon finding as plain text.
+ *
+ * Description only. No recommendation, no proposed edit, no next step -- the reader is a
+ * molecular biologist looking at their own data, and they do not need software to tell them what a
+ * premature stop codon might mean.
+ *
+ * @param {ReturnType<typeof findStopCodons>} finding
+ * @param {{maxSequences?: number, maxPerSequence?: number}} [limits]
+ * @returns {string} empty when there is nothing to report
+ */
+export function formatStopCodonReport(finding, { maxSequences = 10, maxPerSequence = 5 } = {}) {
+	if (!finding?.scanned || finding.affected.length === 0) return '';
+
+	const n = finding.affected.length;
+	const total = finding.totalSequences;
+	const lines = [
+		`In-frame stop codons found in ${n} of ${total} ${total === 1 ? 'sequence' : 'sequences'}, ` +
+			`reading the ${finding.geneticCode} genetic code.`,
+		''
+	];
+
+	for (const seq of finding.affected.slice(0, maxSequences)) {
+		const shown = seq.hits
+			.slice(0, maxPerSequence)
+			.map((h) => `codon ${h.position} (${h.codon})`)
+			.join(', ');
+		const extra =
+			seq.hits.length > maxPerSequence ? `, and ${seq.hits.length - maxPerSequence} more` : '';
+		lines.push(`  ${seq.header}: ${shown}${extra}`);
+	}
+
+	if (n > maxSequences) lines.push(`  ...and ${n - maxSequences} further sequences.`);
+
+	lines.push(
+		'',
+		'Positions are codon columns of the alignment, counting from 1. The final codon of each ' +
+			'sequence is not counted.'
+	);
+
+	return lines.join('\n');
+}
+
 export function validateCodonAlignment(alignmentData, geneticCodeId = 0) {
 	const errors = [];
 
@@ -418,38 +575,24 @@ export function validateCodonAlignment(alignmentData, geneticCodeId = 0) {
 	if (alignmentSites % 3 !== 0) {
 		errors.push(
 			`Alignment site count (${alignmentSites}) is not divisible by 3. ` +
-			`Codon-based analyses require the alignment length to be a multiple of 3.`
+				`Codon-based analyses require the alignment length to be a multiple of 3.`
 		);
 	}
 
-	// Determine stop codons for this genetic code
-	const stopCodons = STOP_CODONS_BY_GENETIC_CODE[geneticCodeId] ||
-		STOP_CODONS_BY_GENETIC_CODE[0];
+	// In-frame stop codons, reported as one consolidated finding.
+	//
+	// This replaces a per-sequence loop that pushed one long sentence per affected sequence -- for a
+	// 200-sequence alignment that produced 200 lines, joined with newlines and shown in a toast. It
+	// also reported positions in UNGAPPED coordinates, obtained by stripping gaps before scanning,
+	// which point at no column the user can actually look at.
+	//
+	// findStopCodons works in alignment columns and reports every occurrence rather than the first
+	// per sequence. See its comment for the four decisions that make the numbers meaningful.
+	const stopFinding = findStopCodons(alignmentData, geneticCodeId);
+	const stopReport = formatStopCodonReport(stopFinding);
+	if (stopReport) errors.push(stopReport);
 
-	const stopCodonSet = new Set(stopCodons);
-
-	// Scan each sequence for in-frame stop codons (excluding the last codon)
-	for (const seq of sequences) {
-		const cleanSeq = seq.sequence.replace(/[-.]/g, '').toUpperCase();
-		// Only check if ungapped length is divisible by 3
-		if (cleanSeq.length % 3 !== 0) continue;
-
-		const lastCodonStart = cleanSeq.length - 3;
-		for (let i = 0; i < lastCodonStart; i += 3) {
-			const codon = cleanSeq.substring(i, i + 3);
-			if (stopCodonSet.has(codon)) {
-				const codonPosition = (i / 3) + 1;
-				errors.push(
-					`In-frame stop codon (${codon}) found in sequence "${seq.header}" ` +
-					`at codon position ${codonPosition}. Codon-based analyses cannot proceed ` +
-					`with premature stop codons.`
-				);
-				break;
-			}
-		}
-	}
-
-	return { valid: errors.length === 0, errors };
+	return { valid: errors.length === 0, errors, stopCodons: stopFinding };
 }
 
 /**

--- a/src/test/codon-validation.test.js
+++ b/src/test/codon-validation.test.js
@@ -67,7 +67,9 @@ describe('validateCodonAlignment', () => {
 			const result = validateCodonAlignment(data, 0);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]).toContain('TAA');
-			expect(result.errors[0]).toContain('codon position 2');
+			// Position is unchanged; the wording is not. Stop codons are now reported as one
+			// consolidated finding in alignment-column coordinates: "codon 2 (TAA)".
+			expect(result.errors[0]).toContain('codon 2 (TAA)');
 		});
 
 		it('detects TAG stop codon in-frame', () => {
@@ -111,7 +113,13 @@ describe('validateCodonAlignment', () => {
 			]);
 			const result = validateCodonAlignment(data, 0);
 			expect(result.valid).toBe(false);
-			expect(result.errors).toHaveLength(2);
+			// ONE consolidated entry now, not one per sequence -- a 200-sequence alignment used to
+			// produce 200 lines joined into a single toast. Both sequences must still be named, so
+			// the consolidation loses nothing.
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0]).toContain('2 of 2 sequences');
+			expect(result.errors[0]).toContain('Seq1: codon 2 (TAA)');
+			expect(result.errors[0]).toContain('Seq2: codon 2 (TAG)');
 		});
 	});
 

--- a/src/test/stop-codon-diagnosis.test.js
+++ b/src/test/stop-codon-diagnosis.test.js
@@ -1,0 +1,149 @@
+/**
+ * Tests for the in-frame stop codon report.
+ *
+ * The report is DESCRIPTIVE by design: it states what is in the file and stops there. Several very
+ * different things produce a premature stop — a frameshift, a pseudogene, a sequencing error, a
+ * genuine nonsense mutation, or simply the wrong genetic code — and choosing between them is a
+ * question about the data, not something software should answer on the user's behalf. There are
+ * assertions below that pin that: no recommendation, and no offer to modify the alignment.
+ *
+ * The correctness half is about coordinates. The previous implementation stripped gaps before
+ * scanning and reported positions in ungapped space, which point at no column the user can look at.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	findStopCodons,
+	formatStopCodonReport,
+	validateCodonAlignment
+} from '../lib/utils/fastaValidation.js';
+
+/** ATG AAA TAA GGG — a premature stop at codon 3 of 4. */
+const withStop = '>seq1\nATGAAATAAGGG\n>seq2\nATGAAAGGGCCC\n';
+
+describe('findStopCodons reports alignment columns, not ungapped positions', () => {
+	it('finds a premature stop and names its codon column', () => {
+		const r = findStopCodons(withStop, 0);
+		expect(r.scanned).toBe(true);
+		expect(r.totalSequences).toBe(2);
+		expect(r.affected).toHaveLength(1);
+		expect(r.affected[0].header).toBe('seq1');
+		expect(r.affected[0].hits).toEqual([{ position: 3, codon: 'TAA' }]);
+	});
+
+	it('counts gapped columns, so the position matches what the user sees', () => {
+		// Gap codon first, then ATG, then TAA. In ALIGNMENT coordinates the stop is codon 3.
+		// Stripping gaps first — the old behaviour — would have called it codon 2, pointing at ATG.
+		const gapped = '>s\n---ATGTAAGGG\n';
+		const r = findStopCodons(gapped, 0);
+		expect(r.affected[0].hits).toEqual([{ position: 3, codon: 'TAA' }]);
+	});
+
+	it('reports every occurrence, not only the first per sequence', () => {
+		const many = '>s\nATGTAAAAATGATAGGGG\n'; // stops at codons 2, 4 and 5; 6 is terminal
+		const r = findStopCodons(many, 0);
+		expect(r.affected[0].hits.map((h) => h.position)).toEqual([2, 4, 5]);
+	});
+
+	it('does not count a terminal stop', () => {
+		const terminal = '>s\nATGAAATAA\n';
+		expect(findStopCodons(terminal, 0).affected).toHaveLength(0);
+	});
+
+	it("uses each sequence's own last non-gap codon as its terminus", () => {
+		// Trailing gaps mean sequences end at different columns; the stop here is terminal for
+		// this sequence even though it is not the last column of the alignment.
+		const trailing = '>s\nATGAAATAA---\n';
+		expect(findStopCodons(trailing, 0).affected).toHaveLength(0);
+	});
+
+	it('does not scan at all when the alignment length is not a multiple of 3', () => {
+		// Codon columns are undefined, so any stop "found" would be an artefact of an arbitrary
+		// frame rather than a fact about the data.
+		const r = findStopCodons('>s\nATGAAATAAG\n', 0);
+		expect(r.scanned).toBe(false);
+		expect(r.affected).toHaveLength(0);
+		expect(r.reason).toMatch(/not a multiple of 3/);
+	});
+
+	it('passes over codons containing gaps or ambiguity rather than guessing', () => {
+		expect(findStopCodons('>s\nATGT-AGGGCCC\n', 0).affected).toHaveLength(0);
+		expect(findStopCodons('>s\nATGTNAGGGCCC\n', 0).affected).toHaveLength(0);
+	});
+
+	it('honours the genetic code, which decides what a stop even is', () => {
+		// TGA is a stop under the universal code and tryptophan under vertebrate mitochondrial.
+		const seq = '>s\nATGTGAAAAGGG\n';
+		expect(findStopCodons(seq, 0).affected).toHaveLength(1);
+		expect(findStopCodons(seq, 1).affected).toHaveLength(0);
+
+		// And AGA is a stop under vertebrate mitochondrial but arginine under universal.
+		const seq2 = '>s\nATGAGAAAAGGG\n';
+		expect(findStopCodons(seq2, 0).affected).toHaveLength(0);
+		expect(findStopCodons(seq2, 1).affected).toHaveLength(1);
+	});
+
+	it('does not throw on unparseable input', () => {
+		expect(() => findStopCodons('not an alignment at all', 0)).not.toThrow();
+		expect(findStopCodons('', 0).scanned).toBe(false);
+	});
+});
+
+describe('formatStopCodonReport describes, and does not advise', () => {
+	const report = formatStopCodonReport(findStopCodons(withStop, 0));
+
+	it('states the count, the sequence, and the codon column', () => {
+		expect(report).toContain('1 of 2 sequences');
+		expect(report).toContain('seq1: codon 3 (TAA)');
+		expect(report).toContain('codon columns of the alignment');
+	});
+
+	it('names the genetic code it read', () => {
+		// Which code was used determines what counts as a stop, so a report that omits it is not
+		// interpretable.
+		expect(report).toContain('Universal');
+		expect(formatStopCodonReport(findStopCodons(withStop, 1))).not.toContain('Universal');
+	});
+
+	it('makes no recommendation and proposes no edit', () => {
+		// The load-bearing assertion. Software that offers to trim, strip, fix or realign a
+		// scientific alignment is asserting that doing so is acceptable, which is not its call.
+		expect(report).not.toMatch(
+			/should|recommend|suggest|try |consider|trim|strip|remove|fix|repair|correct |edit|we can|click here/i
+		);
+	});
+
+	it('is empty when there is nothing to report', () => {
+		expect(formatStopCodonReport(findStopCodons('>s\nATGAAAGGGCCC\n', 0))).toBe('');
+		expect(formatStopCodonReport(null)).toBe('');
+	});
+
+	it('bounds a large report and says how much it left out', () => {
+		const seqs = Array.from({ length: 30 }, (_, i) => `>s${i}\nATGTAAAAAGGG`).join('\n');
+		const r = formatStopCodonReport(findStopCodons(seqs, 0));
+		expect(r).toContain('30 of 30 sequences');
+		expect(r).toMatch(/and 20 further sequences/);
+	});
+});
+
+describe('validateCodonAlignment consolidates the finding', () => {
+	it('produces ONE entry for stop codons rather than one per sequence', () => {
+		// Previously a 200-sequence alignment produced 200 lines, joined with newlines into a toast.
+		const seqs = Array.from({ length: 12 }, (_, i) => `>s${i}\nATGTAAAAAGGG`).join('\n');
+		const result = validateCodonAlignment(seqs, 0);
+		expect(result.valid).toBe(false);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toContain('12 of 12 sequences');
+	});
+
+	it('still reports the divisibility problem on its own terms', () => {
+		const result = validateCodonAlignment('>s\nATGAAATAAG\n', 0);
+		expect(result.errors.some((e) => /divisible by 3/.test(e))).toBe(true);
+		// And does not also claim stop codons, whose positions would be undefined here.
+		expect(result.errors.some((e) => /stop codon/i.test(e))).toBe(false);
+	});
+
+	it('exposes the structured finding for callers that want it', () => {
+		const result = validateCodonAlignment(withStop, 0);
+		expect(result.stopCodons.affected[0].hits[0].position).toBe(3);
+	});
+});


### PR DESCRIPTION
Relates to #199 and #140. **Diagnosis only** — no recommendation, and nothing that offers to modify a user's alignment.

## Why description only

Several very different things produce a premature stop codon: a frameshift, a pseudogene, a sequencing error, a genuine nonsense mutation, or simply the wrong genetic code selected. Choosing between them is a question about the data. A tool that offered to trim, strip or repair the alignment would be asserting that doing so is scientifically acceptable, which is not its call to make.

So the report states what is in the file, in coordinates the reader can check, and stops.

## The coordinates were wrong

The old scan did `seq.sequence.replace(/[-.]/g, '')` **before** reading codons, then reported `codonPosition = i/3 + 1` — a position in ungapped space. On any gapped alignment that points at a different column than the one holding the stop, so there was no column the user could look at to verify it.

HyPhy works in alignment columns, and so does the alignment viewer. The report now does too.

```
Old: '---ATGTAAGGG' → "codon position 2"   (points at ATG)
New: '---ATGTAAGGG' → "codon 3 (TAA)"      (points at the stop)
```

## Three further decisions, each about not claiming more than is known

**Nothing is scanned unless the alignment length is a multiple of three.** Codon columns are otherwise undefined, and any stop "found" would be an artefact of an arbitrary frame rather than a fact about the data. The divisibility problem is reported on its own terms instead.

**Each sequence's own last non-gap codon is skipped**, not the alignment's last column — a terminal stop is ordinary, and sequences end at different columns when there are trailing gaps.

**Only unambiguous ACGT codons are called.** A codon containing a gap or an ambiguity code cannot be read, so it is passed over rather than guessed at.

## Presentation

One consolidated finding instead of one sentence per affected sequence — a 200-sequence alignment previously produced 200 lines, joined with newlines into a single toast. Every occurrence per sequence rather than only the first. The genetic code is named, because which code is in use decides what counts as a stop at all (TGA is a stop under Universal and tryptophan under vertebrate mitochondrial). Long reports bound themselves and say how much they left out.

```
In-frame stop codons found in 3 of 12 sequences, reading the Universal genetic code.

  HIV1_A_KE_1234: codon 47 (TAA), codon 102 (TGA)
  HIV1_B_US_5678: codon 47 (TAA)
  HIV1_C_ZA_9012: codon 210 (TAG)

Positions are codon columns of the alignment, counting from 1. The final codon of each
sequence is not counted.
```

## Verification

17 new tests, including one that pins the constraint directly:

```js
expect(report).not.toMatch(
  /should|recommend|suggest|try |consider|trim|strip|remove|fix|repair|correct |edit|we can|click here/i
);
```

Full suite **602 passed / 34 files**, build clean, e2e on the validation paths (`04-invalid-files`, `02-file-upload`, `07-wasm-analysis`) 9 passed.

**Two existing tests in `codon-validation.test.js` were updated.** Both used ungapped sequences, so the positions they assert are unchanged — only the presentation changed. The multi-sequence one now asserts the consolidated entry still names every affected sequence, so consolidation demonstrably loses nothing.
