### PR TITLE
Clear the previous file's error before anything that can return early

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,7 @@
 	import { syncDescriptorStoresForFile as syncDescriptorStores } from '../lib/utils/descriptorSync.js';
 	import { resolveSelectedAnalysis } from '../lib/utils/analysisSelection.js';
 	import { trackEvent } from '../lib/utils/analytics.js';
+	import { toastStore } from '../stores/toast';
 	import Aioli from '@biowasm/aioli';
 	import TreeSelector from '../lib/TreeSelector.svelte';
 	import ErrorHandler from '../lib/ErrorHandler.svelte';
@@ -694,6 +695,19 @@
 					: 'upload';
 		let currentStage = 'init';
 		try {
+			// CLEAR THE PREVIOUS FILE'S ERROR FIRST, before any branch that can return early.
+			//
+			// This used to sit further down, after the selection branch -- which returns early at the
+			// "loaded existing analysis" path. So selecting a file that already had a datareader result
+			// skipped the reset entirely, and a validation error naming the PREVIOUS file stayed on
+			// screen beside the newly selected one. Same shape as the descriptorSync bug (#168): a
+			// reset placed after something that can exit early is not a reset. Issue #205.
+			validationError = null;
+			// Errors no longer auto-dismiss (#187), which is right for someone who stepped away --
+			// but it means a stale error toast would otherwise outlive the file it describes.
+			// Successes are left alone: they link to a result that still exists.
+			toastStore.dismissWhere((t) => t.type === 'error' || t.type === 'warning');
+
 			// Reset tree state at the start of every file load. addTree only ever adds
 			// keys, so without this a usertree extracted from a previous alignment would
 			// survive into a different file that has no tree of its own (issue #167).
@@ -772,8 +786,7 @@
 
 			if (!file) return; // No file selected
 
-			// Clear any previous errors
-			validationError = null;
+			// (Errors were already cleared at the top of this function, before any early return.)
 
 			// For new uploads, save the file to browser storage
 			// For selections, this is already done

--- a/src/stores/toast.js
+++ b/src/stores/toast.js
@@ -132,6 +132,34 @@ function createToastStore() {
 		},
 
 		/**
+		 * Dismiss every toast matching a predicate.
+		 *
+		 * Exists because errors no longer auto-dismiss. That was the right call -- an 8-second window
+		 * routinely expired while the user was reading, or in another window -- but it made something
+		 * else the caller's job: a message describing one file must not outlive the moment the user
+		 * moves to a different file. Nothing was doing that, so a validation error about file A hung
+		 * over file B, which is the wrong-file class of bug this app has spent a lot of effort
+		 * removing. See issue #205.
+		 *
+		 * @param {(toast: {id: number, type: string, message: string}) => boolean} predicate
+		 */
+		dismissWhere(predicate) {
+			const doomed = [];
+			const unsub = subscribe((toasts) => {
+				for (const t of toasts) {
+					try {
+						if (predicate(t)) doomed.push(t.id);
+					} catch {
+						// A throwing predicate must not take out the toast system.
+					}
+				}
+			});
+			unsub();
+			for (const id of doomed) this.dismiss(id);
+			return doomed.length;
+		},
+
+		/**
 		 * Dismiss all toasts
 		 */
 		dismissAll() {

--- a/src/test/toast-persistence.test.js
+++ b/src/test/toast-persistence.test.js
@@ -98,3 +98,61 @@ describe('#187 hovering or focusing a toast stops its dismiss clock', () => {
 		expect(get(toastStore)).toHaveLength(1);
 	});
 });
+
+/**
+ * Issue #205 — the regression that persistent errors introduced.
+ *
+ * Making errors permanent was right, but it moved a responsibility onto the caller that nothing was
+ * discharging: a message describing one file must not outlive the moment the user moves to another
+ * file. Before #187 the 8-second timer hid this; after it, a validation error naming file A sat on
+ * screen while the user looked at file B, describing sequences that were no longer loaded.
+ */
+describe('#205 stale errors do not follow the user to the next file', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		toastStore.dismissAll();
+	});
+	afterEach(() => {
+		toastStore.dismissAll();
+		vi.useRealTimers();
+	});
+
+	it('dismisses errors and warnings but keeps successes', () => {
+		toastStore.error('In-frame stop codons found in 4 of 8 sequences');
+		toastStore.warning('Short alignment');
+		toastStore.success('FEL analysis complete!');
+
+		const removed = toastStore.dismissWhere((t) => t.type === 'error' || t.type === 'warning');
+
+		expect(removed).toBe(2);
+		const left = get(toastStore);
+		expect(left).toHaveLength(1);
+		// The success toast links to an analysis that still exists, so it is not stale.
+		expect(left[0].type).toBe('success');
+	});
+
+	it('is a no-op when nothing matches', () => {
+		toastStore.success('done');
+		expect(toastStore.dismissWhere((t) => t.type === 'error')).toBe(0);
+		expect(get(toastStore)).toHaveLength(1);
+	});
+
+	it('clears the timer of a dismissed toast, not just the entry', () => {
+		toastStore.warning('short alignment'); // 5s default
+		toastStore.dismissWhere((t) => t.type === 'warning');
+		expect(get(toastStore)).toHaveLength(0);
+		// If the handle leaked, this would fire against a removed id.
+		expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
+		expect(get(toastStore)).toHaveLength(0);
+	});
+
+	it('survives a predicate that throws', () => {
+		toastStore.error('boom');
+		expect(() =>
+			toastStore.dismissWhere(() => {
+				throw new Error('bad predicate');
+			})
+		).not.toThrow();
+		expect(get(toastStore)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Selecting a different file left the previous file's error on screen, describing sequences that were no longer loaded. Reported from the running app.

## Two causes

**1. A reset below an early return.** `handleFileUpload` returns early (`+page.svelte:759`) when the selected file already has a datareader result, and `validationError = null` sat *below* that return. So the reselect path skipped it entirely.

Same shape as #168: **a reset placed after something that can exit early is not a reset.** It is now the first thing the function does, above every branch.

**2. Stale error toasts — this one I introduced.** Nothing anywhere dismissed a toast on file change; the only dismissals were user clicks. Making errors persist (#187) was right on its own terms, but it quietly moved a responsibility onto callers that nothing was discharging: a message describing one file must not outlive the move to another file. The 8-second timer had been *hiding* that, not preventing it.

`toastStore.dismissWhere()` lets the upload path clear errors and warnings while leaving successes alone, since those link to a result that still exists.

## Verification gap — please weight this accordingly

The toast half has **4 unit tests** (12 in that file total, all passing).

**The hoist has no test.** It lives inside a Svelte component, and five attempts at an e2e failed to produce one that discriminates. Two of them *passed with the fix reverted*:

- `loadDemoFile` takes the demo path, which never reaches the early return
- an assertion matched text the Analyze tab already displayed

Rather than commit a test that reads like coverage and provides none, there is none. The hoist is verified by reading and by the build. If you want it pinned before merge, the reproduction needs a real click on a saved-file card (`FileCard.svelte:311`, behind a "Show details" disclosure) after an upload error — that is the interaction I could not get stable.

Full suite **589 passed / 33 files**, build clean.

## Separate finding, worth acting on independently

Chasing the reproduction turned up something that reframes #204: **a file with genuine premature stop codons is rejected by datareader at upload** and never reaches the Analyze tab.

```
File processing error
6 stop codons found. Please double-check your alignment...
```

That message is HyPhy's. `validateCodonAlignment` — the function #204 improves — only runs at analysis time, so for exactly the files it describes, **it is unreachable**. #204 is not wrong, but its practical reach is much smaller than it appears. The reachable place is the upload path, which is what #199 argues for.

Also unconfirmed: HyPhy counts 6 stop codons in that file where my scanner finds 5 across 4 sequences. Probably the terminal stop in `Gorilla_gorilla`, but I have not verified it.
