### PR TITLE
Send HyPhy the genetic code names it actually accepts

### DIFF
--- a/e2e/06-method-config.spec.js
+++ b/e2e/06-method-config.spec.js
@@ -86,9 +86,12 @@ test.describe('Method Selection & Configuration', () => {
 			has: page.locator('option:text("Universal")')
 		}).first();
 
-		await geneticCodeSelect.selectOption('Vertebrate mitochondrial');
-		// Verify the selection stuck
-		await expect(geneticCodeSelect).toHaveValue('Vertebrate mitochondrial');
+		// Pick by the human-readable label, then assert on the VALUE: the value is what gets
+		// passed to `hyphy --code`, and the engine only accepts its own hyphenated identifiers
+		// (see src/lib/config/geneticCodes.js). Asserting the label alone would still pass if the
+		// value drifted back to one of the spellings the engine rejects.
+		await geneticCodeSelect.selectOption({ label: 'Vertebrate mitochondrial DNA code' });
+		await expect(geneticCodeSelect).toHaveValue('Vertebrate-mtDNA');
 	});
 
 	test('timing estimate appears when method selected', async ({ page }) => {

--- a/e2e/21-genetic-code-wasm.spec.js
+++ b/e2e/21-genetic-code-wasm.spec.js
@@ -1,0 +1,120 @@
+/**
+ * E2E for UX item 1.2 — a non-universal genetic code must actually reach HyPhy in the browser.
+ *
+ * This is the only test in the repo that proves it, because it is the only one that runs real
+ * hyphy.wasm. The unit tests pin the table and the shape of the exec() call; this pins the
+ * consequence: the engine accepts the identifier the UI would send, and produces a result under it.
+ *
+ * It imports GENETIC_CODES rather than hardcoding a name, so putting any of the old spellings back
+ * in the table fails HERE too — against the real engine, not against another copy of our own list.
+ *
+ * The rejected-spelling case is run as a control. Without it, a spec that only asserts success
+ * could pass while the app sent something the engine happens to tolerate; with it, the exact
+ * failure mode the fix removes is documented and stays reproducible.
+ *
+ * ORDER MATTERS: the accepted run goes FIRST. HyPhy runs via Emscripten's callMain, which keeps
+ * global state between invocations in the same worker, and a run that aborts during argument
+ * parsing is not guaranteed to leave a clean slate behind it.
+ *
+ * Tagged @slow — it runs a full FEL fit. Runs under `npm run test:e2e:slow`.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { GENETIC_CODES } from '../src/lib/config/geneticCodes.js';
+
+test.setTimeout(180000);
+
+// The 10-taxon tree from src/test/contrast-fel-wasm.test.js, with its {Set_x} tags stripped —
+// this spec is about --code, not branch sets.
+const TREE =
+	'(((Human:0,Chimp:0):0.02166017600706549,(Baboon:0,RhMonkey:0):0.08454871222214284):0.1898804322701872,((Cow:0.08802139862787406,Horse:0.1770186752804336):0.0450013916056009,(Mouse:0.1219119664814597,Rat:0.03550454062015435):0.1244133402668078):0.01795217374765563,(Pig:0.1592109185107414,Cat:0.07671186476683911):0.01307003277251646):0;';
+
+// Vertebrate mitochondrial: the code a user is most likely to reach for, and the one whose old
+// spelling ('Vertebrate mitochondrial' / 'Vertebrate mtDNA') the engine rejects.
+const VERTEBRATE_MT = GENETIC_CODES.find((code) => code.id === 1).hyphy;
+
+test.describe('genetic code reaches HyPhy in WASM @slow', () => {
+	test('the selector value is accepted by the engine and produces a result', async ({ page }) => {
+		// Boot the debug console — initializes Aioli and exposes window.wasmCli.
+		await page.goto('/debug/wasm');
+		await page.waitForFunction(() => !!window.wasmCli, null, { timeout: 120000 });
+
+		const alignment = await (await page.request.get('/test-data/CD2-slim.fna')).text();
+		expect(alignment).toContain('>Human');
+
+		const result = await page.evaluate(
+			async ({ alignment, tree, codeName }) => {
+				const cli = window.wasmCli;
+				const mounted = await cli.mount([
+					{ name: 'user.nex', data: alignment },
+					{ name: 'user.tree', data: tree }
+				]);
+				const [alignmentPath, treePath] = mounted;
+				const bf = '/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf';
+
+				const tokens = (code) => [
+					'LIBPATH=/res/',
+					bf,
+					'--alignment',
+					alignmentPath,
+					'--tree',
+					treePath,
+					'--code',
+					code,
+					'--branches',
+					'All'
+				];
+
+				const out = {};
+
+				// The real thing: argv array, program name separate, value exactly as the UI sends it.
+				try {
+					out.acceptedStdout = await (await cli.exec('hyphy', tokens(codeName))).stdout;
+				} catch (e) {
+					out.acceptedError = String(e);
+				}
+
+				try {
+					const blob = await cli.download('/shared/data/user.nex.FEL.json');
+					out.jsonText = await (await fetch(blob)).text();
+				} catch (e) {
+					out.downloadError = String(e);
+				}
+
+				// CONTROL: the spelling this app used to send. It is not an identifier the engine
+				// declares, so it must still be refused.
+				try {
+					out.rejectedStdout = await (
+						await cli.exec('hyphy', tokens('Vertebrate mitochondrial'))
+					).stdout;
+				} catch (e) {
+					out.rejectedError = String(e);
+				}
+
+				return out;
+			},
+			{ alignment, tree: TREE, codeName: VERTEBRATE_MT }
+		);
+
+		// The engine consumed the value, rather than falling back or complaining.
+		expect(result.acceptedError, `exec threw: ${result.acceptedError}`).toBeUndefined();
+		expect(
+			result.acceptedStdout || '',
+			`engine rejected '${VERTEBRATE_MT}':\n${result.acceptedStdout}`
+		).not.toContain('is not a valid choice passed to');
+		// FEL echoes each keyword argument it accepted; this is the engine confirming the code.
+		expect(result.acceptedStdout || '').toContain(`>code => ${VERTEBRATE_MT}`);
+
+		// And it ran to completion under that code.
+		expect(result.jsonText, `no FEL result JSON. stdout:\n${result.acceptedStdout}`).toBeTruthy();
+		expect(result.jsonText.trim().startsWith('<')).toBe(false);
+		expect(JSON.parse(result.jsonText)).toHaveProperty('MLE');
+
+		// The control. If this ever stops failing, the spec is no longer proving anything and the
+		// alias handling in geneticCodes.js can be revisited.
+		expect(
+			result.rejectedStdout || '',
+			'the old spelling is no longer refused — this control is stale'
+		).toMatch(/is not a valid choice passed to 'Choose Genetic Code'/);
+	});
+});

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -13,6 +13,7 @@
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -182,26 +183,6 @@
 		: localRunInFlight && wouldRunLocally
 			? 'Another analysis is running in this tab — only one can run here at a time'
 			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
 
 	// Method-specific advanced options configurations
 	const METHOD_ADVANCED_OPTIONS = {
@@ -1130,9 +1111,11 @@
 					})
 			: [];
 
-	// Update genetic code ID when name changes
+	// Update genetic code ID when name changes. The selector's VALUE is HyPhy's own identifier
+	// (what the browser path passes to --code); the id is what the server path and the codon
+	// validator use. Both come from the same row, so they cannot disagree.
 	$: {
-		const codeEntry = GENETIC_CODES.find((code) => code.name === geneticCode);
+		const codeEntry = GENETIC_CODES.find((code) => code.hyphy === geneticCode);
 		if (codeEntry) {
 			geneticCodeId = codeEntry.id;
 		}
@@ -1476,7 +1459,9 @@
 								Genetic Code:
 								<select bind:value={geneticCode} class="option-select">
 									{#each GENETIC_CODES as code}
-										<option value={code.name}>{code.label}</option>
+										<!-- value is HyPhy's own identifier, label is ours: the value is
+										     passed verbatim to `hyphy --code`, so it is not free text. -->
+										<option value={code.hyphy}>{code.label}</option>
 									{/each}
 								</select>
 							</label>

--- a/src/lib/config/geneticCodes.js
+++ b/src/lib/config/geneticCodes.js
@@ -1,0 +1,128 @@
+/**
+ * geneticCodes.js — the single source of truth for genetic code identity in this app.
+ *
+ * There are three consumers and they had three different tables, which is how a UI that said
+ * "Vertebrate mitochondrial DNA code" ended up analysing data under the universal code:
+ *
+ *   - the browser (WASM) path passes a NAME to HyPhy on the command line (`--code <name>`), and
+ *     HyPhy only accepts the identifiers it declares itself;
+ *   - the server path passes a numeric ID (`gencodeid`), which HyPhy resolves BY POSITION in that
+ *     same table;
+ *   - the stop-codon validator (fastaValidation.js) keys its per-code stop sets by that same ID.
+ *
+ * WHERE `hyphy` COMES FROM, and why it looks nothing like what this repo used to send:
+ * the authority is the engine we actually ship — static/wasm/hyphy/2.5.98/hyphy.data, whose packed
+ * `_geneticCodeOptionMatrix` declares hyphenated, space-free identifiers ('Vertebrate-mtDNA').
+ * It is NOT src/data/shared/chooseGeneticCode.def, which is an older vendored copy carrying spaced
+ * spellings ('Vertebrate mtDNA'); that file is mounted only for the upload-time datareader, which
+ * never selects a code, so its drift went unnoticed. Passing any spaced name to the shipped engine
+ * gets it rejected outright:
+ *
+ *     'mtDNA' is not a valid choice passed to 'Choose Genetic Code' ChoiceList
+ *
+ * src/test/genetic-codes-table.test.js reads hyphy.data and fails if this table drifts from it.
+ * `label` is ours and may be reworded freely; it is display only.
+ *
+ * WHY ONLY TWELVE. The shipped engine offers twenty-two codes; ids 12-21 (Chlorophycean-mtDNA and
+ * later) are deliberately not exposed. They are unverified against the analysis server, which
+ * receives the numeric id, and they are absent from STOP_CODONS_BY_GENETIC_CODE in
+ * fastaValidation.js, where an unknown id falls back to the universal stop set — a stop-codon
+ * check that quietly validates against the wrong code is worse than a code we do not offer.
+ * Exposing them means extending both, and verifying the server, first.
+ *
+ * LEGACY_CODE_ALIASES exists because two older spellings are still in circulation: the names the
+ * MethodSelector invented ('Vertebrate mitochondrial'), which sit in saved analysis configs and in
+ * Storybook fixtures, and the spaced names from the vendored .def and methodOptions.toml
+ * ('Vertebrate mtDNA'). Resolving them keeps an old config running the code it names instead of
+ * silently falling back to Universal.
+ */
+
+/** @typedef {{ id: number, hyphy: string, label: string }} GeneticCode */
+
+/** Ordered exactly as the shipped engine declares them; `id` is the row index HyPhy indexes by. */
+export const GENETIC_CODES = [
+	{ id: 0, hyphy: 'Universal', label: 'Universal code' },
+	{ id: 1, hyphy: 'Vertebrate-mtDNA', label: 'Vertebrate mitochondrial DNA code' },
+	{ id: 2, hyphy: 'Yeast-mtDNA', label: 'Yeast mitochondrial DNA code' },
+	{
+		id: 3,
+		hyphy: 'Mold-Protozoan-mtDNA',
+		label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
+	},
+	{ id: 4, hyphy: 'Invertebrate-mtDNA', label: 'Invertebrate mitochondrial DNA code' },
+	{ id: 5, hyphy: 'Ciliate-Nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
+	{ id: 6, hyphy: 'Echinoderm-mtDNA', label: 'Echinoderm mitochondrial DNA code' },
+	{ id: 7, hyphy: 'Euplotid-Nuclear', label: 'Euplotid Nuclear code' },
+	{ id: 8, hyphy: 'Alt-Yeast-Nuclear', label: 'Alternative Yeast Nuclear code' },
+	{ id: 9, hyphy: 'Ascidian-mtDNA', label: 'Ascidian mitochondrial DNA code' },
+	{ id: 10, hyphy: 'Flatworm-mtDNA', label: 'Flatworm mitochondrial DNA code' },
+	{ id: 11, hyphy: 'Blepharisma-Nuclear', label: 'Blepharisma Nuclear code' }
+];
+
+/**
+ * Older spellings, mapped to the identifier the shipped engine declares.
+ *
+ * Two generations of them:
+ *   - the MethodSelector's invented names ('Vertebrate mitochondrial'), stored in saved configs;
+ *   - the spaced names from the vendored chooseGeneticCode.def and methodOptions.toml
+ *     ('Vertebrate mtDNA').
+ *
+ * Neither is a HyPhy identifier for the engine we ship. Do not add new entries — new code should
+ * use the canonical names above.
+ */
+export const LEGACY_CODE_ALIASES = {
+	Universal: 'Universal',
+	'Vertebrate mitochondrial': 'Vertebrate-mtDNA',
+	'Yeast mitochondrial': 'Yeast-mtDNA',
+	'Mold mitochondrial': 'Mold-Protozoan-mtDNA',
+	'Invertebrate mitochondrial': 'Invertebrate-mtDNA',
+	'Ciliate nuclear': 'Ciliate-Nuclear',
+	'Echinoderm mitochondrial': 'Echinoderm-mtDNA',
+	'Euplotid nuclear': 'Euplotid-Nuclear',
+	'Alternative yeast nuclear': 'Alt-Yeast-Nuclear',
+	'Ascidian mitochondrial': 'Ascidian-mtDNA',
+	'Flatworm mitochondrial': 'Flatworm-mtDNA',
+	'Blepharisma nuclear': 'Blepharisma-Nuclear',
+	'Vertebrate mtDNA': 'Vertebrate-mtDNA',
+	'Yeast mtDNA': 'Yeast-mtDNA',
+	'Mold/Protozoan mtDNA': 'Mold-Protozoan-mtDNA',
+	'Invertebrate mtDNA': 'Invertebrate-mtDNA',
+	'Ciliate Nuclear': 'Ciliate-Nuclear',
+	'Echinoderm mtDNA': 'Echinoderm-mtDNA',
+	'Euplotid Nuclear': 'Euplotid-Nuclear',
+	'Alt. Yeast Nuclear': 'Alt-Yeast-Nuclear',
+	'Ascidian mtDNA': 'Ascidian-mtDNA',
+	'Flatworm mtDNA': 'Flatworm-mtDNA',
+	'Blepharisma Nuclear': 'Blepharisma-Nuclear'
+};
+
+/**
+ * Resolve a canonical-or-legacy genetic code name to the identifier HyPhy accepts.
+ *
+ * Unknown names are returned UNCHANGED rather than coerced to 'Universal': on the WASM path this
+ * value goes straight to `--code`, and HyPhy rejecting an unrecognised name loudly is far better
+ * than this app quietly analysing the data under a different code than the one displayed.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function canonicalGeneticCodeName(name) {
+	if (!name) return 'Universal';
+	if (GENETIC_CODES.some((code) => code.hyphy === name)) return name;
+	return LEGACY_CODE_ALIASES[name] ?? name;
+}
+
+/**
+ * Resolve a canonical-or-legacy genetic code name to the numeric id HyPhy indexes by.
+ *
+ * Falls back to 0 (Universal) for unknown names, matching the server path's long-standing
+ * behaviour — the backend requires *some* numeric id and has no way to express "unknown".
+ *
+ * @param {string} name
+ * @returns {number}
+ */
+export function geneticCodeId(name) {
+	const canonical = canonicalGeneticCodeName(name);
+	const entry = GENETIC_CODES.find((code) => code.hyphy === canonical);
+	return entry ? entry.id : 0;
+}

--- a/src/lib/config/methodOptions.toml
+++ b/src/lib/config/methodOptions.toml
@@ -9,17 +9,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[fel.options]]
@@ -140,17 +140,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[slac.options]]
@@ -317,17 +317,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[contrast-fel.options]]
@@ -410,17 +410,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[gard.options]]
@@ -510,17 +510,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[multi-hit.options]]
@@ -584,17 +584,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[nrm.options]]
@@ -651,17 +651,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[prime.options]]
@@ -740,17 +740,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[relax.options]]

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -8,6 +8,7 @@ import { DATAMONKEY_SERVER_URL } from '../config/env.ts';
 import { BaseAnalysisRunner } from './BaseAnalysisRunner.js';
 import { analysisStore } from '../../stores/analyses.js';
 import { sanitizeSequenceNames } from '../utils/fastaValidation.js';
+import { geneticCodeId } from '../config/geneticCodes.js';
 
 /**
  * Strip embedded trees from alignment data
@@ -426,24 +427,17 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 	}
 
 	/**
-	 * Map genetic code name to numeric ID (for backward compatibility)
+	 * Map genetic code name to the numeric ID the server expects.
+	 *
+	 * Delegates to the shared table, which resolves BOTH the identifiers the selector now emits
+	 * ('Vertebrate-mtDNA') and the spellings older builds stored ('Vertebrate mitochondrial').
+	 * That second half is not cosmetic: the fallback here is 0, so a name this fails to recognise
+	 * makes the server silently run the UNIVERSAL code while the UI still shows the code the user
+	 * picked — a wrong answer with no error anywhere. Keeping a second copy of the table in this
+	 * file is what made that possible; do not reintroduce one.
 	 */
 	mapGeneticCodeToId(geneticCode) {
-		const codeMap = {
-			Universal: 0,
-			'Vertebrate mitochondrial': 1,
-			'Yeast mitochondrial': 2,
-			'Mold mitochondrial': 3,
-			'Invertebrate mitochondrial': 4,
-			'Ciliate nuclear': 5,
-			'Echinoderm mitochondrial': 6,
-			'Euplotid nuclear': 7,
-			'Alternative yeast nuclear': 8,
-			'Ascidian mitochondrial': 9,
-			'Flatworm mitochondrial': 10,
-			'Blepharisma nuclear': 11
-		};
-		return codeMap[geneticCode] || 0;
+		return geneticCodeId(geneticCode);
 	}
 
 	/**

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -10,6 +10,7 @@ import { get } from 'svelte/store';
 import { getCachedOrCompute, generateAnalysisKey } from '../utils/cacheUtils.js';
 import { sanitizeSequenceNames } from '../utils/fastaValidation.js';
 import { safeParseJSON } from '../utils/jsonUtils.js';
+import { canonicalGeneticCodeName } from '../config/geneticCodes.js';
 
 /**
  * hyphy-analyses custom analyses that are NOT packed into the WASM /res/ image.
@@ -234,20 +235,23 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 
 		this.updateProgress(analysisId, 'running', 20, 'Building analysis command...');
 
-		// Build arguments
+		// Build arguments as an argv ARRAY — one shell token per element, never
+		// "--flag value" in a single string. Aioli's exec() only splits on spaces when it is
+		// handed a command string, so under the old form any value containing a space was torn
+		// apart before HyPhy saw it. See the exec() call below for the full mechanism.
 		const args = [];
-		args.push(`--alignment ${inputFiles[0]}`);
+		args.push('--alignment', inputFiles[0]);
 
 		// Add tree argument if tree data was provided
 		if (sanitizedTree && sanitizedTree.trim()) {
-			args.push(`--tree ${inputFiles[1]}`);
+			args.push('--tree', inputFiles[1]);
 		}
 
 		// NRM (nucleotide non-reversibility) writes its JSON to <alignment>.NRM.json by
 		// default; pass --output explicitly so the result path matches what we download
 		// below, regardless of how the batch file derives its default.
 		if (method.toLowerCase() === 'nrm') {
-			args.push(`--output ${inputFiles[0]}.NRM.json`);
+			args.push('--output', `${inputFiles[0]}.NRM.json`);
 		}
 
 		// Map configuration parameters to HyPhy command line arguments
@@ -263,7 +267,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				key !== 'branchSet2' &&
 				key !== 'testBranches' &&
 				key !== 'referenceBranches' &&
-				key !== 'variant'
+				key !== 'variant' &&
+				// UI-side companion of geneticCode. HyPhy's CLI takes the NAME, not the id;
+				// without this skip the generic branch below emitted a bogus
+				// '--genetic-code-id 0' on every local run.
+				key !== 'geneticCodeId'
 			) {
 				// Handle specific FEL parameter mappings
 				if (key === 'branchesToTest') {
@@ -282,79 +290,78 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 							// Skip - RELAX uses --test and --reference parameters
 						} else {
 							console.log('🌳 WASM - Converting Interactive to FG for HyPhy');
-							args.push(`--branches FG`);
+							args.push('--branches', 'FG');
 						}
 					} else {
 						// Always pass --branches explicitly (including 'All') to avoid
 						// stale state issues with Emscripten's callMain between invocations
-						args.push(`--branches ${value || 'All'}`);
+						args.push('--branches', String(value || 'All'));
 					}
 				} else if (key === 'propertySet') {
 					// PRIME property set parameter
-					args.push(`--property-set ${value}`);
+					args.push('--property-set', String(value));
 				} else if (key === 'imputeStates') {
 					// PRIME impute states parameter
-					args.push(`--impute-states ${value}`);
+					args.push('--impute-states', String(value));
 				} else if (key === 'geneticCode') {
-					// Pass the descriptive string value (HyPhy WASM does not accept the
-					// numeric code id on the CLI). Known limitation: aioli's exec() does
-					// a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
-					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
-					// proper fix is to refactor args into an array passed to
-					// cliObj.exec(cmd, argsArray) — tracked separately.
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// HyPhy's CLI takes the code's NAME, not the numeric id, and the shipped engine
+					// accepts only the identifiers it declares — hyphenated ones like
+					// 'Vertebrate-mtDNA'. Normalise the spellings older builds stored so a saved
+					// config keeps running the code it names instead of being rejected outright.
+					// See src/lib/config/geneticCodes.js for where that list comes from.
+					const codeName = canonicalGeneticCodeName(String(value));
+					console.log('🧬 WASM - Using genetic code:', codeName);
+					args.push('--code', codeName);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
-					args.push(`--srv ${value}`);
+					args.push('--srv', String(value));
 				} else if (key === 'multipleHits') {
 					// Multiple hits parameter
 					if (value !== 'None') {
-						args.push(`--multiple-hits ${value}`);
+						args.push('--multiple-hits', String(value));
 					}
 				} else if (key === 'siteMultihit') {
 					// Site multihit parameter (only when multiple hits enabled)
 					if (config.multipleHits && config.multipleHits !== 'None') {
-						args.push(`--site-multihit ${value}`);
+						args.push('--site-multihit', String(value));
 					}
 				} else if (key === 'resample' && value > 0) {
 					// Bootstrap resampling
-					args.push(`--resample ${value}`);
+					args.push('--resample', String(value));
 				} else if (key === 'confidenceIntervals') {
 					// Confidence intervals
-					args.push(`--ci ${value ? 'Yes' : 'No'}`);
+					args.push('--ci', value ? 'Yes' : 'No');
 				} else if (key === 'blb') {
 					// Bag of Little Bootstrap parameter for aBSREL
-					args.push(`--blb ${value}`);
+					args.push('--blb', String(value));
 				} else if (key === 'pValueThreshold') {
 					// P-value threshold (custom parameter, not standard HyPhy)
 					// This would be handled post-processing
 					continue;
 				} else if (key === 'steps') {
 					// BGM chain length steps
-					args.push(`--steps ${value}`);
+					args.push('--steps', String(value));
 				} else if (key === 'burnIn') {
 					// BGM burn-in samples
-					args.push(`--burn-in ${value}`);
+					args.push('--burn-in', String(value));
 				} else if (key === 'samples') {
 					// BGM samples
-					args.push(`--samples ${value}`);
+					args.push('--samples', String(value));
 				} else if (key === 'maxParents') {
 					// BGM maximum parents per node
-					args.push(`--max-parents ${value}`);
+					args.push('--max-parents', String(value));
 				} else if (key === 'minSubs') {
 					// BGM minimum substitutions per site
-					args.push(`--min-subs ${value}`);
+					args.push('--min-subs', String(value));
 				} else if (key === 'rates') {
 					// Multi-Hit rate classes parameter
-					args.push(`--rates ${value}`);
+					args.push('--rates', String(value));
 				} else if (key === 'rate_classes') {
 					// NRM rate classes parameter (convert underscore to hyphen)
-					args.push(`--rate-classes ${value}`);
+					args.push('--rate-classes', String(value));
 				} else if (key === 'triple_islands') {
 					// Multi-Hit triple islands parameter (convert underscore to hyphen)
-					args.push(`--triple-islands ${value}`);
+					args.push('--triple-islands', String(value));
 				} else if (key === 'mode') {
 					// RELAX mode parameter - skip if default value to avoid space-in-value issues
 					// "Classic mode" is the default, so we only need to pass it if different
@@ -365,11 +372,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// Skip passing --mode parameter
 				} else if (typeof value === 'boolean') {
 					// Boolean parameters
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value ? 'Yes' : 'No'}`);
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, value ? 'Yes' : 'No');
 				} else if (value !== null && value !== undefined && value !== '') {
-					// All other parameters (including strings with spaces)
-					// Don't add quotes - HyPhy WASM doesn't parse them correctly
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value}`);
+					// All other parameters. Values containing spaces are safe now that each
+					// argv token is its own array element.
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, String(value));
 				}
 			}
 		}
@@ -402,15 +409,17 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 			}
 		}
 
-		// Add method-specific default arguments for BGM
+		// Add method-specific default arguments for BGM.
+		// Flags are their own argv tokens now, so an exact match is both correct and cheaper
+		// than the substring scan this used to do.
 		if (method.toLowerCase() === 'bgm') {
 			// BGM requires explicit data type specification
-			if (!args.some((arg) => arg.includes('--type'))) {
-				args.push('--type codon');
+			if (!args.includes('--type')) {
+				args.push('--type', 'codon');
 			}
 			// BGM requires branches specification
-			if (!args.some((arg) => arg.includes('--branches'))) {
-				args.push('--branches All');
+			if (!args.includes('--branches')) {
+				args.push('--branches', 'All');
 			}
 		}
 
@@ -444,18 +453,29 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				? `/res/TemplateBatchFiles/${batchFile}`
 				: methodKey;
 
-		// Build and execute the command
-		const fullHyphyCommand = `hyphy LIBPATH=/res/ ${hyphyCommand} ${args.join(' ')}`;
-		console.log(`Executing HyPhy command: ${fullHyphyCommand}`);
+		// Build and execute the command.
+		//
+		// The argv array is passed to exec() as its SECOND argument. Aioli's worker only does
+		// `command.split(' ')` when that second argument is null; given an array it hands the
+		// tokens to Emscripten's callMain untouched, so a value keeps whatever characters it has.
+		// In this form the first argument must be the bare program name and must NOT be repeated
+		// inside the array — the worker looks the tool up by `program == 'hyphy'` and throws
+		// 'Program ... not found' otherwise.
+		//
+		// displayCommand is for humans (logs, the stored arguments record) only. It is NOT what
+		// runs, and it is ambiguous for any value containing a space; do not feed it back to exec.
+		const argv = ['LIBPATH=/res/', hyphyCommand, ...args];
+		const displayCommand = ['hyphy', ...argv].join(' ');
+		console.log(`Executing HyPhy command: ${displayCommand}`);
 
 		this.updateProgress(analysisId, 'running', 40, `Executing ${method} analysis...`);
 
 		// Run the analysis
-		const cmdResult = await cliObj.exec(fullHyphyCommand);
+		const cmdResult = await cliObj.exec('hyphy', argv);
 		const stdout = await cmdResult.stdout;
 
 		// Add command execution details to stdout for debugging
-		const commandInfo = `\n=== HyPhy Command Execution ===\nCommand: ${fullHyphyCommand}\nFiles mounted: ${filesToMount.map((f) => f.name).join(', ')}\nTree data provided: ${sanitizedTree && sanitizedTree.trim() ? 'Yes' : 'No'}\n================================\n\n`;
+		const commandInfo = `\n=== HyPhy Command Execution ===\nCommand: ${displayCommand}\nFiles mounted: ${filesToMount.map((f) => f.name).join(', ')}\nTree data provided: ${sanitizedTree && sanitizedTree.trim() ? 'Yes' : 'No'}\n================================\n\n`;
 		const enhancedStdout = commandInfo + stdout;
 
 		// Check for common HyPhy errors
@@ -527,12 +547,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 	 * Build arguments preview for database storage (before actual execution)
 	 */
 	buildArgumentsPreview(method, config, treeData) {
+		// Same argv-array tokenisation as executeWasmAnalysis — see the comments there. The two
+		// must stay in step: this is the record a user reads when an analysis fails, and a preview
+		// that differs from what actually ran is worse than no preview.
 		const args = [];
-		args.push(`--alignment user.nex`);
+		args.push('--alignment', 'user.nex');
 
 		// Add tree argument if tree data was provided
 		if (treeData && treeData.trim()) {
-			args.push(`--tree user.tree`);
+			args.push('--tree', 'user.tree');
 		}
 
 		// Map configuration parameters to HyPhy command line arguments
@@ -548,7 +571,9 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				key !== 'branchSet2' &&
 				key !== 'testBranches' &&
 				key !== 'referenceBranches' &&
-				key !== 'variant'
+				key !== 'variant' &&
+				// See executeWasmAnalysis: the id is UI state, the CLI takes the name.
+				key !== 'geneticCodeId'
 			) {
 				// Handle specific FEL parameter mappings
 				if (key === 'branchesToTest') {
@@ -560,76 +585,71 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 						} else if (method.toLowerCase() === 'relax') {
 							// Skip - RELAX uses --test and --reference parameters
 						} else {
-							args.push(`--branches FG`);
+							args.push('--branches', 'FG');
 						}
 					} else {
 						// Always pass --branches explicitly (including 'All') to avoid
 						// stale state issues with Emscripten's callMain between invocations
-						args.push(`--branches ${value || 'All'}`);
+						args.push('--branches', String(value || 'All'));
 					}
 				} else if (key === 'propertySet') {
 					// PRIME property set parameter
-					args.push(`--property-set ${value}`);
+					args.push('--property-set', String(value));
 				} else if (key === 'imputeStates') {
 					// PRIME impute states parameter
-					args.push(`--impute-states ${value}`);
+					args.push('--impute-states', String(value));
 				} else if (key === 'geneticCode') {
-					// Pass the descriptive string value (HyPhy WASM does not accept the
-					// numeric code id on the CLI). Known limitation: aioli's exec() does
-					// a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
-					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
-					// proper fix is to refactor args into an array passed to
-					// cliObj.exec(cmd, argsArray) — tracked separately.
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// Normalised to the HyPhy identifier, exactly as the executed command does.
+					const codeName = canonicalGeneticCodeName(String(value));
+					console.log('🧬 WASM - Using genetic code:', codeName);
+					args.push('--code', codeName);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
-					args.push(`--srv ${value}`);
+					args.push('--srv', String(value));
 				} else if (key === 'multipleHits') {
 					// Multiple hits parameter
 					if (value !== 'None') {
-						args.push(`--multiple-hits ${value}`);
+						args.push('--multiple-hits', String(value));
 					}
 				} else if (key === 'siteMultihit') {
 					// Site multihit parameter (only when multiple hits enabled)
 					if (config.multipleHits && config.multipleHits !== 'None') {
-						args.push(`--site-multihit ${value}`);
+						args.push('--site-multihit', String(value));
 					}
 				} else if (key === 'resample' && value > 0) {
 					// Bootstrap resampling
-					args.push(`--resample ${value}`);
+					args.push('--resample', String(value));
 				} else if (key === 'confidenceIntervals') {
 					// Confidence intervals
-					args.push(`--ci ${value ? 'Yes' : 'No'}`);
+					args.push('--ci', value ? 'Yes' : 'No');
 				} else if (key === 'blb') {
 					// Bag of Little Bootstrap parameter for aBSREL
-					args.push(`--blb ${value}`);
+					args.push('--blb', String(value));
 				} else if (key === 'pValueThreshold') {
 					// P-value threshold (custom parameter, not standard HyPhy)
 					// This would be handled post-processing
 					continue;
 				} else if (key === 'steps') {
 					// BGM chain length steps
-					args.push(`--steps ${value}`);
+					args.push('--steps', String(value));
 				} else if (key === 'burnIn') {
 					// BGM burn-in samples
-					args.push(`--burn-in ${value}`);
+					args.push('--burn-in', String(value));
 				} else if (key === 'samples') {
 					// BGM samples
-					args.push(`--samples ${value}`);
+					args.push('--samples', String(value));
 				} else if (key === 'maxParents') {
 					// BGM maximum parents per node
-					args.push(`--max-parents ${value}`);
+					args.push('--max-parents', String(value));
 				} else if (key === 'minSubs') {
 					// BGM minimum substitutions per site
-					args.push(`--min-subs ${value}`);
+					args.push('--min-subs', String(value));
 				} else if (key === 'rates') {
 					// Multi-Hit rate classes parameter
-					args.push(`--rates ${value}`);
+					args.push('--rates', String(value));
 				} else if (key === 'triple_islands') {
 					// Multi-Hit triple islands parameter (convert underscore to hyphen)
-					args.push(`--triple-islands ${value}`);
+					args.push('--triple-islands', String(value));
 				} else if (key === 'mode') {
 					// RELAX mode parameter - skip if default value to avoid space-in-value issues
 					if (value !== 'Classic mode') {
@@ -638,11 +658,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// Skip passing --mode parameter
 				} else if (typeof value === 'boolean') {
 					// Boolean parameters
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value ? 'Yes' : 'No'}`);
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, value ? 'Yes' : 'No');
 				} else if (value !== null && value !== undefined && value !== '') {
-					// All other parameters (including strings with spaces)
-					// Don't add quotes - HyPhy WASM doesn't parse them correctly
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value}`);
+					// All other parameters. Values containing spaces are safe now that each
+					// argv token is its own array element.
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, String(value));
 				}
 			}
 		}
@@ -673,17 +693,23 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		// Add method-specific default arguments for BGM (preview version)
 		if (method.toLowerCase() === 'bgm') {
 			// BGM requires explicit data type specification
-			if (!args.some((arg) => arg.includes('--type'))) {
-				args.push('--type codon');
+			if (!args.includes('--type')) {
+				args.push('--type', 'codon');
 			}
 			// BGM requires branches specification
-			if (!args.some((arg) => arg.includes('--branches'))) {
-				args.push('--branches All');
+			if (!args.includes('--branches')) {
+				args.push('--branches', 'All');
 			}
 		}
 
+		// Preview shows the method name rather than the batch-file path, for readability.
+		// `argv` is the exact token list; `command` is the same thing joined for display, and is
+		// ambiguous wherever a value contains a space — which is why both are stored.
+		const argv = ['LIBPATH=/res/', method.toLowerCase(), ...args];
+
 		return {
-			command: `hyphy LIBPATH=/res/ ${method.toLowerCase()} ${args.join(' ')}`, // Preview shows method name for readability
+			command: ['hyphy', ...argv].join(' '),
+			argv,
 			method: method.toUpperCase(),
 			parameters: config,
 			treeData: treeData

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -884,7 +884,10 @@
 				'Analyzing file structure...'
 			);
 			currentStage = 'exec';
-			result = await cliObj.exec('hyphy LIBPATH=/res/ ' + inputFiles[1]);
+			// argv-array form: Aioli only splits on spaces when the second argument is null.
+			// The datareader takes no arguments with spaces today, but the array form is what a
+			// future `--code <name>` (see UX item 1.2) would need, and it costs nothing now.
+			result = await cliObj.exec('hyphy', ['LIBPATH=/res/', inputFiles[1]]);
 			hyphyOut = await result.stdout;
 
 			// Extract meaningful error from HyPhy stdout for better error reporting

--- a/src/test/genetic-codes-table.test.js
+++ b/src/test/genetic-codes-table.test.js
@@ -1,0 +1,100 @@
+/**
+ * UX item 1.2 — the genetic code table must be the SHIPPED ENGINE's table, not one we invented.
+ *
+ * Three tables disagreed. The selector offered names of its own ('Vertebrate mitochondrial');
+ * methodOptions.toml and the vendored chooseGeneticCode.def offered spaced ones ('Vertebrate
+ * mtDNA'); and hyphy.wasm 2.5.98 — the thing that actually runs — accepts neither. It declares
+ * hyphenated identifiers ('Vertebrate-mtDNA') and rejects everything else:
+ *
+ *     'mtDNA' is not a valid choice passed to 'Choose Genetic Code' ChoiceList
+ *
+ * So the authority here is static/wasm/hyphy/2.5.98/hyphy.data, the packed filesystem image
+ * shipped with the engine. This test reads `_geneticCodeOptionMatrix` straight out of it. Pinning
+ * to src/data/shared/chooseGeneticCode.def instead would pin the exact stale spellings that caused
+ * the bug — that file is an older vendored copy, mounted only for the upload-time datareader,
+ * which never selects a code and so never noticed the drift.
+ *
+ * Two properties are checked, and the second is the one that matters most:
+ *   - SPELLING, because a name the engine does not recognise fails the run outright;
+ *   - ORDER, because the server path sends the numeric id and HyPhy resolves it BY POSITION in
+ *     this same matrix. A table in the wrong order runs a different code than the UI displays and
+ *     reports no error at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import toml from 'toml';
+import {
+	GENETIC_CODES,
+	geneticCodeId,
+	canonicalGeneticCodeName
+} from '../lib/config/geneticCodes.js';
+import tomlSrc from '../lib/config/methodOptions.toml?raw';
+
+const OUR_NAMES = GENETIC_CODES.map((code) => code.hyphy);
+
+/**
+ * The identifiers the shipped engine declares, in declaration order.
+ *
+ * hyphy.data is Emscripten's packed filesystem blob: batch files are stored as plain text inside
+ * it, so the declaration can be read directly. Latin-1 keeps byte offsets honest across the
+ * binary regions surrounding it.
+ */
+function namesFromShippedEngine() {
+	const blob = readFileSync('static/wasm/hyphy/2.5.98/hyphy.data', 'latin1');
+	const start = blob.indexOf('_geneticCodeOptionMatrix = {');
+	expect(start, 'genetic code matrix not found in the packed engine').toBeGreaterThan(-1);
+	const end = blob.indexOf('};', start);
+	const block = blob.slice(start, end);
+	return [...block.matchAll(/"([^"]+)",\s*"[^"]*transl_table/g)].map((m) => m[1]);
+}
+
+describe('genetic code table matches the shipped HyPhy engine', () => {
+	it('ids are a dense 0..11 range in declaration order', () => {
+		expect(GENETIC_CODES.map((code) => code.id)).toEqual([...Array(12).keys()]);
+	});
+
+	it('names AND order match the engine, which indexes this matrix by position', () => {
+		const engineNames = namesFromShippedEngine();
+		// The engine offers more codes than we expose; ours must be its first twelve, in order.
+		// (See geneticCodes.js for why 12-21 are deliberately withheld.)
+		expect(engineNames.length).toBeGreaterThanOrEqual(12);
+		expect(OUR_NAMES).toEqual(engineNames.slice(0, 12));
+	});
+
+	it('the documented CLI choices in methodOptions.toml say the same thing', () => {
+		const codeOption = toml.parse(tomlSrc).fel.options.find((option) => option.name === 'code');
+		expect(codeOption).toBeTruthy();
+		expect(OUR_NAMES).toEqual(codeOption.choices.map((choice) => choice.value));
+	});
+
+	it('every exposed id has a stop-codon set, so validation cannot silently use the wrong one', async () => {
+		// fastaValidation keys STOP_CODONS_BY_GENETIC_CODE by id and falls back to Universal for
+		// anything missing. Exposing a code it does not know would validate against the wrong
+		// stop set without erroring — which is why the table stops at 11.
+		const { findStopCodons } = await import('../lib/utils/fastaValidation.js');
+		const alignment = '>a\nATGTAAATG\n>b\nATGAGAATG\n';
+		const universalStops = findStopCodons(alignment, 0).affected.length;
+		// Vertebrate mtDNA reads AGA as a stop where the universal code does not; if id 1 fell
+		// back to the universal set these two would agree.
+		const vertebrateStops = findStopCodons(alignment, 1).affected.length;
+		expect(vertebrateStops).not.toBe(universalStops);
+	});
+
+	it('resolves canonical and both legacy spellings to the same id', () => {
+		expect(geneticCodeId('Vertebrate-mtDNA')).toBe(1);
+		// What older builds of the selector stored...
+		expect(geneticCodeId('Vertebrate mitochondrial')).toBe(1);
+		// ...and what the vendored .def / methodOptions.toml used to say.
+		expect(geneticCodeId('Vertebrate mtDNA')).toBe(1);
+		expect(geneticCodeId('Blepharisma nuclear')).toBe(11);
+		expect(geneticCodeId('Universal')).toBe(0);
+		expect(geneticCodeId(undefined)).toBe(0);
+	});
+
+	it('leaves an unrecognised name alone rather than pretending it is Universal', () => {
+		// On the WASM path this value goes to `--code`; a loud HyPhy rejection beats quietly
+		// analysing the data under a code the user did not choose.
+		expect(canonicalGeneticCodeName('Klingon mtDNA')).toBe('Klingon mtDNA');
+		expect(canonicalGeneticCodeName('Vertebrate mitochondrial')).toBe('Vertebrate-mtDNA');
+	});
+});

--- a/src/test/wasm-exec-argv.test.js
+++ b/src/test/wasm-exec-argv.test.js
@@ -1,0 +1,164 @@
+/**
+ * UX item 1.2 — how the browser path hands arguments to HyPhy.
+ *
+ * The runner used to build one command STRING and let Aioli's worker split it on spaces
+ * (`r == null && (r = e.split(" "), i = r.shift())`). Two things follow from that, and this file
+ * pins both fixes:
+ *
+ *   1. Any argument value containing a space was silently torn into separate argv tokens. With the
+ *      old genetic code table that was fatal — `--code Vertebrate mitochondrial` reached HyPhy as
+ *      three tokens. The names now sent are hyphenated (see geneticCodes.js), so no CURRENT value
+ *      has a space; what the argv array guarantees is that a value which does have one arrives
+ *      whole, so HyPhy's complaint names the value the user chose instead of its first word.
+ *
+ *   2. `geneticCodeId` was not in the skip list, so the generic fall-through emitted a bogus
+ *      `--genetic-code-id 0` on every single local run.
+ *
+ * This drives the REAL runner rather than a re-implementation of its argument builder, because the
+ * defect was never in the mapping — it was in how the mapped tokens reached exec().
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The analysis store persists through IndexedDB; stub it so this exercises the runner.
+vi.mock('../lib/utils/indexedDBStorage', () => {
+	const records = new Map();
+	return {
+		analysisStorage: {
+			getAnalysis: vi.fn(async (id) => records.get(id) ?? null),
+			saveAnalysis: vi.fn(async (a) => {
+				records.set(a.id, a);
+				return a;
+			}),
+			getAllAnalyses: vi.fn(async () => [...records.values()]),
+			deleteAnalysis: vi.fn(async (id) => records.delete(id)),
+			clearAllAnalyses: vi.fn(async () => records.clear()),
+			__records: records
+		}
+	};
+});
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const { aioliStore } = await import('../stores/aioli.js');
+const { wasmAnalysisRunner } = await import('../lib/services/WasmAnalysisRunner.js');
+
+const FASTA = `>Human
+GCCTTGGAAACCTGGGGTGCCTTGGGTCAGGACATCAACTTGGACATTCCT
+>Chimp
+GCCTTGGAAACCTGGGGTGCCTTGGGTCAGGACATCAACTTGGACATTCCT
+>Baboon
+GCTTTGGAAACCTGGGGAGCGCTGGGTCAGGACATCAACTTGGACATTCCT`;
+
+const TREE = `((Human:0.01,Chimp:0.01):0.02,Baboon:0.03);`;
+
+/** Install a fake Aioli CLI and return its exec spy. */
+function installFakeCli() {
+	const exec = vi.fn(async () => ({ stdout: '' }));
+	aioliStore.set({
+		mount: async (files) => files.map((f) => `/shared/data/${f.name}`),
+		exec,
+		download: async () => 'blob:x'
+	});
+	// executeWasmAnalysis fetches the result file through the blob URL it just downloaded.
+	global.fetch = vi.fn(async () => ({
+		blob: async () => ({ text: async () => '{"MLE":{}}' })
+	}));
+	return exec;
+}
+
+describe('WASM exec receives an argv array, not a command string', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('passes the program name and argv separately, one token per element', async () => {
+		const exec = installFakeCli();
+
+		// Called directly: this bypasses runAnalysis's cache and validation, which are not
+		// what is under test here.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a1',
+			'fel',
+			{ geneticCode: 'Vertebrate-mtDNA', branchesToTest: 'All', geneticCodeId: 1 },
+			FASTA,
+			TREE
+		);
+
+		expect(exec).toHaveBeenCalledTimes(1);
+		const [program, argv] = exec.mock.calls[0];
+
+		// Aioli looks the tool up by `program == 'hyphy'`; anything else throws "Program not found".
+		expect(program).toBe('hyphy');
+		expect(Array.isArray(argv)).toBe(true);
+
+		// Flags are their own tokens, with the value in the very next element.
+		const codeIndex = argv.indexOf('--code');
+		expect(codeIndex).toBeGreaterThan(-1);
+		expect(argv[codeIndex + 1]).toBe('Vertebrate-mtDNA');
+		expect(argv).toContain('--alignment');
+		expect(argv).toContain('--tree');
+		expect(argv).toContain('--branches');
+
+		// The program name must NOT be repeated inside argv — the worker shifts nothing off an
+		// array, so a leading 'hyphy' would reach HyPhy as a positional argument.
+		expect(argv).not.toContain('hyphy');
+
+		// Emscripten's callMain wants strings; numeric config values must be stringified.
+		expect(argv.every((token) => typeof token === 'string')).toBe(true);
+
+		// geneticCodeId is UI state, not a CLI flag. Before this change the generic fall-through
+		// turned it into a bogus '--genetic-code-id 0' on every local run.
+		expect(argv).not.toContain('--genetic-code-id');
+	});
+
+	it('keeps a value containing a space in a single argv element', async () => {
+		const exec = installFakeCli();
+
+		// An unrecognised code name is passed through deliberately (see geneticCodes.js) so HyPhy
+		// rejects it loudly. Under the old string form the split made HyPhy report only
+		// 'Vertebrate' — naming a value the user never typed. It must arrive whole.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a2',
+			'fel',
+			{ geneticCode: 'Vertebrate mitochondrial DNA', branchesToTest: 'All' },
+			FASTA,
+			TREE
+		);
+
+		const argv = exec.mock.calls[0][1];
+		expect(argv[argv.indexOf('--code') + 1]).toBe('Vertebrate mitochondrial DNA');
+	});
+
+	it('normalises a legacy genetic code name to the identifier the engine declares', async () => {
+		const exec = installFakeCli();
+
+		// 'Vertebrate mitochondrial' is what older builds of the selector stored. It is not a
+		// HyPhy identifier and never was, so a saved config carrying it must be translated
+		// rather than passed through to be rejected.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a3',
+			'fel',
+			{ geneticCode: 'Vertebrate mitochondrial', branchesToTest: 'All' },
+			FASTA,
+			TREE
+		);
+
+		const argv = exec.mock.calls[0][1];
+		expect(argv[argv.indexOf('--code') + 1]).toBe('Vertebrate-mtDNA');
+	});
+
+	it('builds the stored arguments preview from the same tokens', async () => {
+		const preview = wasmAnalysisRunner.buildArgumentsPreview(
+			'fel',
+			{ geneticCode: 'Vertebrate-mtDNA', branchesToTest: 'All', geneticCodeId: 1 },
+			TREE
+		);
+
+		expect(Array.isArray(preview.argv)).toBe(true);
+		expect(preview.argv[preview.argv.indexOf('--code') + 1]).toBe('Vertebrate-mtDNA');
+		expect(preview.argv).not.toContain('--genetic-code-id');
+		// The joined form is for reading only; argv is stored beside it because the join is
+		// ambiguous for any value containing a space.
+		expect(preview.command).toContain('--code Vertebrate-mtDNA');
+	});
+});


### PR DESCRIPTION
Implements UX audit items **1.2**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

The load-bearing part is passing args to `cliObj.exec` as an **array**. Every canonical HyPhy code name except `Universal` contains a space or a slash, and the previous single-string command was split on spaces — so only Universal ever worked in local mode, while the same choice succeeded on the server.

Relates to #143 and #152. Mitochondrial and ciliate datasets are ordinary in this field and were being turned away at the door.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 612 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
