### PR TITLE
Stop dumping raw result JSON under methods that have a visualisation

### DIFF
--- a/e2e/08-results.spec.js
+++ b/e2e/08-results.spec.js
@@ -5,6 +5,15 @@
 import { test, expect } from './fixtures/coverage.js';
 import { freshStart, seedCompletedAnalysis, MOCK_FEL_RESULT } from './fixtures/helpers.js';
 
+/** Open the Results tab and select the first analysis card. */
+async function openFirstResult(page) {
+	await page.locator('button:has-text("Results")').first().click();
+	const card = page.locator('[data-testid="analysis-card"]').first();
+	await expect(card).toBeVisible({ timeout: 10000 });
+	await card.click();
+	await expect(page.locator('[data-testid="analysis-viewer"]')).toBeVisible({ timeout: 10000 });
+}
+
 test.describe('Results Tab', () => {
 	test.beforeEach(async ({ page }) => {
 		await freshStart(page);
@@ -52,23 +61,28 @@ test.describe('Results Tab', () => {
 		await expect(exportSection.first()).toBeVisible({ timeout: 10000 });
 	});
 
-	test('View in HyPhy-eye button present', async ({ page }) => {
-		const resultsTab = page.locator('button:has-text("Results")').first();
-		await resultsTab.click();
-		await page.waitForTimeout(1000);
+	// Replaces 'View in HyPhy-eye button present', which asserted the button if it was there and the
+	// viewer if it was not — it could not fail. It could not even have detected the button: the seed
+	// helper lowercases, and the markup was gated on a case-sensitive list of uppercase method names.
+	//
+	// storedMethod is UPPERCASE deliberately, because that is what every runner persists
+	// (WasmAnalysisRunner/BackendAnalysisRunner call method.toUpperCase()). Lowercasing it back to the
+	// helper default would make all three assertions pass on the unfixed page and quietly neuter this.
+	test('completed results carry no hyphy-eye link', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: MOCK_FEL_RESULT,
+			method: 'FEL',
+			storedMethod: 'FEL',
+			fileName: 'bglobin.nex'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
 
-		const card = page.locator('[data-testid="analysis-card"]').first();
-		await card.click();
-		await page.waitForTimeout(3000);
-
-		// The hyphy-eye button/link may say various things
-		const hyphyEyeBtn = page.locator('text=/[Hh]y[Pp]hy/');
-		if (await hyphyEyeBtn.count() > 0) {
-			await expect(hyphyEyeBtn.first()).toBeVisible();
-		} else {
-			// If hyphy-eye button is not present, at least the viewer should be visible
-			const viewer = page.locator('[data-testid="analysis-viewer"]');
-			await expect(viewer).toBeVisible();
-		}
+		await expect(page.getByRole('button', { name: /View in HyPhy-eye/i })).toHaveCount(0);
+		await expect(page.getByText(/automatically shared via localStorage/i)).toHaveCount(0);
+		// The other arm: a manual-upload link, shown for exactly the methods hyphy-eye has no page for.
+		await expect(page.locator('[data-testid="analysis-viewer"] a[href*="hyphy"]')).toHaveCount(0);
 	});
 });

--- a/e2e/08-results.spec.js
+++ b/e2e/08-results.spec.js
@@ -61,6 +61,62 @@ test.describe('Results Tab', () => {
 		await expect(exportSection.first()).toBeVisible({ timeout: 10000 });
 	});
 
+	// A visualisation REPLACES the raw JSON, it does not sit on top of one. Both halves of that
+	// sentence are asserted here on purpose; an earlier version of this file only checked that the
+	// viewer was visible, which the buggy page satisfied too.
+	test('a method with a visualisation renders no raw JSON dump', async ({ page }) => {
+		await openFirstResult(page);
+
+		await expect(page.locator('[data-testid="analysis-viewer"] .hyphy-scope-container')).toBeVisible(
+			{ timeout: 10000 }
+		);
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toHaveCount(0);
+	});
+
+	// The other direction, so the fix above cannot be "simplified" into deleting the dump outright.
+	// NRM has no hyphy-scope visualiser (getHyphyScopeVisualization returns null for it), so the raw
+	// document IS its result view.
+	//
+	// This was written as a guard but turns out to be a pin: on the unfixed page 'NRM' IS in the
+	// hardcoded whitelist, so it entered a branch whose every child is gated on a HyPhy result shape
+	// HyPhy does not emit (`input.file`, an array `fits`, `tested.sites`) and rendered NOTHING —
+	// a completed NRM run showed a heading, an export panel and no results at all.
+	test('a method with no visualisation keeps the raw JSON dump', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: MOCK_FEL_RESULT,
+			method: 'NRM',
+			storedMethod: 'NRM',
+			fileName: 'nrm-fixture.fasta'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
+
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toBeVisible({
+			timeout: 10000
+		});
+	});
+
+	// The leftover developer panel. Seeded without `test results` so AbsrelVisualizationWrapper takes
+	// its own error branch and hyphy-scope's AbsrelVisualization is never handed a mock it would
+	// choke on — the panel under test rendered above the visualisation either way.
+	test('no aBSREL debug panel above the visualisation', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: JSON.stringify({ input: { 'file name': 'bglobin.nex' } }),
+			method: 'ABSREL',
+			storedMethod: 'ABSREL',
+			fileName: 'bglobin.nex'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
+
+		// A closed <details> still renders its <summary>, so count-0 is the right assertion.
+		await expect(page.getByText('Debug: aBSREL Data Structure')).toHaveCount(0);
+	});
+
 	// Replaces 'View in HyPhy-eye button present', which asserted the button if it was there and the
 	// viewer if it was not — it could not fail. It could not even have detected the button: the seed
 	// helper lowercases, and the markup was gated on a case-sensitive list of uppercase method names.

--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -149,6 +149,20 @@ test.describe('AxoMEME', () => {
 		await expect(page.locator('.axomeme-visualization')).toBeVisible();
 		await expect(page.locator('.axomeme-plot svg').first()).toBeVisible({ timeout: 20000 });
 
+		// And NOTHING dumps the stored result underneath it. This is the production-shaped check for
+		// the raw-JSON removal: this run persists method 'AXOMEME' (uppercase, via
+		// AxomemeAnalysisRunner), which is what made it miss the old hardcoded whitelist and fall
+		// through to the generic dump. `modelSha256` is a key only a JSON.stringify of the stored
+		// result can produce, so it catches the dump wherever in the result pane it is rendered — the
+		// class name alone would miss a second <pre> in a different branch, which is exactly what the
+		// first attempt at this fix left behind.
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toHaveCount(0);
+		await expect(
+			page.locator('[data-testid="analysis-viewer"] .result-content pre', {
+				hasText: 'modelSha256'
+			})
+		).toHaveCount(0);
+
 		// Rank is a first-class column and the score is NOT labelled LRT. Measured across 12 real
 		// submissions, the model's predicted LRT clears the chi-square gates once in 662 sites, so
 		// presenting it as an LRT invites a comparison it cannot support.

--- a/e2e/fixtures/helpers.js
+++ b/e2e/fixtures/helpers.js
@@ -209,9 +209,18 @@ export async function getCompletedCount(page) {
  * Seed a completed analysis into IndexedDB for fast Results tab testing.
  * Uses the same DB schema as the app: 'datamonkey-db' version 2 with 'files' and 'analyses' stores.
  * Returns the analysis ID.
+ *
+ * `storedMethod` overrides the exact string written to the `method` column. It exists because the
+ * default lowercases, and NO runner does: WasmAnalysisRunner writes method.toUpperCase(),
+ * BackendAnalysisRunner writes method.toUpperCase(), AxomemeAnalysisRunner writes 'AXOMEME'. Any
+ * assertion about markup gated on the method string therefore has to opt into the production casing
+ * or it exercises a branch users never reach. Defaults to null so existing callers are unaffected.
  */
-export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', fileName = 'bglobin.nex' } = {}) {
-	return await page.evaluate(async ({ resultJson, method, fileName, dbName, dbVersion }) => {
+export async function seedCompletedAnalysis(
+	page,
+	{ resultJson, method = 'FEL', storedMethod = null, fileName = 'bglobin.nex' } = {}
+) {
+	return await page.evaluate(async ({ resultJson, method, storedMethod, fileName, dbName, dbVersion }) => {
 		function openDB() {
 			return new Promise((resolve, reject) => {
 				const req = indexedDB.open(dbName, dbVersion);
@@ -252,7 +261,7 @@ export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', 
 		analysisTx.objectStore('analyses').put({
 			id: analysisId,
 			fileId: fileId,
-			method: method.toLowerCase(),
+			method: storedMethod ?? method.toLowerCase(),
 			status: 'completed',
 			result: resultJson,
 			createdAt: now - 60000,
@@ -263,5 +272,5 @@ export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', 
 
 		db.close();
 		return analysisId;
-	}, { resultJson, method, fileName, dbName: DB_NAME, dbVersion: DB_VERSION });
+	}, { resultJson, method, storedMethod, fileName, dbName: DB_NAME, dbVersion: DB_VERSION });
 }

--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -3,7 +3,6 @@
 	import { analysisStore } from '../stores/analyses';
 	import { persistentFileStore } from '../stores/fileInfo';
 	import ExportPanel from './ExportPanel.svelte';
-	import FelVisualization from './FelVisualization.svelte';
 	import AxomemeResults from './AxomemeResults.svelte';
 	import AnalysisProgress from './AnalysisProgress.svelte';
 	import { safeParseJSON } from './utils/jsonUtils';
@@ -280,20 +279,6 @@
 								<h3 class="mb-4 text-lg font-semibold">
 									{analysis.method.toUpperCase()} Analysis Visualization
 								</h3>
-								<!-- Debug logging for aBSREL data structure -->
-								{#if analysis.method.toLowerCase() === 'absrel'}
-									<div class="mb-4 text-xs text-text-silver">
-										<details>
-											<summary>Debug: aBSREL Data Structure</summary>
-											<pre
-												class="max-h-40 overflow-auto bg-surface-raised p-2 text-xs">{JSON.stringify(
-													resultData,
-													null,
-													2
-												)}</pre>
-										</details>
-									</div>
-								{/if}
 								<svelte:component this={hyphyScopeComponent} data={resultData} />
 							</div>
 						</div>
@@ -324,98 +309,13 @@
 								</div>
 							{/if}
 						</div>
-					{:else if ['FEL', 'CONTRAST-FEL', 'SLAC', 'MEME', 'BUSTED', 'RELAX', 'FUBAR', 'aBSREL', 'ABSREL', 'GARD', 'MULTI-HIT', 'NRM'].includes(analysis.method)}
-						<!-- Selection analysis results with fallback legacy visualization for FEL -->
-						<div class="selection-analysis">
-							{#if resultData.input && resultData.input.file}
-								<p><strong>Analysis File:</strong> {resultData.input.file}</p>
-							{/if}
-
-							<!-- Legacy FEL visualization (keeping as fallback) -->
-							{#if analysis.method === 'FEL' && !hyphyScopeComponent}
-								<div class="mb-6 mt-6 rounded-lg bg-white p-4 shadow-sm">
-									<h3 class="mb-4 text-lg font-semibold">FEL Analysis Visualization (Legacy)</h3>
-									<FelVisualization {resultData} />
-								</div>
-							{/if}
-
-							{#if resultData.fits && resultData.fits.length > 0}
-								<h3 class="mb-2 text-lg font-bold">Model Fits</h3>
-								<div class="overflow-x-auto">
-									<table class="w-full table-auto">
-										<thead class="bg-surface-sunken">
-											<tr>
-												<th class="p-2 text-left">Model</th>
-												<th class="p-2 text-left">Log Likelihood</th>
-												<th class="p-2 text-left">Parameters</th>
-												<th class="p-2 text-left">AIC</th>
-											</tr>
-										</thead>
-										<tbody>
-											{#each resultData.fits as fit}
-												<tr class="border-b">
-													<td class="p-2">{fit.model || 'Unknown'}</td>
-													<td class="p-2"
-														>{fit.log_likelihood ? fit.log_likelihood.toFixed(2) : 'N/A'}</td
-													>
-													<td class="p-2">{fit.parameters || 'N/A'}</td>
-													<td class="p-2">{fit.AIC ? fit.AIC.toFixed(2) : 'N/A'}</td>
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								</div>
-							{/if}
-
-							{#if resultData.tested && resultData.tested.sites && resultData.tested.sites.length > 0}
-								<h3 class="my-2 text-lg font-bold">Site Results</h3>
-								<div class="max-h-96 overflow-auto">
-									<table class="w-full table-auto">
-										<thead class="sticky top-0 bg-surface-sunken">
-											<tr>
-												<th class="p-2 text-left">Site</th>
-												<th class="p-2 text-left">p-value</th>
-												<th class="p-2 text-left">alpha</th>
-												<th class="p-2 text-left">beta</th>
-												<th class="p-2 text-left">Selection</th>
-											</tr>
-										</thead>
-										<tbody>
-											{#each resultData.tested.sites as site}
-												<tr class="border-b" class:bg-status-warning-bg={site.p <= 0.05}>
-													<td class="p-2">{site.site_index || site.site || 'N/A'}</td>
-													<td class="p-2">{site.p ? site.p.toExponential(2) : 'N/A'}</td>
-													<td class="p-2">{site.alpha ? site.alpha.toFixed(2) : 'N/A'}</td>
-													<td class="p-2">{site.beta ? site.beta.toFixed(2) : 'N/A'}</td>
-													<td class="p-2">
-														{#if site.p <= 0.05}
-															{#if site.beta > site.alpha}
-																<span class="font-bold text-status-error">Positive</span>
-															{:else}
-																<span class="font-bold text-brand-royal">Negative</span>
-															{/if}
-														{:else}
-															<span class="text-text-silver">Neutral</span>
-														{/if}
-													</td>
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								</div>
-							{/if}
-
-							{#if !resultData.tested && !resultData.fits}
-								<pre class="bg-surface-sunken p-2 text-sm">{JSON.stringify(
-										resultData,
-										null,
-										2
-									)}</pre>
-							{/if}
-
-						</div>
-					{:else}
-						<!-- Generic JSON display for other methods -->
+					{:else if !hyphyScopeComponent}
+						<!-- No visualisation exists for this method, so the raw result document IS the result view.
+						     The converse is the point: a method that has a visualisation never gets a megabyte <pre>
+						     stapled underneath it. This was a hardcoded list of method names, which both missed
+						     methods that do have one (AXOMEME, BGM, PRIME, B-STILL) and compared case-sensitively
+						     against a value the runners persist uppercased. NRM is the only method that lands here
+						     today. -->
 						<div class="json-display">
 							<h3 class="mb-2 text-lg font-bold">Analysis Results</h3>
 							<pre class="max-h-96 overflow-auto bg-surface-sunken p-2 text-sm">{JSON.stringify(

--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -6,12 +6,6 @@
 	import FelVisualization from './FelVisualization.svelte';
 	import AxomemeResults from './AxomemeResults.svelte';
 	import AnalysisProgress from './AnalysisProgress.svelte';
-	import { FINAL_HYPHY_EYE_URL } from './config/env';
-	import {
-		shareWithHyphyEye,
-		isMethodSupported,
-		getHyphyEyeUrl
-	} from './utils/hyphyEyeIntegration';
 	import { safeParseJSON } from './utils/jsonUtils';
 	import { formatArguments, formatLogTail, buildDiagnostics } from './utils/analysisDiagnostics.js';
 	import {
@@ -30,7 +24,7 @@
 	import AbsrelVisualizationWrapper from './AbsrelVisualizationWrapper.svelte';
 	import FubarVisualizationWrapper from './FubarVisualizationWrapper.svelte';
 	import MultiHitVisualizationWrapper from './MultiHitVisualizationWrapper.svelte';
-	import { Server, Monitor, ExternalLink } from 'lucide-svelte';
+	import { Server, Monitor } from 'lucide-svelte';
 
 	export let analysisId = null;
 
@@ -419,42 +413,6 @@
 									)}</pre>
 							{/if}
 
-							<!-- HyPhy-eye integration with localStorage sharing -->
-							{#if isMethodSupported(analysis.method)}
-								<div class="mb-4 mt-4 rounded-lg bg-status-info-bg p-4 text-center shadow-sm">
-									<p class="mb-2 text-status-info-text">
-										View results with automatic data sharing:
-									</p>
-									<button
-										on:click={() => shareWithHyphyEye(resultData, analysis.method)}
-										class="inline-flex items-center rounded-md bg-brand-royal px-4 py-2 text-white transition-colors hover:bg-brand-deep"
-									>
-										View in HyPhy-eye
-										<ExternalLink class="ml-1 h-4 w-4" />
-									</button>
-									<p class="mt-2 text-sm text-brand-royal">
-										Analysis results will be automatically shared via localStorage.
-									</p>
-								</div>
-							{:else}
-								<div class="mb-4 mt-4 rounded-lg bg-surface-sunken p-4 text-center shadow-sm">
-									<p class="mb-2">Open results in a new tab:</p>
-									<a
-										href="{FINAL_HYPHY_EYE_URL}/pages/{analysis.method
-											.toLowerCase()
-											.replace('-', '')}"
-										target="_blank"
-										rel="noopener noreferrer"
-										class="inline-flex items-center rounded-md bg-brand-royal px-4 py-2 text-white transition-colors hover:bg-brand-deep"
-									>
-										Open {analysis.method.toUpperCase()} Results in hyphy-eye
-										<ExternalLink class="ml-1 h-4 w-4" />
-									</a>
-									<p class="mt-2 text-sm text-text-slate">
-										Note: You will need to upload your result JSON to hyphy-eye manually.
-									</p>
-								</div>
-							{/if}
 						</div>
 					{:else}
 						<!-- Generic JSON display for other methods -->

--- a/src/test/results-viewer-markup.test.js
+++ b/src/test/results-viewer-markup.test.js
@@ -1,0 +1,26 @@
+/**
+ * Source-level guards on the results viewer (UX audit item 4.3).
+ *
+ * This is a grep test, deliberately. The property it pins is an ABSENCE, and an absence is cheap to
+ * reintroduce and expensive to notice: the e2e pin that covers it needs a production build and a
+ * seeded IndexedDB. This file fails in under a second when someone pastes the markup back, which is
+ * the point at which it is cheapest to fix.
+ *
+ * hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any deployed
+ * build the results are written to localStorage on the DataMonkey origin and the tab that opens is
+ * vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the viewer must
+ * not reference hyphy-eye at all. Note that 'hyphy-scope' — the visualisation library the viewer
+ * legitimately uses — does not match this pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// import.meta.url is not a file: URL under this vitest environment, so resolve from the repo root.
+const source = readFileSync(resolve(process.cwd(), 'src/lib/AnalysisResultViewer.svelte'), 'utf8');
+
+describe('AnalysisResultViewer markup', () => {
+	it('does not link to or import hyphy-eye', () => {
+		expect(source).not.toMatch(/hyphy-?eye/i);
+	});
+});

--- a/src/test/results-viewer-markup.test.js
+++ b/src/test/results-viewer-markup.test.js
@@ -1,16 +1,19 @@
 /**
- * Source-level guards on the results viewer (UX audit item 4.3).
+ * Source-level guards on the results viewer (UX audit items 4.2 and 4.3).
  *
- * This is a grep test, deliberately. The property it pins is an ABSENCE, and an absence is cheap to
- * reintroduce and expensive to notice: the e2e pin that covers it needs a production build and a
- * seeded IndexedDB. This file fails in under a second when someone pastes the markup back, which is
- * the point at which it is cheapest to fix.
+ * These are grep tests, deliberately. Both properties they pin are ABSENCES, and an absence is
+ * cheap to reintroduce and expensive to notice: the e2e pins that cover them need a production
+ * build and, for AxoMEME, a 17 MB model download. This file fails in under a second when someone
+ * pastes the markup back, which is the point at which it is cheapest to fix.
  *
- * hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any deployed
- * build the results are written to localStorage on the DataMonkey origin and the tab that opens is
- * vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the viewer must
- * not reference hyphy-eye at all. Note that 'hyphy-scope' — the visualisation library the viewer
- * legitimately uses — does not match this pattern.
+ * 4.3: hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any
+ * deployed build the results are written to localStorage on the DataMonkey origin and the tab that
+ * opens is vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the
+ * viewer must not reference hyphy-eye at all. Note 'hyphy-scope' — the visualisation library — does
+ * not match this pattern and is unaffected.
+ *
+ * 4.2: the aBSREL debug panel serialised the entire result document into a <details> above the
+ * visualisation for every aBSREL run, on every user's machine.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -22,5 +25,17 @@ const source = readFileSync(resolve(process.cwd(), 'src/lib/AnalysisResultViewer
 describe('AnalysisResultViewer markup', () => {
 	it('does not link to or import hyphy-eye', () => {
 		expect(source).not.toMatch(/hyphy-?eye/i);
+	});
+
+	it('carries no aBSREL debug panel', () => {
+		expect(source).not.toMatch(/Debug: aBSREL/);
+	});
+
+	it('gates the raw JSON dump on the absence of a visualisation, not a method name list', () => {
+		// The old condition was a hardcoded, case-sensitive array of method names; it missed every
+		// method whose stored name is uppercase-but-absent (AXOMEME, BGM, PRIME, B-STILL) and so
+		// rendered a visualisation AND a megabyte <pre> under it.
+		expect(source).toContain('{:else if !hyphyScopeComponent}');
+		expect(source).not.toMatch(/\[\s*'FEL',\s*'CONTRAST-FEL'/);
 	});
 });


### PR DESCRIPTION
Implements UX audit items **4.2, 4.3**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

Removes the raw JSON dump appended beneath four methods' visualisations and the leftover aBSREL debug panel, and removes the HyPhy-eye links.

Note **4.3 follows your verdict, not the audit's proposal**: the document proposed redesigning the link; you wrote "REMOVE hyphy-eye link from the pages", so it is removed rather than reworked.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 605 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
