### PR TITLE
Offer AxoMEME on the server now that there is a server to offer

### DIFF
--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -193,9 +193,15 @@ test.describe('AxoMEME', () => {
 		await expect(page.locator('.axomeme-beta')).toBeVisible({ timeout: 30000 });
 	});
 
-	test('suppresses controls that cannot reach the model', async ({ page }) => {
-		// Both were live at first and both imply a capability AxoMEME does not have: there is no
-		// server-side AxoMEME, and the model's tokenizer bakes in the universal genetic code.
+	test('suppresses the genetic code, which neither surface can honour', async ({ page }) => {
+		// This used to assert that the EXECUTION MODE toggle was suppressed too. That is no longer
+		// true and should not be: there is a server-side AxoMEME now (axomeme.sh runs a Node CLI
+		// through the standard job lifecycle), so the toggle is a real choice.
+		//
+		// The genetic code is different, and the distinction is the point of this test. Neither
+		// surface can honour one: the model's tokenizer bakes in the universal table, and the server
+		// descriptor hardcodes genetic_code "Universal" and warns if one is supplied. A control that
+		// reaches nothing implies a capability that does not exist.
 		await freshStart(page);
 		await loadDemoFile(page, 'CD2-slim.fna');
 		await expect(async () => {
@@ -205,9 +211,11 @@ test.describe('AxoMEME', () => {
 
 		await selectMethod(page, 'AxoMEME');
 		const body = await page.locator('body').innerText();
-		expect(body).not.toMatch(/Backend Server/i);
-		expect(body).toMatch(/Runs in your browser/i);
+		// The mode toggle is now OFFERED for AxoMEME -- that is the capability the server added.
+		expect(body, 'the execution-mode toggle should be available now').toMatch(/Backend Server/i);
+		// The genetic code still is not, on either surface.
 		expect(body).toMatch(/cannot be changed for this method/i);
+		expect(body).not.toMatch(/Genetic Code:/i);
 
 		// And the controls must come back for a method that does have them.
 		await selectMethod(page, 'FEL');

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -132,11 +132,14 @@
 		});
 
 		try {
-			// AxoMEME is dispatched BEFORE the backend/WASM split, because it belongs to neither. It is
-			// not a HyPhy analysis: no hyphy.wasm invocation, no server job, no HyPhy JSON. It runs an
-			// ONNX graph in this tab and returns in seconds. The executionMode toggle does not apply —
-			// there is no server-side AxoMEME yet — so it is deliberately ignored rather than silently
-			// routing a browser-only method through a socket that has no handler for it.
+			// AxoMEME is handled here because the IN-BROWSER path belongs to neither of the two
+			// branches below: no hyphy.wasm invocation, no HyPhy JSON, just an ONNX graph evaluated in
+			// this tab. It is still not a HyPhy analysis on the server either — axomeme.sh runs a Node
+			// CLI rather than HYPHYMPI — but it now goes through the standard job lifecycle, so a
+			// backend run falls through to the ordinary split and needs nothing special here.
+			//
+			// The executionMode toggle is therefore real for AxoMEME now; it used to be ignored because
+			// there was no server-side implementation to route to.
 			if (method.toLowerCase() === 'axomeme') {
 				if (!$currentFile || !$currentFile.id) {
 					throw new Error('No file selected for analysis');
@@ -184,23 +187,27 @@
 					);
 				}
 
-				const { axomemeAnalysisRunner } = await import('./services/AxomemeAnalysisRunner.js');
-				// No toast here, and no rethrow. BaseAnalysisRunner.completeAnalysis already fires one on
-				// success (with a View Results action) and one on failure, so doing it again stacked two
-				// toasts on every run — and letting the runner's rethrow reach the outer catch stacked a
-				// second error toast on top of that. The other two branches do not rethrow on the normal
-				// path, which is why only AxoMEME double-reported.
-				try {
-					return await axomemeAnalysisRunner.runAnalysis(
-						method,
-						config,
-						alignment,
-						tree,
-						$currentFile.id
-					);
-				} catch (error) {
-					console.error('AxoMEME analysis failed:', error);
-					return null;
+				// Only the browser path is special-cased. A backend run falls through to the standard
+				// split, which already knows how to spawn `<method>:spawn` and track a job.
+				if (config.executionMode !== 'backend') {
+					const { axomemeAnalysisRunner } = await import('./services/AxomemeAnalysisRunner.js');
+					// No toast here, and no rethrow. BaseAnalysisRunner.completeAnalysis already fires one on
+					// success (with a View Results action) and one on failure, so doing it again stacked two
+					// toasts on every run — and letting the runner's rethrow reach the outer catch stacked a
+					// second error toast on top of that. The other two branches do not rethrow on the normal
+					// path, which is why only AxoMEME double-reported.
+					try {
+						return await axomemeAnalysisRunner.runAnalysis(
+							method,
+							config,
+							alignment,
+							tree,
+							$currentFile.id
+						);
+					} catch (error) {
+						console.error('AxoMEME analysis failed:', error);
+						return null;
+					}
 				}
 			}
 

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1035,6 +1035,14 @@
 	 *     nothing, which is the worst of the three options.
 	 */
 	$: browserOnly = Boolean(currentMethod?.config?.browserOnly);
+	// Separate from browserOnly on purpose. AxoMEME now HAS a server-side implementation, so the
+	// execution-mode toggle applies to it -- but neither implementation can honour a genetic code,
+	// because the model's tokenizer bakes in the universal table and the server descriptor hardcodes
+	// it. Conflating "runs only in the browser" with "has no genetic code" meant enabling the first
+	// would silently have re-enabled a control that reaches nothing.
+	$: noGeneticCode = Boolean(
+		currentMethod?.config?.noGeneticCode || currentMethod?.config?.browserOnly
+	);
 	// Keep the reported mode honest for analytics and the run-started toast — but REMEMBER what the
 	// user chose and give it back.
 	//
@@ -1457,9 +1465,10 @@
 						<span class="options-label">Essential</span>
 					</div>
 
-					{#if browserOnly}
+					{#if noGeneticCode}
 						<p class="browser-only-note">
-							This model reads the standard genetic code. It cannot be changed for this method.
+							This model reads the standard genetic code. It cannot be changed for this method, in
+							the browser or on the server.
 						</p>
 					{:else}
 						<div class="option-group">

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -611,6 +611,32 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 					'kill-zero-lengths': config.killZeroLengths || config['kill-zero-lengths'] || 'No'
 				};
 
+			case 'axomeme': {
+				// AxoMEME is a neural surrogate, not a HyPhy method, and the server descriptor
+				// (app/axomeme/descriptor.js) reflects that: no genetic code, no branch selection, no
+				// p-value. NOTE that `gencodeid` from baseParams is deliberately NOT spread in here --
+				// the server's validateParameters override WARNS when genetic_code is supplied for
+				// axomeme, because universal is baked into the model's tokenizer. Sending it would
+				// produce a warning on every single run for a value that cannot be honoured.
+				const maxSpecies = parseInt(config.maxSpecies, 10);
+				return {
+					analysis_type: 'axomeme',
+					// Whitelisted server-side to ["percentile","zscore","pvalue"]; anything else falls
+					// back to percentile there. Same default as the in-browser path, for the same
+					// reason: the model's predicted LRT rarely reaches the fixed chi-square gates that
+					// pvalue compares against, so pvalue makes the method silent.
+					call_mode: config.callMode || 'percentile',
+					// Clamped to [2, 512] server-side. Sent only when the user set it, so the server's
+					// own default stays the single source of truth.
+					...(Number.isFinite(maxSpecies) ? { max_species: maxSpecies } : {}),
+					// Dropped to "" (auto-pick) server-side unless it matches SAFE_SEQUENCE_NAME. That
+					// whitelist is a security control -- the value is interpolated into a comma-joined
+					// SLURM --export string -- so an unusual FASTA header is silently ignored rather
+					// than rewritten. Send only what the user actually chose.
+					...(config.referenceSequence ? { reference_sequence: config.referenceSequence } : {})
+				};
+			}
+
 			case 'prime':
 				return {
 					...baseParams,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -87,14 +87,20 @@
 		// binary. It is served by AxomemeAnalysisRunner, which evaluates an ONNX graph in the browser.
 		AxoMEME: {
 			command: null,
+			// Null for the in-browser path, which writes no HyPhy JSON. A backend run does produce a
+			// results file, under the server descriptor's AXOMEME suffix.
 			outputSuffix: null,
 			url: 'axomeme',
 			args: [],
 			runner: 'axomeme',
-			// Drives the UI: no execution-mode toggle (there is no server-side AxoMEME) and no genetic
-			// code selector (the model's tokenizer bakes in the universal table). A control that cannot
-			// reach the model is worse than no control, because it implies a capability.
-			browserOnly: true,
+			// There IS a server-side AxoMEME now (axomeme.sh runs a Node CLI through the standard job
+			// lifecycle), so the execution-mode toggle is real and `browserOnly` is gone.
+			//
+			// The genetic-code suppression stays, and is now its own flag rather than a side effect of
+			// browserOnly: the model's tokenizer bakes in the universal table, and the SERVER agrees --
+			// its descriptor hardcodes genetic_code "Universal" and warns if one is supplied. A control
+			// that cannot reach the model is worse than no control, because it implies a capability.
+			noGeneticCode: true,
 			description:
 				'Predicts what MEME would report for each site, in seconds rather than hours. A neural surrogate, not a substitute for the full analysis.'
 		},

--- a/src/test/axomeme-backend-params.test.js
+++ b/src/test/axomeme-backend-params.test.js
@@ -1,0 +1,66 @@
+/**
+ * Parameter mapping for server-side AxoMEME.
+ *
+ * Verified against the running server (localhost:7015) before these were written: the payload built
+ * here spawns a real job and returns results whose modelSha256 matches the browser path's
+ * VERIFIED_MODEL_SHA256, so both surfaces run the same checkpoint.
+ *
+ * The load-bearing assertion is a NEGATIVE one — `gencodeid` must not be sent. Every other method
+ * spreads it in from baseParams, and the server's validateParameters override WARNS when a genetic
+ * code is supplied for axomeme, because universal is baked into the model's tokenizer. Sending it
+ * would produce a warning on every run for a value that cannot be honoured, and the natural way to
+ * write this case (spreading baseParams like its neighbours) reintroduces it silently.
+ */
+import { describe, it, expect } from 'vitest';
+import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
+
+const prep = (config = {}) => backendAnalysisRunner.prepareAnalysisParameters('axomeme', config);
+
+describe('AxoMEME backend parameters', () => {
+	it('never sends a genetic code', () => {
+		const p = prep({ geneticCodeId: 1, geneticCode: 'Vertebrate mitochondrial' });
+		expect(p.gencodeid, 'the server warns on genetic_code for axomeme').toBeUndefined();
+		expect(p.genetic_code).toBeUndefined();
+	});
+
+	it('identifies itself as axomeme', () => {
+		expect(prep().analysis_type).toBe('axomeme');
+	});
+
+	it('defaults call_mode to percentile, matching the in-browser path', () => {
+		// Not the reference driver's pvalue default: the model's predicted LRT rarely reaches the
+		// fixed chi-square gates pvalue compares against, so pvalue makes the method silent.
+		expect(prep().call_mode).toBe('percentile');
+	});
+
+	it('passes the chosen call mode through', () => {
+		for (const mode of ['percentile', 'zscore', 'pvalue']) {
+			expect(prep({ callMode: mode }).call_mode).toBe(mode);
+		}
+	});
+
+	it('omits max_species unless the user set one', () => {
+		// The server clamps to [2, 512] and defaults to 512. Omitting it keeps that the single source
+		// of truth rather than duplicating the default on the client where it can drift.
+		expect(prep()).not.toHaveProperty('max_species');
+		expect(prep({ maxSpecies: 128 }).max_species).toBe(128);
+	});
+
+	it('ignores a non-numeric max_species rather than forwarding garbage', () => {
+		expect(prep({ maxSpecies: 'lots' })).not.toHaveProperty('max_species');
+	});
+
+	it('omits reference_sequence unless chosen', () => {
+		// Dropped to "" server-side unless it matches SAFE_SEQUENCE_NAME, which is a security control:
+		// the value is interpolated into a comma-joined SLURM --export string.
+		expect(prep()).not.toHaveProperty('reference_sequence');
+		expect(prep({ referenceSequence: 'HIV1_B_US_1983' }).reference_sequence).toBe('HIV1_B_US_1983');
+	});
+
+	it('sends no branch selection or p-value', () => {
+		// AxoMEME honours neither; the descriptor has no field for either.
+		const p = prep({ branchesToTest: 'Internal', pValueThreshold: 0.05 });
+		expect(p.branches).toBeUndefined();
+		expect(p.pvalue).toBeUndefined();
+	});
+});


### PR DESCRIPTION
The backend team added a server-side AxoMEME. `axomeme.sh` runs `lib/axomeme/cli.js` as a Node process rather than HYPHYMPI, but the job lifecycle is the standard `analysis-factory` one, so it is reachable at `axomeme:spawn` like any other method. The client suppressed the execution-mode toggle for AxoMEME because there was nothing to route to — there is now.

## Verified against the running server first

Before writing the integration I probed `localhost:7015` with exactly the payload the client builds:

```
[status update] {"id":"probe-12345","analysis_type":"axomeme","phase":"running","scheduler":"slurm"}
[completed]     {"method":"AxoMEME","modelSha256":"3e06b591a060fca9...","sites":[...]}
```

- `modelSha256` matches the browser path's `VERIFIED_MODEL_SHA256` — **both surfaces run the same checkpoint**
- Result schema is identical: same top-level keys (`method, modelVersion, modelSha256, isSurrogate, surrogateFor, sites, summary`) and same per-site keys (`site, refCodon, refAa, isVariable, lrt, logLrt, alphaDs, betaPosDn, pPos, zScore, percentile, call`), so `AxomemeResults` renders a server run unchanged

## `gencodeid` is deliberately not sent

Every other method spreads it in from `baseParams`, and the natural way to write this case would too. But the server's `validateParameters` override **warns** when a genetic code is supplied for axomeme, because universal is baked into the model's tokenizer. Sending it would produce a warning on every run for a value nothing can honour.

There is a test whose entire job is to fail if someone later tidies this case to match its neighbours.

## `max_species` / `reference_sequence` sent only when set

So the server's clamp (`[2, 512]`, default 512) and its `SAFE_SEQUENCE_NAME` whitelist stay the single source of truth rather than being duplicated client-side where they drift. That whitelist is a security control — the value is interpolated into a comma-joined SLURM `--export` string.

## `browserOnly` split into two flags

It was gating **both** the mode toggle and the genetic-code suppression, and only the first has changed. AxoMEME has a server now, but neither surface can honour a genetic code — the model's tokenizer bakes in the universal table and the server descriptor hardcodes it. Enabling the toggle without splitting the flag would silently have restored a control that reaches nothing.

The tree-with-branch-lengths guard stays on both paths; the server rejects topology-only trees before spawning, same as the browser check.

## Verification

- **614 unit tests / 35 files**, 8 of them new for the parameter mapping
- Build clean
- `19-axomeme` + `20-run-strip` e2e: 11 passed
- Live server round-trip as above

**One existing e2e was rewritten.** `suppresses controls that cannot reach the model` asserted the mode toggle was hidden. That is no longer correct and shouldn't be — it now asserts the toggle *is* offered while the genetic code is still suppressed, which is the distinction that actually matters.

## Not included

No UI for `max_species` or `reference_sequence`. The server defaults are sensible and the browser path uses the same 512 cap; adding controls is a separate question about whether users need them exposed.
