### PR TITLE
Complete backend analyses in real time again

### DIFF
--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -105,9 +105,14 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 	setupGlobalHandlers() {
 		// Generic handlers that work for all analysis methods
 		this.socket.on('status update', (status) => {
+			// The server sends the job id as `id`, not `jobId` (verified live). Reading both means
+			// progress routes correctly even with concurrent jobs, instead of falling through to the
+			// single-job heuristic below every time.
+			const statusJobId = status.jobId ?? status.id ?? null;
+
 			// Try to find the analysis ID for this status update
-			if (status.jobId && this.activeAnalyses.has(status.jobId)) {
-				const analysisId = this.activeAnalyses.get(status.jobId);
+			if (statusJobId && this.activeAnalyses.has(statusJobId)) {
+				const analysisId = this.activeAnalyses.get(statusJobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -140,15 +145,38 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 
 			const results = data.results || data;
 
-			// Route strictly by jobId. Completing the "first" active analysis on a
-			// missing/unmatched jobId would misroute results between concurrent jobs.
-			if (data.jobId && this.activeAnalyses.has(data.jobId)) {
-				const analysisId = this.activeAnalyses.get(data.jobId);
+			// ROUTING, and why it is not simply "by jobId".
+			//
+			// #166 made this route strictly by jobId, because completing "the first active analysis"
+			// on an unmatched id misroutes results between concurrent jobs. That was right about the
+			// hazard and wrong about the data: the server's `completed` packet carries only
+			// { results, type }. It has no jobId and no id -- verified against a live server, where
+			// `status update` packets DO carry `id` but `completed` does not
+			// (lib/clientsocket.js:60 forwards each redis packet whole, and that one lacks it).
+			//
+			// So strict routing silently completed nothing, for every backend method, and a finished
+			// analysis only appeared after a page refresh. The old fallback had been masking it.
+			//
+			// The rule below keeps the protection and restores the behaviour: attribute by jobId when
+			// one is present, otherwise attribute ONLY when exactly one analysis is in flight -- in
+			// which case the event cannot belong to anything else. With two or more and no id, there
+			// is genuinely no way to tell, so it refuses rather than guessing. That is strictly safer
+			// than pre-#166 (which completed the first of N) and strictly more useful than post-#166
+			// (which completed none of 1). See issue #208 for the server-side fix that removes the
+			// ambiguity entirely.
+			const jobId = data.jobId ?? data.id ?? null;
+
+			if (jobId && this.activeAnalyses.has(jobId)) {
+				const analysisId = this.activeAnalyses.get(jobId);
 				await this.completeAnalysis(analysisId, true, results);
-				this.activeAnalyses.delete(data.jobId);
+				this.activeAnalyses.delete(jobId);
+			} else if (!jobId && this.activeAnalyses.size === 1) {
+				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				await this.completeAnalysis(analysisId, true, results);
+				this.activeAnalyses.delete(onlyJobId);
 			} else {
-				console.warn('⚠️ Completed event without a matching jobId, ignoring to avoid misrouting:', {
-					receivedJobId: data.jobId,
+				console.warn('⚠️ Completed event cannot be attributed; ignoring to avoid misrouting:', {
+					receivedJobId: jobId,
 					activeAnalysesCount: this.activeAnalyses.size
 				});
 			}
@@ -177,9 +205,17 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				const analysisId = this.activeAnalyses.get(errorJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(errorJobId);
+			} else if (!errorJobId && this.activeAnalyses.size === 1) {
+				// Same reasoning as the completed handler: with exactly one job in flight the error
+				// cannot belong to anything else, and refusing to attribute it leaves a failed run
+				// sitting at "running" forever. With two or more it is genuinely ambiguous, so the
+				// branch below still refuses rather than killing an innocent concurrent job.
+				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				await this.completeAnalysis(analysisId, false, null, userFacingError);
+				this.activeAnalyses.delete(onlyJobId);
 			} else {
 				console.warn(
-					'⚠️ Script error without a matching jobId, not failing any analysis to avoid killing concurrent jobs:',
+					'⚠️ Script error cannot be attributed, not failing any analysis to avoid killing concurrent jobs:',
 					{
 						receivedJobId: errorJobId,
 						activeAnalysesCount: this.activeAnalyses.size

--- a/src/test/state-qa-regressions.test.js
+++ b/src/test/state-qa-regressions.test.js
@@ -166,6 +166,56 @@ describe('#166 backend socket events route strictly by jobId', () => {
 		expect(runner.activeAnalyses.size).toBe(2);
 	});
 
+	// ---------------------------------------------------------------------------------------
+	// #208 — the server does not send a jobId on `completed`, so strict routing completed nothing
+	// ---------------------------------------------------------------------------------------
+
+	it('completes the only in-flight analysis when the event carries no jobId', async () => {
+		// The server's `completed` packet is { results, type } -- no jobId, no id (verified against a
+		// live server). #166 made routing strict, which was right about the hazard and wrong about
+		// the data: it silently completed nothing for EVERY backend method, and a finished analysis
+		// only appeared after a page refresh.
+		runner.activeAnalyses.clear();
+		runner.activeAnalyses.set('job-only', 'analysis-only');
+
+		await handlers['completed']({ results: { ok: true } });
+
+		expect(completed.map((c) => c.analysisId)).toEqual(['analysis-only']);
+		expect(runner.activeAnalyses.size).toBe(0);
+	});
+
+	it('still refuses when there is no jobId and more than one job is in flight', async () => {
+		// Genuinely ambiguous. This is the case #166 existed for, and it must keep refusing.
+		await handlers['completed']({ results: { ok: true } });
+		expect(completed, 'guessed between two concurrent jobs').toEqual([]);
+		expect(runner.activeAnalyses.size).toBe(2);
+	});
+
+	it('does NOT fall back to the single job when an unmatched jobId is present', async () => {
+		// The subtle one. A jobId that does not match is positive evidence the event belongs to
+		// something else -- a stale job, another tab. Absence of an id is ambiguity; a wrong id is
+		// information, and falling back on it would reintroduce the misrouting #166 removed.
+		runner.activeAnalyses.clear();
+		runner.activeAnalyses.set('job-only', 'analysis-only');
+
+		await handlers['completed']({ jobId: 'job-SOMEONE-ELSE', results: { ok: true } });
+
+		expect(completed, 'attributed an event that named a different job').toEqual([]);
+		expect(runner.activeAnalyses.size).toBe(1);
+	});
+
+	it('fails the only in-flight analysis on an unattributed script error', async () => {
+		// Otherwise a failed run sits at "running" forever -- the #165 symptom by another route.
+		runner.activeAnalyses.clear();
+		runner.activeAnalyses.set('job-only', 'analysis-only');
+
+		await handlers['script error']({ message: 'boom' });
+
+		expect(completed).toHaveLength(1);
+		expect(completed[0].analysisId).toBe('analysis-only');
+		expect(completed[0].success).toBe(false);
+	});
+
 	it('fails only the analysis whose jobId matched', async () => {
 		await handlers['script error']({ jobId: 'job-A', message: 'boom' });
 		expect(completed).toHaveLength(1);


### PR DESCRIPTION
A finished server-side analysis stayed at "running" until the page was refreshed. **This affected every backend method, not just AxoMEME, and I caused it in #166.**

## What happened

#166 made socket routing strict — complete only the analysis whose `jobId` matches — because completing "the first active analysis" on an unmatched id misroutes results between concurrent jobs. Right about the hazard, wrong about the data.

Verified against the live server: the `completed` packet is

```json
{ "results": "...", "type": "completed" }
```

No `jobId`. No `id`. `status update` packets *do* carry `id`, but `completed` does not — `lib/clientsocket.js:60` forwards each redis packet whole and that one lacks the field.

So strict routing matched nothing, every time. The old fallback had been masking the gap rather than causing harm.

## The rule now

1. Attribute by id when one is present (`jobId` or `id`).
2. Otherwise attribute **only when exactly one analysis is in flight** — the event cannot belong to anything else.
3. With two or more and no id, still refuse. That is genuinely ambiguous and is the case #166 existed for.

Strictly safer than pre-#166 (which completed the first of N) and strictly more useful than post-#166 (which completed none of 1). It is also **the same rule `status update` in this file has always used**, which is a good sign it is the right shape.

**An unmatched id does not fall back to the single-job rule.** Absence of an id is ambiguity; a *wrong* id is information — it says the event belongs to something else, a stale job or another tab — and guessing past it reintroduces exactly what #166 removed. There is a test for that distinction specifically.

## Also fixed

- **`script error` had the same defect.** An unattributable failure left the run at "running" forever, which is the #165 symptom reached by another route.
- **`status update` now reads `id` as well as `jobId`**, so progress routes correctly with concurrent jobs instead of falling through to the single-job heuristic every time.

## Verification

4 new tests in the #166 block, verified to fail with the fix reverted:

```
REVERT: strict jobId only
  × completes the only in-flight analysis when the event carries no jobId
  Tests  1 failed | 18 passed (19)
```

The three #166 protections still pass unchanged. Full suite **610 passed / 34 files**, build clean.

## The real fix is server-side

Put the job id in the completed packet and the ambiguity disappears entirely — then rule 2 becomes dead code and concurrent backend jobs become safe. Filed as a separate issue against the server.
