### PR TITLE
Stop defaulting hours-long runs to the browser, and say what AxoMEME will call

### DIFF
--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -217,11 +217,22 @@ test.describe('AxoMEME', () => {
 		expect(body).toMatch(/cannot be changed for this method/i);
 		expect(body).not.toMatch(/Genetic Code:/i);
 
+		// While a demo is loaded and AxoMEME is selected: the pre-run copy has to state that the
+		// default calling mode ALWAYS flags a share of the variable sites, whether or not any of them
+		// is under selection. The results table says "Top 2%" afterwards; before the run, nothing did.
+		// Asserted on the testid rather than on body text — "percentile ... rank sites" is already on
+		// the page and would pass with this line removed.
+		const consequence = page.locator('[data-testid="axomeme-call-consequence"]');
+		await expect(consequence).toBeVisible();
+		await expect(consequence).toContainText(/top 2%/i);
+
 		// And the controls must come back for a method that does have them.
 		await selectMethod(page, 'FEL');
 		const felBody = await page.locator('body').innerText();
 		expect(felBody).toMatch(/Backend Server/i);
 		expect(felBody).toMatch(/Genetic Code/i);
+		// The consequence line belongs to AxoMEME only.
+		await expect(page.locator('[data-testid="axomeme-call-consequence"]')).toHaveCount(0);
 	});
 });
 

--- a/e2e/21-execution-mode-advice.spec.js
+++ b/e2e/21-execution-mode-advice.spec.js
@@ -1,0 +1,60 @@
+/**
+ * E2E: what the execution-mode panel says before a long run.
+ *
+ * SCOPE, stated because it is a real limitation of this environment: there is no socket.io server in
+ * the e2e run, so the app is always disconnected here and only the DISCONNECTED branch of the advice
+ * is reachable. The connected branch — pre-selecting Backend Server and naming both durations — is
+ * covered by src/test/execution-mode-default.test.js, which mounts the component with
+ * backendConnectivity forced to connected.
+ *
+ * TRAP THIS FILE AVOIDS: asserting a bare duration regex like /1h 39m/ against the page body. The
+ * "Before you run" panel already prints exactly that string on unfixed main, so a body-text
+ * assertion passes either way. Everything below hangs off the advice element's own testid, off the
+ * radios' checked/disabled state, and off the advice agreeing with the panel.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+
+/** The shapes formatTimeDescription() can produce, longest first so '~1h 39m' wins over '~1h'. */
+const DURATION = /~\d+d \d+h|~\d+ days?|~\d+h \d+m|~\d+ hours?|~\d+ min|< 1 minute/;
+
+test.describe('Execution mode advice', () => {
+	test('warns that a slow browser run needs the tab, and agrees with the outlook panel', async ({
+		page
+	}) => {
+		await freshStart(page);
+		// 20 taxa x 85 codons. BGM at that size is 'Slow' in the browser — the app has always known
+		// this and always defaulted to running it here anyway.
+		await loadDemoFile(page, 'large.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+
+		await selectMethod(page, 'BGM');
+
+		const advice = page.locator('[data-testid="execution-mode-advice"]');
+		await expect(advice).toBeVisible();
+		const adviceText = await advice.innerText();
+		expect(adviceText).toMatch(/tab must stay open/);
+		// With no server reachable, nothing may point at one.
+		expect(adviceText).not.toMatch(/on the server/);
+
+		// The duration in the advice is the SAME duration the "Before you run" row prints, because
+		// both read one estimate. Two independently-worded numbers on one screen is the failure this
+		// couples away.
+		const shown = adviceText.match(DURATION);
+		expect(shown, `no duration in advice: ${adviceText}`).not.toBeNull();
+		await expect(page.locator('[data-testid="run-outlook"]')).toContainText(shown[0]);
+
+		// Disconnected: local stays selected and the server radio stays unavailable.
+		await expect(page.locator('input[type="radio"][value="local"]')).toBeChecked();
+		await expect(page.locator('input[type="radio"][value="backend"]')).toBeDisabled();
+
+		// FEL on the same file finishes in under a minute either way, so there is nothing to say.
+		await selectMethod(page, 'FEL');
+		await expect(page.locator('[data-testid="execution-mode-advice"]')).toHaveCount(0);
+		await expect(page.locator('input[type="radio"][value="local"]')).toBeChecked();
+	});
+});

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -13,6 +13,10 @@
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	import { executionAdvice } from './utils/executionAdvice.js';
+	// callModes.js is a leaf (no imports) precisely so this line costs the main chunk nothing but the
+	// constants — see the note at the top of that file.
+	import { describeCallMode, CALL_DEFAULTS } from './services/axomeme/callModes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -151,6 +155,11 @@
 	let geneticCode = 'Universal';
 	let geneticCodeId = 0; // For matching HyPhy numeric codes
 	let executionMode = 'local'; // 'local' or 'backend'
+	// Has the user touched the execution-mode radios for the method+file currently on screen? The
+	// advice below may move the radio, but only until someone disagrees with it: an estimate is a
+	// curve fitted at R² ≈ 0.63, a click is a decision, and the decision wins.
+	let executionModeTouched = false;
+	let lastAdvisedFor = null;
 	let isSubmitting = false; // Track submission state for button feedback
 
 	// WHY THE RUN BUTTON IS BLOCKED, derived from the analysis store rather than a timer.
@@ -1061,6 +1070,50 @@
 		executionModeBeforeBrowserOnly = null;
 	}
 
+	// WHERE THIS RUN SHOULD GO, and why the default is no longer always Local.
+	//
+	// executionMode was hard-coded to 'local' and nothing ever moved it, including for datasets this
+	// app's own estimator calls Very Slow: BGM on 20x255 reads "~2h 15m" in the panel three rows below
+	// these radios while Local sits selected, and a local run dies with the tab. The advice comes from
+	// the same estimator the panel prints, so the two can never contradict each other.
+	//
+	// The counts are read WITHOUT AnalysisTimingEstimate's `|| 10` / `|| 1000` fallbacks. Those exist
+	// so the panel can show its shape before a file is parsed; borrowing them here would let a
+	// fabricated dataset move a radio with nothing loaded.
+	$: seqCount = $fileMetricsStore?.FILE_INFO?.sequences ?? $currentFile?.sequences ?? 0;
+	$: siteCount = $fileMetricsStore?.FILE_INFO?.sites ?? $currentFile?.sites ?? 0;
+	$: advice = executionAdvice({
+		method: selectedMethod,
+		sequences: seqCount,
+		sites: siteCount,
+		methodOptions: methodOptions[selectedMethod] || {},
+		serverConnected: $backendConnectivity.isConnected
+	});
+
+	// A different method, or a different file, is a different question — so the advice gets to answer
+	// it again. Within one method+file, a click is final.
+	$: adviceKey = `${selectedMethod ?? ''}|${$currentFile?.id ?? ''}`;
+	$: if (adviceKey !== lastAdvisedFor) {
+		lastAdvisedFor = adviceKey;
+		executionModeTouched = false;
+	}
+
+	// ORDERED AFTER the browserOnly restore above, deliberately. Both write executionMode; if a
+	// browser-only method ever returns, the restore must have the last word or the two ping-pong.
+	$: if (!executionModeTouched && advice.recommend === 'backend' && executionMode !== 'backend') {
+		executionMode = 'backend';
+	}
+	// Safety rail, and it fixes something older than the advice: pick Backend, lose the socket, and
+	// the radio greys out while executionMode stays 'backend' — the run then throws "Backend server is
+	// not connected" (AnalyzeTab.svelte:215-217) with a disabled radio still claiming to be selected.
+	$: if (!$backendConnectivity.isConnected && executionMode === 'backend') {
+		executionMode = 'local';
+	}
+	// Only true while the recommendation is actually in force. The advice sentence itself never claims
+	// which radio is selected, because the user may have clicked Local a second ago.
+	$: autoSelectedBackend =
+		advice.recommend === 'backend' && !executionModeTouched && executionMode === 'backend';
+
 	// Get current method's advanced options
 	$: currentMethodOptions = selectedMethod
 		? METHOD_ADVANCED_OPTIONS[selectedMethod.toLowerCase()] || {}
@@ -1260,10 +1313,10 @@
 		}
 	}
 
-	// Smart default: suggest backend for larger datasets
-	function getSmartDefault(fileSequenceCount = 0) {
-		return fileSequenceCount > 1000 ? 'backend' : 'local';
-	}
+	// getSmartDefault(fileSequenceCount > 1000 ? 'backend' : 'local') used to live here. It was never
+	// called by anything, and a second, contradicting threshold — sequence count alone, ignoring
+	// sites and the method — would now disagree with executionAdvice() on exactly the datasets this
+	// panel is about (BGM on 20 sequences is hours; FEL on 900 is not).
 
 	// Handle branch selection from interactive tree
 	function handleBranchSelectionChange(event) {
@@ -1400,10 +1453,18 @@
 							bind:group={executionMode}
 							value="local"
 							class="execution-mode-radio"
+							on:change={() => (executionModeTouched = true)}
 						/>
 						<div class="execution-mode-content">
 							<div class="execution-mode-name">Local (Browser)</div>
-							<div class="execution-mode-desc">Fast • Small datasets</div>
+							<!-- "Fast • Small datasets" was a claim about the dataset the app had already
+							     measured and disagreed with. Where there is a fitted equation, say the number;
+							     where there is not, say the consequence, which is true either way. -->
+							<div class="execution-mode-desc">
+								{advice.local
+									? `${advice.local.description} in this tab`
+									: 'Runs in this tab — it must stay open'}
+							</div>
 						</div>
 					</label>
 					<label class="execution-mode-option">
@@ -1413,12 +1474,15 @@
 							value="backend"
 							class="execution-mode-radio"
 							disabled={!$backendConnectivity.isConnected}
+							on:change={() => (executionModeTouched = true)}
 						/>
 						<div class="execution-mode-content">
 							<div class="execution-mode-name">Backend Server</div>
 							<div class="execution-mode-desc">
 								{#if $backendConnectivity.isConnected}
-									Powerful • Large datasets
+									{advice.server
+										? `${advice.server.description} on the server`
+										: 'Runs on the server — you can close the tab'}
 								{:else}
 									Server unavailable
 								{/if}
@@ -1426,10 +1490,26 @@
 						</div>
 					</label>
 				</div>
+				{#if $backendConnectivity.isConnected && advice.advice}
+					<p class="execution-mode-advice" data-testid="execution-mode-advice">
+						{advice.advice}{#if autoSelectedBackend}
+							The server is selected; choose Local to run it here anyway.{/if}
+					</p>
+				{/if}
 				{#if !$backendConnectivity.isConnected}
 					<div class="backend-status-warning">
 						<AlertTriangle class="warning-icon" />
-						<span>Server temporarily unavailable. Please use Local mode.</span>
+						<!-- The slow-run sentence extends the existing warning rather than opening a second,
+						     competing box next to it. The two branches are mutually exclusive, so the testid
+						     stays unique on the page. -->
+						<div class="warning-lines">
+							<span>Server temporarily unavailable. Please use Local mode.</span>
+							{#if advice.advice}
+								<p class="execution-mode-advice" data-testid="execution-mode-advice">
+									{advice.advice}
+								</p>
+							{/if}
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -1562,6 +1642,17 @@
 									{/if}
 								</div>
 							{/each}
+							<!-- What the SELECTED mode will actually do, which the option renderer above cannot
+							     say: it prints one static `config.description` for all three modes, and the
+							     consequence that matters here is specific to one of them. percentile always
+							     calls a fixed share of the variable sites, whether or not any site is under
+							     selection — the results table says so afterwards ("Top 2%"), and before the run
+							     nothing did. -->
+							{#if selectedMethod?.toLowerCase() === 'axomeme'}
+								<p class="call-mode-consequence" data-testid="axomeme-call-consequence">
+									{describeCallMode(methodOptions[selectedMethod]?.callMode ?? CALL_DEFAULTS.mode)}
+								</p>
+							{/if}
 						{:else}
 							<div class="no-options">
 								<span class="no-options-text">This method uses default parameters</span>
@@ -1907,9 +1998,19 @@
 		color: #718096;
 	}
 
+	/* Sits directly under the two radios and reads as their caption, not as an alert: it is a
+	   comparison of two durations the user can act on, and colouring it would make an ordinary
+	   large-dataset run look like an error. */
+	.execution-mode-advice {
+		margin: 8px 0 0;
+		font-size: 12px;
+		line-height: 1.45;
+		color: #4a5568;
+	}
+
 	.backend-status-warning {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 8px;
 		margin-top: 12px;
 		padding: 8px 12px;
@@ -1918,6 +2019,19 @@
 		border-radius: 4px;
 		font-size: 12px;
 		color: #92400e;
+	}
+
+	.warning-lines {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	/* Inside the warning it is a second line of the same message, so it takes the warning's colour
+	   and drops its own top margin. */
+	.backend-status-warning .execution-mode-advice {
+		margin: 0;
+		color: inherit;
 	}
 
 	.warning-icon {
@@ -2163,6 +2277,16 @@
 		margin-top: 4px;
 		line-height: 1.4;
 		font-style: italic;
+	}
+
+	/* Upright, unlike .option-description above it: that one compares the three modes, this one states
+	   what the chosen mode will do to this alignment. Different job, so it should not look like more
+	   of the same caption. */
+	.call-mode-consequence {
+		margin: 8px 0 0;
+		font-size: 12px;
+		line-height: 1.45;
+		color: #4a5568;
 	}
 
 	.option-group.disabled {

--- a/src/lib/services/axomeme/callModes.js
+++ b/src/lib/services/axomeme/callModes.js
@@ -1,0 +1,95 @@
+/**
+ * callModes.js — the tier gates AxoMEME calls sites with, and one sentence saying what each mode
+ * will actually do to this alignment.
+ *
+ * A LEAF MODULE ON PURPOSE. The gates used to live in postprocess.js, which imports tokenizer.js and
+ * its 64-codon genetic-code table. MethodSelector is on every user's critical path and needs the
+ * numbers to describe the choice before a run, so importing postprocess.js there would pull the
+ * model's tokenizer into the main chunk for the fourteen methods that will never touch it — the same
+ * leakage RunOutlook lazy-loads MemeHitLikelihood to avoid. postprocess.js re-exports CALL_DEFAULTS
+ * from here, so every existing import site is unchanged and there is still exactly one definition.
+ */
+
+/**
+ * Default tier gates.
+ *
+ * THE DEFAULT MODE IS `percentile`, WHICH IS NOT THE REFERENCE'S DEFAULT, and the reason is measured
+ * rather than preferential. The reference defaults to `pvalue`, which compares the predicted LRT
+ * against 4.45 and 3.12 — chi-square thresholds for a GENUINE likelihood ratio. The model's output
+ * does not live on that scale. Across 12 real DataMonkey submissions and 662 variable sites, the
+ * highest predicted LRT anywhere was 3.902; exactly one site cleared 3.12 and none cleared 4.45.
+ * On an alignment where MEME itself reports 17 sites at p <= 0.05, the model's maximum was 2.484.
+ *
+ * So under `pvalue` this feature ships reporting nothing on real data. That is not a threshold worth
+ * tuning — it reflects what the model is: a RANKER. The metric its authors report is Spearman rank
+ * correlation, not calibration, and rank correlation can be good while absolute scale is off.
+ * `percentile` asks the question the model can answer — which sites in THIS alignment look most
+ * interesting — instead of one it cannot.
+ *
+ * The gates themselves are unchanged from the driver's argparse (lines 984-991), so switching modes
+ * reproduces the reference exactly.
+ */
+export const CALL_DEFAULTS = Object.freeze({
+	mode: 'percentile',
+	tier1LrtGate: 4.45, // p <= 0.05
+	tier2LrtGate: 3.12, // p <= 0.10
+	tier1Zscore: 2.5,
+	tier2Zscore: 2.0,
+	tier1Percentile: 98.0,
+	tier2Percentile: 95.0
+});
+
+/** Same rounding postprocess.js uses for the tier LABELS, so pre-run copy and the results table
+ *  print the same percentage rather than two roundings of one number. */
+const pct = (n) => n.toFixed(0);
+
+/**
+ * What choosing this mode will do to THIS alignment, in one sentence.
+ *
+ * WHY THIS EXISTS: `percentile` — the default — always calls a fixed share of the variable sites,
+ * whether or not any site is under selection. Ranking is what the model is for, and the results
+ * table is honest about it ("Top 2%" / "Top 5%"), but before the run the only copy was a three-way
+ * comparison of the modes that never said a share is always called. A user running a conserved gene
+ * gets 2% of its variable sites back and has no way to know that was arithmetic rather than a
+ * finding.
+ *
+ * TWO WORDINGS THAT LOOK LIKE NITPICKS AND ARE NOT:
+ *
+ *   - VARIABLE sites, not sites. Percentiles are computed over variable sites only
+ *     (postprocess.js:170-185); invariant sites are zeroed before the model is consulted. On the
+ *     conserved alignments this line is written for, "top 2% of sites" overstates the count by
+ *     whatever fraction of the gene does not vary — which is most of it.
+ *   - The Tier 2 label is the CUMULATIVE "Top 5%", because that is the string the results table
+ *     prints. The tier SET is exclusive (the 95th-98th percentile band, 3% of variable sites), so
+ *     the sentence names both: the band it adds, and the label it will carry.
+ *
+ * @param {string} [mode] - 'percentile' | 'zscore' | 'pvalue'; anything else falls back to the
+ *   default mode's sentence, because that is the mode a missing value actually runs as
+ *   (METHOD_ADVANCED_OPTIONS.axomeme.callMode.default === CALL_DEFAULTS.mode).
+ * @param {object} [cfg] - gates to describe; every number in the sentence is derived from these
+ * @returns {string}
+ */
+export function describeCallMode(mode, cfg = CALL_DEFAULTS) {
+	if (mode === 'zscore') {
+		return (
+			`Flags sites at Z ≥ ${cfg.tier1Zscore} as Tier 1 and Z ≥ ${cfg.tier2Zscore} as Tier 2, ` +
+			`where Z counts standard deviations above this alignment's own mean predicted LRT over its ` +
+			`variable sites — still relative to this alignment, not an absolute test of significance.`
+		);
+	}
+
+	if (mode === 'pvalue') {
+		return (
+			`Flags variable sites with a predicted LRT ≥ ${cfg.tier1LrtGate} as Tier 1 and ` +
+			`≥ ${cfg.tier2LrtGate} as Tier 2. These are fixed chi-square gates rather than ranks, and ` +
+			`the model's predicted LRTs rarely reach them, so this usually reports nothing at all.`
+		);
+	}
+
+	return (
+		`Flags the top ${pct(100 - cfg.tier1Percentile)}% of this alignment's variable sites as Tier 1 ` +
+		`and the next ${pct(cfg.tier1Percentile - cfg.tier2Percentile)}% as Tier 2 (labelled ` +
+		`"Top ${pct(100 - cfg.tier2Percentile)}%"), whether or not any site is under selection. Use it to ` +
+		`prioritise sites for a full MEME run, not to decide significance.`
+	);
+}

--- a/src/lib/services/axomeme/postprocess.js
+++ b/src/lib/services/axomeme/postprocess.js
@@ -23,35 +23,15 @@
  */
 
 import { GENETIC_CODE, aaToken } from './tokenizer.js';
+import { CALL_DEFAULTS } from './callModes.js';
 
 /**
- * Default tier gates.
- *
- * THE DEFAULT MODE IS `percentile`, WHICH IS NOT THE REFERENCE'S DEFAULT, and the reason is measured
- * rather than preferential. The reference defaults to `pvalue`, which compares the predicted LRT
- * against 4.45 and 3.12 — chi-square thresholds for a GENUINE likelihood ratio. The model's output
- * does not live on that scale. Across 12 real DataMonkey submissions and 662 variable sites, the
- * highest predicted LRT anywhere was 3.902; exactly one site cleared 3.12 and none cleared 4.45.
- * On an alignment where MEME itself reports 17 sites at p <= 0.05, the model's maximum was 2.484.
- *
- * So under `pvalue` this feature ships reporting nothing on real data. That is not a threshold worth
- * tuning — it reflects what the model is: a RANKER. The metric its authors report is Spearman rank
- * correlation, not calibration, and rank correlation can be good while absolute scale is off.
- * `percentile` asks the question the model can answer — which sites in THIS alignment look most
- * interesting — instead of one it cannot.
- *
- * The gates themselves are unchanged from the driver's argparse (lines 984-991), so switching modes
- * reproduces the reference exactly.
+ * The tier gates live in callModes.js — a leaf with no imports — so the pre-run copy in
+ * MethodSelector can state what a mode will do without dragging tokenizer.js's genetic-code table
+ * into the main bundle. Re-exported here because this is where every caller already looks for them,
+ * and because one definition is the point of the move.
  */
-export const CALL_DEFAULTS = Object.freeze({
-	mode: 'percentile',
-	tier1LrtGate: 4.45, // p <= 0.05
-	tier2LrtGate: 3.12, // p <= 0.10
-	tier1Zscore: 2.5,
-	tier2Zscore: 2.0,
-	tier1Percentile: 98.0,
-	tier2Percentile: 95.0
-});
+export { CALL_DEFAULTS };
 
 export const NEUTRAL_CALL = 'Neutral';
 

--- a/src/lib/utils/executionAdvice.js
+++ b/src/lib/utils/executionAdvice.js
@@ -1,0 +1,98 @@
+/**
+ * executionAdvice.js — where a submission should run, and what to say about it before it runs.
+ *
+ * Extracted from MethodSelector for the same reason runStatusLine.js was: the decision and the
+ * sentence that explains it are the design, and a design that lives inside a 2000-line component
+ * cannot be tested and drifts. See design/03-run-feedback/.
+ *
+ * THE PROBLEM THIS FILE EXISTS TO FIX: execution mode was hard-coded to 'local' for every method and
+ * every dataset. The app already computed, and already displayed one row away, that BGM on a 20x255
+ * alignment is ~2h 15m in this browser against ~33 min on the server — and still defaulted to the
+ * browser, where a reload or a closed tab loses the run outright.
+ *
+ * TWO RULES KEEP THIS HONEST:
+ *
+ *  1. NEVER INVENT A NUMBER. Only methods with a fitted equation in BACKEND_TIMING_EQUATIONS get
+ *     advice; AxoMEME, PRIME, NRM, B-STILL and FADE have none, and the answer there is silence, not
+ *     a guess. Same rule runStatusLine.js applies to the elapsed row.
+ *  2. THE SENTENCE INTERPOLATES THE ESTIMATE'S OWN `description`, never a re-derived duration, so it
+ *     is impossible for the advice to disagree with the "Before you run" row rendering the same
+ *     field a few pixels below it.
+ */
+
+import { calculateRuntimeEstimate } from './timingEstimates.js';
+
+/**
+ * Categories worth speaking up about. Anything faster runs locally without comment: a browser is the
+ * better place for a two-minute analysis (no queue, no upload), and nagging on fast runs would train
+ * users to ignore the line that matters. Names must match SPEED_CATEGORIES in timingEstimates.js —
+ * execution-advice.test.js pins that.
+ */
+export const SLOW_CATEGORIES = new Set(['slow', 'very-slow']);
+
+/** No fitted equation, or no dataset yet: no estimate, no advice, no moved radio. */
+const NO_ADVICE = Object.freeze({
+	hasEstimate: false,
+	local: null,
+	server: null,
+	recommend: null,
+	advice: null
+});
+
+/**
+ * @param {object} input
+ * @param {string} [input.method] - method key, any case (BGM / bgm both work)
+ * @param {number} [input.sequences]
+ * @param {number} [input.sites] - codon sites, as FILE_INFO reports them
+ * @param {object} [input.methodOptions] - advanced options; some multiply the runtime
+ * @param {boolean} [input.serverConnected] - a recommendation to use a server that is down is worse
+ *   than none, so this gates the whole 'backend' branch
+ * @returns {{hasEstimate: boolean, local: object|null, server: object|null,
+ *   recommend: 'backend'|null, advice: string|null}}
+ */
+export function executionAdvice({
+	method,
+	sequences,
+	sites,
+	methodOptions = {},
+	serverConnected = false
+} = {}) {
+	if (!method || !(sequences > 0) || !(sites > 0)) return NO_ADVICE;
+
+	const local = calculateRuntimeEstimate(method, sequences, sites, 'wasm', methodOptions);
+	// `minutes === null` is how timingEstimates.js reports "no equation for this method". It is not a
+	// zero and must not be treated as a fast run.
+	if (local.minutes === null) return NO_ADVICE;
+
+	const server = calculateRuntimeEstimate(method, sequences, sites, 'backend', methodOptions);
+
+	if (!SLOW_CATEGORIES.has(local.category)) {
+		// Both estimates are still returned: the radio sub-labels state each mode's duration whether or
+		// not there is anything to advise.
+		return { hasEstimate: true, local, server, recommend: null, advice: null };
+	}
+
+	if (serverConnected) {
+		// The comparison, and nothing about which radio is selected. Whether the recommendation is
+		// actually in effect is the component's business — the user may have clicked Local since, and a
+		// sentence claiming "the server is selected" would then be a lie printed next to a Local radio.
+		return {
+			hasEstimate: true,
+			local,
+			server,
+			recommend: 'backend',
+			advice: `${local.description} in this browser vs ${server.description} on the server.`
+		};
+	}
+
+	// No server to send it to, so no recommendation — only the consequence the user is about to
+	// accept. "The tab must stay open" is the fact that costs people work: a local run dies with the
+	// page (analyses.js:672-741).
+	return {
+		hasEstimate: true,
+		local,
+		server,
+		recommend: null,
+		advice: `This will take ${local.description} and the tab must stay open.`
+	};
+}

--- a/src/test/axomeme-call-modes.test.js
+++ b/src/test/axomeme-call-modes.test.js
@@ -1,0 +1,83 @@
+/**
+ * describeCallMode() — the pre-run sentence that says what AxoMEME's calling mode will do.
+ *
+ * The tests that matter here are the DERIVATION ones. Copy that hard-codes "top 2%" is true until
+ * someone retunes tier1Percentile, at which point the pre-run promise and the results table disagree
+ * and nothing fails. Every number in the sentence has to come out of the config it is describing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { describeCallMode, CALL_DEFAULTS } from '../lib/services/axomeme/callModes.js';
+
+describe('describeCallMode', () => {
+	it('states the fixed share percentile mode always calls', () => {
+		const text = describeCallMode('percentile');
+		// The band it flags as Tier 1...
+		expect(text).toContain('top 2%');
+		// ...and the CUMULATIVE label the results table will print for Tier 2 (postprocess.js labels
+		// the 95th-98th band 'Top 5%'). Pre-run copy naming only the exclusive 3% would read as a
+		// contradiction of the results page.
+		expect(text).toContain('Top 5%');
+		expect(text).toContain('next 3%');
+		// VARIABLE sites, not sites: percentiles are computed over variable sites only, and on the
+		// conserved alignments this line exists for that is a small fraction of the gene.
+		expect(text).toMatch(/variable sites/i);
+		// The thing that was missing before: a share is called whether or not anything is selected.
+		expect(text).toMatch(/whether or not any site is under selection/i);
+	});
+
+	it('derives every percentage from the gates rather than hard-coding them', () => {
+		const text = describeCallMode('percentile', {
+			...CALL_DEFAULTS,
+			tier1Percentile: 99,
+			tier2Percentile: 90
+		});
+		expect(text).toContain('top 1%');
+		expect(text).toContain('next 9%');
+		expect(text).toContain('Top 10%');
+		expect(text).not.toContain('2%');
+		expect(text).not.toContain('5%');
+	});
+
+	it('names the z-score gates it is describing', () => {
+		expect(describeCallMode('zscore')).toContain(`Z ≥ ${CALL_DEFAULTS.tier1Zscore}`);
+		// Distinct values, so neither number can pass by being a substring of the other.
+		const text = describeCallMode('zscore', {
+			...CALL_DEFAULTS,
+			tier1Zscore: 3.75,
+			tier2Zscore: 1.25
+		});
+		expect(text).toContain('Z ≥ 3.75');
+		expect(text).toContain('Z ≥ 1.25');
+		expect(text).toMatch(/relative to this alignment/i);
+	});
+
+	it('warns that pvalue mode usually reports nothing', () => {
+		const text = describeCallMode('pvalue');
+		expect(text).toContain(String(CALL_DEFAULTS.tier1LrtGate)); // 4.45
+		expect(text).toContain(String(CALL_DEFAULTS.tier2LrtGate)); // 3.12
+		expect(text).toMatch(/usually reports nothing/i);
+		// It is a fixed gate, not a rank — that distinction is the whole reason pvalue is not default.
+		expect(text).toMatch(/rather than ranks/i);
+	});
+
+	it('falls back to the mode a missing value actually runs as', () => {
+		// METHOD_ADVANCED_OPTIONS.axomeme.callMode.default is CALL_DEFAULTS.mode, so an undefined or
+		// unrecognised mode runs as percentile. The sentence has to describe THAT, not shrug.
+		expect(CALL_DEFAULTS.mode).toBe('percentile');
+		const fallback = describeCallMode('percentile');
+		expect(describeCallMode(undefined)).toBe(fallback);
+		expect(describeCallMode('nonsense')).toBe(fallback);
+	});
+
+	it('keeps one definition of the gates after the move out of postprocess.js', () => {
+		// postprocess.js re-exports rather than re-declares. A fork here would let the results table
+		// and the pre-run copy disagree about the same run.
+		return Promise.all([
+			import('../lib/services/axomeme/postprocess.js'),
+			import('../lib/services/axomeme/callModes.js')
+		]).then(([postprocess, callModes]) => {
+			expect(postprocess.CALL_DEFAULTS).toBe(callModes.CALL_DEFAULTS);
+		});
+	});
+});

--- a/src/test/axomeme-prerun-copy.test.js
+++ b/src/test/axomeme-prerun-copy.test.js
@@ -1,0 +1,91 @@
+/**
+ * AxoMEME's pre-run copy, mounted.
+ *
+ * TRAP THIS FILE AVOIDS: asserting body text like /percentile/ or /rank sites/. Unfixed main already
+ * renders "percentile and zscore rank sites within this alignment…" in the option description, so
+ * such an assertion passes with the fix reverted and proves nothing. What is new is a line that
+ * states the CONSEQUENCE of the mode currently selected — so the assertions are on its testid, and
+ * on the sentence CHANGING when the mode changes.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import MethodSelector from '../lib/MethodSelector.svelte';
+import { fileMetricsStore } from '../stores/fileInfo.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('../lib/utils/indexedDBStorage.js', () => ({
+	fileStorage: {
+		getAllFiles: vi.fn().mockResolvedValue([]),
+		getFile: vi.fn().mockResolvedValue(null),
+		saveFile: vi.fn().mockResolvedValue(true),
+		deleteFile: vi.fn().mockResolvedValue(true)
+	},
+	analysisStorage: {
+		getAllAnalyses: vi.fn().mockResolvedValue([]),
+		saveAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysis: vi.fn().mockResolvedValue(null),
+		deleteAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysesByFileId: vi.fn().mockResolvedValue([]),
+		clearAllAnalyses: vi.fn().mockResolvedValue(true)
+	}
+}));
+
+// The AxoMEME entry from +page.svelte's methodConfig, verbatim in the fields this component reads.
+const methodConfig = {
+	AxoMEME: {
+		command: null,
+		outputSuffix: null,
+		url: 'axomeme',
+		args: [],
+		runner: 'axomeme',
+		noGeneticCode: true,
+		description:
+			'Predicts what MEME would report for each site, in seconds rather than hours. A neural surrogate, not a substitute for the full analysis.'
+	}
+};
+
+/** The 'How to rank sites' control, identified by what it offers rather than by DOM position. */
+function callModeSelect() {
+	return [...document.querySelectorAll('select')].find((s) =>
+		[...s.options].some((o) => o.value === 'pvalue')
+	);
+}
+
+describe('AxoMEME pre-run copy', () => {
+	afterEach(() => {
+		cleanup();
+		fileMetricsStore.set(null);
+	});
+
+	it('says a fixed share is always called, and changes when the mode does', async () => {
+		fileMetricsStore.set({ FILE_INFO: { sequences: 12, sites: 187 } });
+		render(MethodSelector, { props: { methodConfig, runMethod: vi.fn() } });
+		await fireEvent.change(screen.getByTestId('method-dropdown'), {
+			target: { value: 'AxoMEME' }
+		});
+		await tick();
+		await tick();
+
+		const line = screen.getByTestId('axomeme-call-consequence');
+		expect(line.textContent).toMatch(/top 2%/i);
+		// The sentence that was missing: percentile mode calls a share of the alignment regardless of
+		// whether anything in it is under selection.
+		expect(line.textContent).toMatch(/whether or not/i);
+		expect(line.textContent).toMatch(/variable sites/i);
+
+		// THE ASSERTION THAT CANNOT PASS BY ACCIDENT: switching the mode rewrites the consequence.
+		const select = callModeSelect();
+		expect(select, 'call-mode select not found').toBeTruthy();
+		await fireEvent.change(select, { target: { value: 'pvalue' } });
+		await tick();
+		await tick();
+
+		const after = screen.getByTestId('axomeme-call-consequence').textContent;
+		expect(after).toMatch(/usually reports nothing/i);
+		expect(after).toContain('4.45');
+		expect(after).not.toMatch(/top 2%/i);
+	}, 30000);
+});

--- a/src/test/execution-advice.test.js
+++ b/src/test/execution-advice.test.js
@@ -1,0 +1,140 @@
+/**
+ * executionAdvice() — which mode a submission defaults to, and what the panel says about it.
+ *
+ * The assertions below compare against the ESTIMATOR'S OWN output rather than against literal
+ * durations ('~2h 15m'). A literal would turn every retune of the fitted equations into a red test
+ * for no reason, and — worse — would let the advice and the "Before you run" row drift apart while
+ * both stayed green. The point of the module is that they read from one place.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { executionAdvice, SLOW_CATEGORIES } from '../lib/utils/executionAdvice.js';
+import { calculateRuntimeEstimate, SPEED_CATEGORIES } from '../lib/utils/timingEstimates.js';
+
+// A real dataset shape from the bundled demos. BGM at this size is 'very-slow' locally and 'slow' on
+// the server — the exact case where defaulting to the browser costs a user hours.
+const SEQS = 20;
+const SITES = 255;
+
+describe('executionAdvice', () => {
+	it('recommends the server for a slow local run when the server is up', () => {
+		const result = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+
+		const local = calculateRuntimeEstimate('bgm', SEQS, SITES, 'wasm');
+		const server = calculateRuntimeEstimate('bgm', SEQS, SITES, 'backend');
+
+		expect(result.hasEstimate).toBe(true);
+		expect(result.recommend).toBe('backend');
+		expect(result.advice).toContain(local.description);
+		expect(result.advice).toContain(server.description);
+		// Both estimates travel with the advice so the radio sub-labels can print them.
+		expect(result.local.description).toBe(local.description);
+		expect(result.server.description).toBe(server.description);
+	});
+
+	it('never promises a server that is down', () => {
+		const result = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: false
+		});
+
+		const local = calculateRuntimeEstimate('bgm', SEQS, SITES, 'wasm');
+		const server = calculateRuntimeEstimate('bgm', SEQS, SITES, 'backend');
+
+		expect(result.recommend).toBeNull();
+		expect(result.advice).toMatch(/tab must stay open/);
+		expect(result.advice).toContain(local.description);
+		// THE ASSERTION THAT MATTERS: no server duration anywhere in the sentence. Offering "~33 min on
+		// the server" while the socket is down is advice the user cannot act on.
+		expect(result.advice).not.toContain(server.description);
+	});
+
+	it('says nothing about a run that is not slow', () => {
+		const result = executionAdvice({
+			method: 'fel',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+
+		expect(result.hasEstimate).toBe(true);
+		expect(SLOW_CATEGORIES.has(result.local.category)).toBe(false);
+		expect(result.recommend).toBeNull();
+		expect(result.advice).toBeNull();
+		// Still carries both estimates: the sub-labels state durations even when there is no advice.
+		expect(result.local.description).toBeTruthy();
+		expect(result.server.description).toBeTruthy();
+	});
+
+	it('invents nothing for a method with no fitted equation', () => {
+		// AxoMEME, PRIME, NRM, B-STILL and FADE are absent from BACKEND_TIMING_EQUATIONS. A guessed
+		// duration is worse than none, and a guessed CATEGORY would silently move a radio.
+		for (const method of ['axomeme', 'prime', 'nrm', 'b-still', 'fade']) {
+			const result = executionAdvice({
+				method,
+				sequences: SEQS,
+				sites: SITES,
+				serverConnected: true
+			});
+			expect(result, method).toEqual({
+				hasEstimate: false,
+				local: null,
+				server: null,
+				recommend: null,
+				advice: null
+			});
+		}
+	});
+
+	it('stays silent with no file loaded', () => {
+		for (const input of [
+			{ method: 'bgm', sequences: 0, sites: SITES },
+			{ method: 'bgm', sequences: SEQS, sites: 0 },
+			{ method: null, sequences: SEQS, sites: SITES },
+			{}
+		]) {
+			const result = executionAdvice({ ...input, serverConnected: true });
+			expect(result.hasEstimate, JSON.stringify(input)).toBe(false);
+			expect(result.recommend).toBeNull();
+			expect(result.advice).toBeNull();
+		}
+	});
+
+	it('accepts the method name in the case the dropdown uses', () => {
+		// MethodSelector passes selectedMethod straight through, and methodConfig's keys are 'BGM',
+		// 'aBSREL', 'AxoMEME'. Lowercasing happens inside the estimator; this pins that it happens.
+		const upper = executionAdvice({
+			method: 'BGM',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+		expect(upper.recommend).toBe('backend');
+	});
+
+	it('applies advanced options that multiply the runtime', () => {
+		// Same alignment, 10x the MCMC steps: the estimate has to move, or the advice is describing a
+		// run nobody submitted.
+		const plain = executionAdvice({ method: 'bgm', sequences: SEQS, sites: SITES });
+		const heavy = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			methodOptions: { steps: 100000 }
+		});
+		expect(heavy.local.minutes).toBeGreaterThan(plain.local.minutes);
+	});
+
+	it('names categories that timingEstimates.js actually defines', () => {
+		// Drift guard. Rename 'very-slow' in SPEED_CATEGORIES and this set silently stops matching
+		// anything, which disables the advice everywhere without failing a single other test.
+		expect(Object.keys(SPEED_CATEGORIES)).toEqual(expect.arrayContaining([...SLOW_CATEGORIES]));
+	});
+});

--- a/src/test/execution-mode-default.test.js
+++ b/src/test/execution-mode-default.test.js
@@ -1,0 +1,155 @@
+/**
+ * Execution mode: what the panel actually defaults to, mounted.
+ *
+ * executionAdvice() is unit-tested next door; this file exists because the bug was never in the
+ * arithmetic. The app has always computed "~2h 15m in this browser" and printed it one row below a
+ * Local radio it had already selected. What has to be asserted is the RADIO — `.checked` on the
+ * inputs — not any sentence the unfixed page also renders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import MethodSelector from '../lib/MethodSelector.svelte';
+import { backendConnectivity } from '../stores/backendConnectivity.js';
+import { fileMetricsStore } from '../stores/fileInfo.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('../lib/utils/indexedDBStorage.js', () => ({
+	fileStorage: {
+		getAllFiles: vi.fn().mockResolvedValue([]),
+		getFile: vi.fn().mockResolvedValue(null),
+		saveFile: vi.fn().mockResolvedValue(true),
+		deleteFile: vi.fn().mockResolvedValue(true)
+	},
+	analysisStorage: {
+		getAllAnalyses: vi.fn().mockResolvedValue([]),
+		saveAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysis: vi.fn().mockResolvedValue(null),
+		deleteAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysesByFileId: vi.fn().mockResolvedValue([]),
+		clearAllAnalyses: vi.fn().mockResolvedValue(true)
+	}
+}));
+
+// The two entries this file needs, copied from +page.svelte's methodConfig. BGM is the slow one
+// (~2h 15m locally at 20x255); FEL is the fast one.
+const methodConfig = {
+	BGM: {
+		command: 'bgm',
+		outputSuffix: 'BGM.json',
+		url: 'bgm',
+		args: [],
+		description: 'A method for detecting coevolving sites.'
+	},
+	FEL: {
+		command: 'fel',
+		outputSuffix: 'FEL.json',
+		url: 'fel',
+		args: [],
+		description: 'A method for detecting pervasive selection.'
+	}
+};
+
+const SEQS = 20;
+const SITES = 255;
+
+async function mountWith({ connected, method }) {
+	backendConnectivity.set({
+		isConnected: connected,
+		isConnecting: false,
+		serverUrl: 'http://localhost:7015',
+		lastChecked: null,
+		error: null
+	});
+	fileMetricsStore.set({ FILE_INFO: { sequences: SEQS, sites: SITES } });
+
+	render(MethodSelector, { props: { methodConfig, runMethod: vi.fn() } });
+	const dropdown = screen.getByTestId('method-dropdown');
+	await fireEvent.change(dropdown, { target: { value: method } });
+	await tick();
+	await tick();
+	return {
+		local: document.querySelector('input[value="local"]'),
+		backend: document.querySelector('input[value="backend"]')
+	};
+}
+
+describe('execution mode default', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+	});
+
+	afterEach(() => {
+		cleanup();
+		fileMetricsStore.set(null);
+		backendConnectivity.set({
+			isConnected: false,
+			isConnecting: false,
+			serverUrl: 'http://localhost:7015',
+			lastChecked: null,
+			error: null
+		});
+	});
+
+	it('pre-selects the server for an hours-long local run, and yields to a click', async () => {
+		const { local, backend } = await mountWith({ connected: true, method: 'BGM' });
+
+		// THE ASSERTION. On unfixed main this is local:true / backend:false with "~2h 15m" printed
+		// directly underneath.
+		expect(backend.checked).toBe(true);
+		expect(local.checked).toBe(false);
+		expect(backend.disabled).toBe(false);
+
+		const advice = screen.getByTestId('execution-mode-advice').textContent;
+		expect(advice).toContain('in this browser');
+		expect(advice).toContain('on the server');
+		// It says so rather than moving the radio silently.
+		expect(advice).toMatch(/server is selected/i);
+
+		// A click is a decision and outranks a fitted curve. Without the touched flag the reactive
+		// statement immediately puts it back on backend.
+		await fireEvent.click(local);
+		await tick();
+		await tick();
+		expect(local.checked).toBe(true);
+		expect(backend.checked).toBe(false);
+		// And the copy stops claiming a selection that is no longer true.
+		expect(screen.getByTestId('execution-mode-advice').textContent).not.toMatch(
+			/server is selected/i
+		);
+	}, 30000);
+
+	it('leaves a fast method alone, and still states what each mode costs', async () => {
+		const { local, backend } = await mountWith({ connected: true, method: 'FEL' });
+
+		expect(local.checked).toBe(true);
+		expect(backend.checked).toBe(false);
+		// No nagging on a run that finishes in under a minute either way.
+		expect(screen.queryAllByTestId('execution-mode-advice')).toHaveLength(0);
+
+		// But the sub-labels are not silent. They used to read "Fast • Small datasets" and "Powerful •
+		// Large datasets" — a claim about the dataset made without looking at it, on a panel that had
+		// the estimate in hand. Now each names its own duration and what it costs the user.
+		const localLabel = local.closest('.execution-mode-option').textContent;
+		const backendLabel = backend.closest('.execution-mode-option').textContent;
+		expect(localLabel).toMatch(/in this tab/);
+		expect(backendLabel).toMatch(/on the server/);
+		expect(localLabel).not.toMatch(/Small datasets/);
+		expect(backendLabel).not.toMatch(/Large datasets/);
+	}, 30000);
+
+	it('states the cost instead of recommending a server that is down', async () => {
+		const { local, backend } = await mountWith({ connected: false, method: 'BGM' });
+
+		expect(local.checked).toBe(true);
+		expect(backend.disabled).toBe(true);
+
+		const advice = screen.getByTestId('execution-mode-advice');
+		expect(advice.textContent).toMatch(/tab must stay open/);
+		// The disconnected sentence is a second line of the existing warning, not a competing box.
+		expect(advice.closest('.backend-status-warning')).not.toBeNull();
+		expect(advice.textContent).not.toMatch(/on the server/);
+	}, 30000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,8 +8,14 @@ const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
 export default defineConfig({
 	plugins: [sveltekit()],
 
+	// Under vitest, resolve Svelte's BROWSER entry. Without the extra condition `mount()` comes from
+	// svelte/index-server.js and every component render throws "mount(...) is not available on the
+	// server" — which is why no test in this repo could mount a component until now. This is the
+	// workaround the Svelte 5 testing docs prescribe; it is scoped to the test run so the dev server
+	// and the production build resolve exactly as before.
 	resolve: {
-		dedupe: ['svelte']
+		dedupe: ['svelte'],
+		...(process.env.VITEST ? { conditions: ['browser'] } : {})
 	},
 
 	test: {


### PR DESCRIPTION
Implements UX audit items **2.1, 2.3**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

Execution mode no longer always defaults to Local when the app's own estimate says the run will take hours, and AxoMEME's percentile mode now states pre-run that it flags a fixed fraction of sites.

The percentile copy matters because percentile is the default calling mode: a user who does not know it reports a fixed share of sites can read the output as a significance result.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 620 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
