### PR TITLE
Make the status pill, file selection and branch selection reachable

### DIFF
--- a/e2e/10-branch-selector.spec.js
+++ b/e2e/10-branch-selector.spec.js
@@ -5,6 +5,28 @@
 import { test, expect } from './fixtures/coverage.js';
 import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
 
+/**
+ * Turn on Interactive branch selection and make sure the TREE view is showing.
+ *
+ * Below ~700px the component now opens in list view, because the tree is not a usable control at
+ * that size. These specs are about the tree itself, so they ask for it explicitly rather than
+ * depending on a width-derived default — at desktop width the button is already active and the
+ * click is a no-op.
+ */
+async function showInteractiveTree(page) {
+	const branchSelect = page.locator('select').filter({
+		has: page.locator('option:text("Interactive")')
+	});
+	await branchSelect.first().selectOption('Interactive');
+
+	// Tolerate the toggle being absent on purpose: if this helper hard-required it, every assertion
+	// below would fail with "no such element" instead of failing on the geometry it is meant to pin.
+	const treeBtn = page.locator('[data-testid="branch-view-tree"]');
+	if (await treeBtn.count()) {
+		await treeBtn.click();
+	}
+}
+
 test.describe('Branch Selector UI', () => {
 	test.beforeEach(async ({ page }) => {
 		await freshStart(page);
@@ -14,62 +36,114 @@ test.describe('Branch Selector UI', () => {
 
 	test('selecting Interactive branches renders SVG tree', async ({ page }) => {
 		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
 
-		// Find and select Interactive branch mode
-		const branchSelect = page.locator('select').filter({
-			has: page.locator('option:text("Interactive")')
-		});
-
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
-
-			// SVG tree should render (web-first; no fixed wait needed).
-			const svg = page.locator('.interactive-tree-section svg, .tree-selector-wrapper svg');
-			await expect(svg.first()).toBeVisible({ timeout: 10000 });
-		}
+		// SVG tree should render (web-first; no fixed wait needed).
+		const svg = page.locator('.interactive-tree-section svg, .tree-selector-wrapper svg');
+		await expect(svg.first()).toBeVisible({ timeout: 10000 });
 	});
 
 	test('tree has clickable nodes', async ({ page }) => {
 		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
 
-		const branchSelect = page.locator('select').filter({
-			has: page.locator('option:text("Interactive")')
-		});
-
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
-
-			// Web-first: wait for the SVG tree to render at least one node.
-			const nodes = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node');
-			await expect(nodes.first()).toBeVisible({ timeout: 10000 });
-			expect(await nodes.count()).toBeGreaterThan(0);
-		}
+		// Web-first: wait for the SVG tree to render at least one node.
+		const nodes = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node');
+		await expect(nodes.first()).toBeVisible({ timeout: 10000 });
+		expect(await nodes.count()).toBeGreaterThan(0);
 	});
 
 	test('clicking a node toggles selection', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
+
+		// Web-first: wait for a node to render before clicking.
+		const node = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node').first();
+		await expect(node).toBeVisible({ timeout: 10000 });
+		await node.scrollIntoViewIfNeeded();
+		// No force:true. This used to bypass the actionability check because the r=3 node was too
+		// small to be hit reliably at mobile width; the node is now r>=6 and the tree no longer
+		// overflows, so a plain click has to pass. Reverting the radius/pan-box work makes this
+		// time out, which is the point of removing the escape hatch.
+		await node.click();
+
+		// Should show selection info (either count or branch names).
+		const selectionInfo = page.locator('.selection-summary, .no-selection-message');
+		await expect(selectionInfo.first()).toBeVisible({ timeout: 10000 });
+	});
+
+	test('the tree does not push the page sideways', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+
+		// Compare the document width WITHOUT the tree to the width WITH it, rather than asserting an
+		// absolute zero: the page already has unrelated horizontal overflow at Pixel 5 width (the
+		// method dropdown and the toast container both exceed 393px), which is a separate defect and
+		// would make an absolute assertion fail for reasons this item does not own. What must hold is
+		// that RENDERING THE TREE WIDENS NOTHING. Measured on unmodified main: 512px before, 1086px
+		// after — the BranchSelector was mounted at a hard 1000px inside containers that never clip.
+		const widthBefore = await page.evaluate(() => document.documentElement.scrollWidth);
+
+		await showInteractiveTree(page);
+		await expect(page.locator('.tree-selector-wrapper svg').first()).toBeVisible({
+			timeout: 10000
+		});
+
+		const widthAfter = await page.evaluate(() => document.documentElement.scrollWidth);
+		expect(widthAfter).toBeLessThanOrEqual(widthBefore);
+
+		// ...and it must be contained by PANNING, not by squashing the tree down to phone width,
+		// which would make it unreadable instead of unreachable.
+		const pan = await page.evaluate(() => {
+			const el = document.querySelector('.tree-pan');
+			if (!el) return null;
+			return {
+				clientWidth: el.clientWidth,
+				scrollWidth: el.scrollWidth,
+				viewport: document.documentElement.clientWidth
+			};
+		});
+		expect(pan).not.toBeNull();
+		expect(pan.clientWidth).toBeLessThanOrEqual(pan.viewport);
+
+		// This spec runs in both projects. Only below BranchSelector's minWidth (640) is the tree
+		// drawn wider than its box; at desktop width it fits, and scrollWidth === clientWidth is the
+		// correct result rather than a regression.
+		if (pan.clientWidth < 640) {
+			expect(pan.scrollWidth).toBeGreaterThan(pan.clientWidth);
+		}
+	});
+
+	test('tree nodes are large enough to tap', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
+
+		const node = page.locator('.tree-selector-wrapper svg circle').first();
+		await expect(node).toBeVisible({ timeout: 10000 });
+
+		// Web-first: the radius pass runs in a requestAnimationFrame after phylotree draws, so poll
+		// rather than sampling once and racing the frame.
+		await expect
+			.poll(async () => Number(await node.getAttribute('r')), { timeout: 10000 })
+			.toBeGreaterThanOrEqual(6);
+	});
+
+	test('narrow viewports open in list view, which is keyboard operable', async ({ page }) => {
 		await selectMethod(page, 'FEL');
 
 		const branchSelect = page.locator('select').filter({
 			has: page.locator('option:text("Interactive")')
 		});
+		await branchSelect.first().selectOption('Interactive');
 
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
+		const listBtn = page.locator('[data-testid="branch-view-list"]');
+		await expect(listBtn).toBeVisible({ timeout: 10000 });
 
-			// Web-first: wait for a node to render before clicking.
-			const node = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node').first();
-			await expect(node).toBeVisible({ timeout: 10000 });
-			await node.scrollIntoViewIfNeeded();
-			// force:true bypasses the actionability check: on the narrow mobile
-			// viewport the advanced-options panel visually overlaps the tiny
-			// (r=3) SVG node and intercepts pointer events, though the node itself
-			// is visible and hit-testable at its center. We assert visibility
-			// above, so forcing the click tests the toggle behavior, not layout.
-			await node.click({ force: true });
-
-			// Should show selection info (either count or branch names).
-			const selectionInfo = page.locator('.selection-summary, .no-selection-message');
-			await expect(selectionInfo.first()).toBeVisible({ timeout: 10000 });
+		// The default depends on width, and only the narrow case is a behaviour claim: a phone must
+		// not land on a control it cannot operate.
+		const viewport = page.viewportSize()?.width ?? 0;
+		if (viewport < 700) {
+			await expect(listBtn).toHaveAttribute('aria-pressed', 'true');
+			await expect(page.locator('[data-testid="branch-list"]')).toBeVisible();
 		}
 	});
 });

--- a/e2e/14-responsive.spec.js
+++ b/e2e/14-responsive.spec.js
@@ -5,7 +5,15 @@
  */
 
 import { test, expect } from './fixtures/coverage.js';
-import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	selectMethod,
+	seedCompletedAnalysis,
+	getStatusIndicator,
+	MOCK_FEL_RESULT
+} from './fixtures/helpers.js';
 
 test.describe('Mobile Responsiveness', () => {
 	test.beforeEach(async ({ page }) => {
@@ -48,5 +56,33 @@ test.describe('Mobile Responsiveness', () => {
 
 		const runBtn = page.locator('[data-testid="run-analysis-btn"]');
 		await expect(runBtn).toBeVisible({ timeout: 10000 });
+	});
+
+	test('status indicator is visible without opening the menu', async ({ page }) => {
+		await seedCompletedAnalysis(page, { resultJson: MOCK_FEL_RESULT, method: 'FEL' });
+		await page.reload();
+		await page.waitForSelector('.sample-card');
+
+		// The element exists either way — it used to live inside the `hidden … sm:flex` group, so
+		// only visibility distinguishes the fixed state. Do not weaken this to toHaveCount.
+		await expect(getStatusIndicator(page)).toHaveCount(1);
+		await expect(getStatusIndicator(page)).toBeVisible();
+	});
+
+	test('activating the indicator closes the mobile menu', async ({ page }) => {
+		await seedCompletedAnalysis(page, { resultJson: MOCK_FEL_RESULT, method: 'FEL' });
+		await page.reload();
+		await page.waitForSelector('.sample-card');
+
+		await page.locator('button[aria-controls="mobile-menu"]').click();
+		await expect(page.locator('#mobile-menu')).toBeVisible();
+
+		// Plain click, no force: the indicator has to be genuinely actionable with the menu open.
+		await getStatusIndicator(page).click();
+
+		await expect(page).toHaveURL(/tab=results/);
+		// The URL alone is not a valid pin — the old in-menu copy navigated too. What was broken is
+		// that the menu stayed open on top of the destination.
+		await expect(page.locator('#mobile-menu')).toHaveCount(0);
 	});
 });

--- a/e2e/21-keyboard-a11y.spec.js
+++ b/e2e/21-keyboard-a11y.spec.js
@@ -1,0 +1,69 @@
+/**
+ * E2E tests for keyboard operability of file selection and the Analyze panel.
+ *
+ * Deliberately NOT in MOBILE_SPECS: keyboard behaviour is width-independent, so this belongs in
+ * the fast chromium project.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab } from './fixtures/helpers.js';
+
+test.describe('Keyboard accessibility', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('the disabled Analyze tab explains itself without hover', async ({ page }) => {
+		// Asserting the dedicated testid, not page-body text: the unfixed page already renders
+		// "Upload a file in the Data tab to run analyses", so a loose text assertion would pass
+		// either way and pin nothing.
+		await expect(page.getByTestId('tab-gate-hint')).toHaveText(
+			'Load a file on the Data tab to unlock Analyze.'
+		);
+	});
+
+	test('the tab bar exposes tablist semantics', async ({ page }) => {
+		await expect(page.getByRole('tab', { name: /Data/ })).toHaveAttribute('aria-selected', 'true');
+	});
+
+	test('a file can be selected with the keyboard alone', async ({ page }) => {
+		// Load two files, then target the one that is NOT current: loading small.nex second makes it
+		// the active file, so pressing Enter on the CD2-slim card has to actually change something.
+		// Targeting an already-active card would let the aria-current assertion pass trivially.
+		await loadDemoFile(page, 'CD2-slim.fna');
+		await loadDemoFile(page, 'small.nex');
+
+		const card = page.locator('.file-card').filter({ hasText: 'CD2-slim.fna' });
+		const select = card.getByTestId('file-select');
+		await expect(select).not.toHaveAttribute('aria-current', 'true');
+
+		// locator.press() focuses the element and then types — keyboard only, and atomic, so a
+		// re-render of the file list between focus and keypress cannot silently drop the focus.
+		await select.press('Enter');
+
+		await expect(select).toHaveAttribute('aria-current', 'true');
+		await expect(card.getByTestId('file-selected-chip')).toBeVisible();
+
+		// Selection must come BEFORE the destructive Delete in tab order; it used to come after.
+		await select.press('Tab');
+		await expect(page.locator(':focus')).toHaveAttribute('aria-label', /details/i);
+	});
+
+	test('the Analyze panel collapses and re-expands from the keyboard', async ({ page }) => {
+		await loadDemoFile(page, 'CD2-slim.fna');
+		await goToAnalyzeTab(page);
+
+		const t = page.getByTestId('analysis-section-toggle');
+		await expect(t).toHaveAttribute('aria-expanded', 'true');
+
+		await t.focus();
+		await page.keyboard.press('Enter');
+		await expect(t).toHaveAttribute('aria-expanded', 'false');
+		await expect(page.getByTestId('method-dropdown')).toHaveCount(0);
+
+		// The second Enter is the bug itself: a section collapsed by mouse used to be permanently
+		// shut for a keyboard user, because the only toggle was a click handler on a bare div.
+		await page.keyboard.press('Enter');
+		await expect(page.getByTestId('method-dropdown')).toBeVisible();
+	});
+});

--- a/e2e/22-branch-list-mode.spec.js
+++ b/e2e/22-branch-list-mode.spec.js
@@ -1,0 +1,62 @@
+/**
+ * E2E test for the branch-selection LIST view.
+ *
+ * This pins the actual complaint behind item 6.5 rather than the geometry: RELAX refuses to run
+ * until TEST and REFERENCE branches are tagged, and until now the only way to tag them was to click
+ * a phylotree SVG — mouse-only, and unusable below ~700px. The list is a second rendering of the
+ * same phylotree state, so it must be able to make the Run button live.
+ *
+ * Width-independent, so it belongs in the fast chromium project, not MOBILE_SPECS.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+
+test.describe('Branch selection list view', () => {
+	test('RELAX becomes runnable using only the list view', async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await goToAnalyzeTab(page);
+		await selectMethod(page, 'RELAX');
+
+		const runBtn = page.locator('[data-testid="run-analysis-btn"]');
+		await expect(runBtn).toBeDisabled();
+		await expect(
+			page.locator('text=Please select TEST and REFERENCE branches on the tree before running RELAX.')
+		).toBeVisible();
+
+		await page.locator('[data-testid="branch-view-list"]').click();
+		const rows = page.locator('[data-testid="branch-row-select"]');
+		await expect(rows.first()).toBeVisible({ timeout: 10000 });
+		expect(await rows.count()).toBeGreaterThan(1);
+
+		await rows.nth(0).selectOption('TEST');
+		await rows.nth(1).selectOption('REFERENCE');
+
+		await expect(runBtn).toBeEnabled({ timeout: 10000 });
+		await expect(
+			page.locator('text=Please select TEST and REFERENCE branches on the tree before running RELAX.')
+		).toHaveCount(0);
+	});
+
+	test('reassigning a branch in the list moves its tag rather than adding one', async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await goToAnalyzeTab(page);
+		await selectMethod(page, 'RELAX');
+
+		await page.locator('[data-testid="branch-view-list"]').click();
+		const rows = page.locator('[data-testid="branch-row-select"]');
+		await expect(rows.first()).toBeVisible({ timeout: 10000 });
+
+		await rows.nth(0).selectOption('TEST');
+		await expect(rows.nth(0)).toHaveValue('TEST');
+
+		// Sets are mutually exclusive: the second assignment has to replace the first, not stack.
+		await rows.nth(0).selectOption('REFERENCE');
+		await expect(rows.nth(0)).toHaveValue('REFERENCE');
+
+		// With every tagged branch in REFERENCE there is no TEST set, so RELAX stays blocked.
+		await expect(page.locator('[data-testid="run-analysis-btn"]')).toBeDisabled();
+	});
+});

--- a/src/lib/AnalysisStatusIndicator.svelte
+++ b/src/lib/AnalysisStatusIndicator.svelte
@@ -13,8 +13,15 @@
 		}
 	});
 
+	// Callback prop rather than createEventDispatcher: this component is legacy syntax while
+	// +layout.svelte is runes-mode, and a callback prop is the form that works unambiguously across
+	// that boundary. The layout passes closeMobileMenu, so activating the pill from inside an open
+	// hamburger menu does not leave the menu covering the destination it just navigated to.
+	export let onNavigate = () => {};
+
 	// Function to navigate to the Results tab when clicked
 	function navigateToResults() {
+		onNavigate();
 		goto('/?tab=results');
 	}
 

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -451,33 +451,42 @@
 
 	<!-- Analysis Section (expanded by default) -->
 	<div class="mb-premium-xl rounded-premium border border-border-platinum bg-white shadow-premium">
+		<!--
+			The whole header row used to be a `<div on:click>`, so a section collapsed with the mouse
+			could not be reopened from the keyboard — permanently shut for keyboard users. The
+			disclosure is now a real button; the Console button is its SIBLING rather than a child,
+			because nested buttons are invalid HTML (which is also why its stopPropagation is gone).
+		-->
 		<div
-			class="flex cursor-pointer items-center justify-between rounded-t-premium bg-brand-whisper p-premium-md transition-all duration-premium hover:bg-brand-ghost"
-			on:click={toggleAnalysisSection}
+			class="flex items-center justify-between rounded-t-premium bg-brand-whisper p-premium-md transition-all duration-premium hover:bg-brand-ghost"
 		>
-			<h2 class="text-premium-header font-semibold text-text-rich">Analysis</h2>
-			<div class="flex items-center">
-				{#if $currentFile}
-					<button
-						on:click={(e) => {
-							e.stopPropagation();
-							handleToggleStdOut();
-						}}
-						class="mr-premium-md rounded-premium-sm bg-brand-royal px-premium-md py-premium-xs text-premium-meta font-medium text-white transition-all duration-premium hover:bg-brand-deep"
-					>
-						{isStdOutVisible ? 'Hide Console' : 'Show Console'}
-					</button>
-				{/if}
+			<button
+				type="button"
+				data-testid="analysis-section-toggle"
+				class="flex flex-1 items-center justify-between rounded-premium-sm text-left focus:outline-none focus:ring-2 focus:ring-brand-royal"
+				on:click={toggleAnalysisSection}
+				aria-expanded={analysisSectionExpanded}
+				aria-controls="analysis-section-body"
+			>
+				<h2 class="text-premium-header font-semibold text-text-rich">Analysis</h2>
 				<ChevronDown
 					class="h-6 w-6 text-brand-royal transition-transform duration-premium {analysisSectionExpanded
 						? 'rotate-180'
 						: ''}"
 				/>
-			</div>
+			</button>
+			{#if $currentFile}
+				<button
+					on:click={handleToggleStdOut}
+					class="ml-premium-md rounded-premium-sm bg-brand-royal px-premium-md py-premium-xs text-premium-meta font-medium text-white transition-all duration-premium hover:bg-brand-deep"
+				>
+					{isStdOutVisible ? 'Hide Console' : 'Show Console'}
+				</button>
+			{/if}
 		</div>
 
 		{#if analysisSectionExpanded}
-			<div class="p-premium-lg">
+			<div id="analysis-section-body" class="p-premium-lg">
 				{#if $currentFile}
 					<!-- Method Selector (includes timing estimate) -->
 					<MethodSelector

--- a/src/lib/BranchSelector.svelte
+++ b/src/lib/BranchSelector.svelte
@@ -3,9 +3,10 @@
 -->
 
 <script>
-	import { onMount, createEventDispatcher, tick } from 'svelte';
+	import { onMount, onDestroy, createEventDispatcher, tick } from 'svelte';
 	import * as phylotree from 'phylotree';
 	import * as d3 from 'd3';
+	import { assignBranchToSet, branchNameOf, listBranches } from './utils/branchSetTagging.js';
 
 	const dispatch = createEventDispatcher();
 
@@ -13,6 +14,14 @@
 	export let treeData = '';
 	export let height = 400;
 	export let width = 800;
+
+	// Smallest width the tree is ever drawn at. Below this, tip labels collide and the tree stops
+	// being readable at all, so we draw at minWidth and let the pan box scroll instead of squashing.
+	export let minWidth = 640;
+
+	// Width at or below which the list view is the better default. Chosen to match minWidth's
+	// intent: if the viewport cannot show the tree without panning, start with the list.
+	export let listByDefaultBelow = 700;
 
 	// Props - Selection mode
 	export let mode = 'single-set'; // 'single-set' for FG/BG, 'multi-set' for contrast-fel
@@ -28,6 +37,32 @@
 	let treeContainer;
 	let tree;
 	let internalSelectedBranches = []; // Internal tracking of selection
+
+	// Responsive state. `hostEl` is the pan box; its width is PARENT-driven only (width: 100%), never
+	// tree-driven, otherwise the ResizeObserver would feed the tree's own width back into itself.
+	let hostEl;
+	let measuredWidth = 0;
+	let resizeTimer;
+	let resizeObserver;
+	let lastRenderedWidth = 0;
+	$: renderWidth = Math.max(minWidth, measuredWidth || width);
+
+	// View state. The list is not a different selection MODE — it is a second rendering of the same
+	// phylotree state — so it deliberately does not touch `branchesToTest` upstream.
+	let view = 'tree';
+	// True when the last render happened with the pan box hidden, which leaves the SVG without a
+	// viewBox. Switching to the tree view then has to redraw; otherwise it must not.
+	let renderedWhileHidden = false;
+	let branchFilter = '';
+	let branchRows = [];
+
+	// Node hit targets. Phylotree draws r=3 circles; that is a 6px target, well under any usable
+	// minimum, and it is why e2e/10-branch-selector.spec.js needed force:true to click one.
+	const MIN_NODE_RADIUS = 6;
+
+	// Re-rendering builds a brand-new phylotree, so it is not free: it throws away the live
+	// selection, which we then have to restore. Ignore width jitter below this.
+	const RERENDER_WIDTH_THRESHOLD = 24;
 
 	// Unique container ID to avoid conflicts
 	let containerId = `tree-container-${Math.random().toString(36).substring(2, 9)}`;
@@ -58,10 +93,66 @@
 	}
 
 	onMount(() => {
+		// Decide the initial view from a real measurement, synchronously, BEFORE the first render.
+		// Deriving it from the debounced ResizeObserver instead would flip the view ~150ms after the
+		// tree had already appeared — visibly jarring, and a race for anything reading the DOM.
+		// It is decided once: a later resize must not yank the view out from under the user.
+		measuredWidth = Math.round(hostEl?.getBoundingClientRect().width || 0);
+		if (measuredWidth) {
+			view = measuredWidth < listByDefaultBelow ? 'list' : 'tree';
+		}
+
 		if (treeData) {
 			renderTree();
 		}
+
+		if (typeof ResizeObserver !== 'undefined' && hostEl) {
+			resizeObserver = new ResizeObserver((entries) => {
+				const w = Math.round(entries[0]?.contentRect?.width || 0);
+				clearTimeout(resizeTimer);
+				resizeTimer = setTimeout(() => handleHostResize(w), 150);
+			});
+			resizeObserver.observe(hostEl);
+		}
 	});
+
+	onDestroy(() => {
+		clearTimeout(resizeTimer);
+		resizeObserver?.disconnect();
+	});
+
+	// React to a real width change only. A phone rotated mid-selection must not silently lose its
+	// TEST/REFERENCE assignments, so the selection is snapshotted and handed back to phylotree
+	// through its own initial-selection / initial-sets render options.
+	async function handleHostResize(w) {
+		if (!w) return;
+		measuredWidth = w;
+
+		if (!tree) return;
+		const next = Math.max(minWidth, w);
+		if (Math.abs(next - lastRenderedWidth) <= RERENDER_WIDTH_THRESHOLD) return;
+
+		await tick();
+		renderTree(snapshotSelection());
+	}
+
+	// Capture the current selection in a form phylotree can replay after a re-render.
+	function snapshotSelection() {
+		if (!tree?.display) return null;
+
+		if (effectiveMode === 'multi-set') {
+			const sets = {};
+			selectionSets.forEach((setName) => {
+				const members = tree.display.getSetMembers?.(setName) || [];
+				const names = members.map(branchNameOf).filter(Boolean);
+				if (names.length > 0) sets[setName] = names;
+			});
+			return Object.keys(sets).length > 0 ? { sets } : null;
+		}
+
+		const names = (tree.display.getSelection?.() || []).map(branchNameOf).filter(Boolean);
+		return names.length > 0 ? { names } : null;
+	}
 
 	// Watch for tree data changes
 	$: if (treeData && treeContainer) {
@@ -190,7 +281,7 @@
 	// Note: updateNodeStyling removed - phylotree handles styling automatically
 	// via CSS classes like .phylotree-set-branch-{setName}
 
-	function renderTree() {
+	function renderTree(restore = null) {
 		try {
 			// Make sure we have a valid Newick string
 			if (!treeData || treeData.trim() === '') {
@@ -202,10 +293,15 @@
 			tree = new phylotree.phylotree(treeData);
 
 			// Render the tree with multi-set options if in multi-set mode
+			lastRenderedWidth = renderWidth;
+			renderedWhileHidden = view !== 'tree';
 			const renderOptions = {
 				container: `#${containerId}`,
 				height: height,
-				width: width,
+				// renderWidth, not `width`: below minWidth the tree is drawn at minWidth and the pan box
+				// scrolls. Drawing it at the viewport width instead used to squash the whole tree, and
+				// drawing it at a hard-coded 1000px used to push the PAGE 693px wider than a phone.
+				width: renderWidth,
 				'show-menu': true,
 				selectable: true,
 				collapsible: true,
@@ -220,6 +316,11 @@
 					name,
 					color: setColors[i] || setColors[i % setColors.length]
 				}));
+				if (restore?.sets) {
+					renderOptions['initial-sets'] = restore.sets;
+				}
+			} else if (restore?.names) {
+				renderOptions['initial-selection'] = restore.names;
 			}
 
 			tree.render(renderOptions);
@@ -257,6 +358,7 @@
 						} catch (e) {
 							// getBBox can fail if SVG not visible, ignore
 						}
+						enforceMinNodeRadius(container);
 					});
 				}
 
@@ -265,10 +367,34 @@
 					setupClickHandlers(container);
 				}
 			}
+
+			refreshBranchRows();
 		} catch (e) {
 			console.error('BranchSelector: Error rendering tree:', e);
 			dispatch('error', { message: e.message, error: e });
 		}
+	}
+
+	/**
+	 * Grow phylotree's r=3 node circles to a tappable size.
+	 *
+	 * This is done as a d3 attribute pass, not purely in CSS, because the SVG2 `r` geometry property
+	 * is unsupported on older engines — CSS alone would leave those users with the 6px target the
+	 * whole item is about. It has to be re-applied after every selection change, because phylotree
+	 * redraws the node circles on update().
+	 */
+	function enforceMinNodeRadius(container) {
+		if (!container) return;
+		requestAnimationFrame(() => {
+			// Both classes matter: phylotree tags LEAF groups `.node` and internal ones
+			// `.internal-node` (see its css_classes map), so `.node circle` alone silently misses
+			// every internal node — which is most of what you tag for RELAX and Contrast-FEL.
+			d3.select(container)
+				.selectAll('.node circle, .internal-node circle')
+				.attr('r', function () {
+					return Math.max(MIN_NODE_RADIUS, +this.getAttribute('r') || 0);
+				});
+		});
 	}
 
 	// Set up event listeners for branch selection
@@ -303,6 +429,80 @@
 		d3.select(container)
 			.selectAll('.branch, path.branch, .node circle')
 			.style('cursor', 'pointer');
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// List view
+	//
+	// The tree is the only way to assign branches to sets, and it is a mouse-only, sighted-only,
+	// wide-screen-only control: RELAX and Contrast-FEL refuse to run until TEST/REFERENCE (or two
+	// groups) are tagged, so on a phone — or with a keyboard — those two methods were simply
+	// unrunnable. This list renders the SAME phylotree state through form controls. It is not a new
+	// branch-selection mode: assignments go through phylotree's own APIs and out through the
+	// existing selectionChange event, so nothing upstream needs to know it exists.
+	// ---------------------------------------------------------------------------------------------
+
+	function treeNodes() {
+		// phylotree 2.x keeps the tree in `nodes` (a d3 hierarchy). There is no `tree.json`.
+		return tree?.nodes?.descendants?.() || [];
+	}
+
+	function refreshBranchRows() {
+		branchRows = listBranches(treeNodes());
+	}
+
+	$: filteredBranchRows = branchFilter.trim()
+		? branchRows.filter((row) => row.name.toLowerCase().includes(branchFilter.trim().toLowerCase()))
+		: branchRows;
+
+	// Options offered per row: the real sets, plus "unassigned".
+	$: rowSetOptions = effectiveMode === 'multi-set' ? selectionSets : ['Foreground'];
+
+	async function setView(next) {
+		const wasHidden = renderedWhileHidden;
+		view = next;
+
+		if (next === 'list') {
+			refreshBranchRows();
+			return;
+		}
+
+		// Only redraw if the tree was last drawn into a display:none box — there it had no layout, so
+		// getBBox threw and the viewBox was never set. Redrawing unconditionally would also throw away
+		// and rebuild a perfectly good tree every time the already-active Tree button is pressed.
+		if (!wasHidden) return;
+
+		await tick();
+		renderTree(snapshotSelection());
+	}
+
+	function handleRowAssignment(branchName, setName) {
+		if (!tree) return;
+
+		const nodes = treeNodes();
+		const node = nodes.find((n) => branchNameOf(n) === branchName);
+		if (!node) return;
+
+		if (effectiveMode === 'multi-set') {
+			// Prefer phylotree's own set APIs so the tree view's colours agree with the list. addToSet
+			// is already mutually exclusive; removeFromSet needs to be told which set to leave.
+			if (setName && tree.display?.addToSet) {
+				tree.display.addToSet(node, setName);
+			} else if (!setName && tree.display?.removeFromSet) {
+				const current = node._selectionSet;
+				if (current) tree.display.removeFromSet(node, current);
+			} else {
+				// No display (or an older phylotree): fall back to the extracted, DOM-free tagging.
+				assignBranchToSet(nodes, branchName, setName, selectionSets);
+			}
+		} else if (setName) {
+			tree.display?.selectNodes?.([branchName]);
+		} else {
+			tree.display?.deselectNodes?.([branchName]);
+		}
+
+		updateSelectedBranches();
+		enforceMinNodeRadius(treeContainer);
 	}
 
 	// Clear all selections (for single-select mode)
@@ -352,18 +552,11 @@
 					});
 				});
 			} else {
-				// Fallback: manually traverse to find nodes in any set
-				function findSelectedNodes(node) {
-					if (node._selectionSet || selectionSets.some(s => node[s])) {
-						if (!current_selection.includes(node)) {
-							current_selection.push(node);
-						}
-					}
-					node.children?.forEach(findSelectedNodes);
-				}
-				if (tree.json) {
-					findSelectedNodes(tree.json);
-				}
+				// Fallback for a tree with no display: scan the hierarchy directly. (This used to walk
+				// `tree.json`, which phylotree 2.x does not define, so it could never find anything.)
+				current_selection = treeNodes().filter(
+					(node) => node._selectionSet || selectionSets.some((s) => node[s])
+				);
 			}
 		} else {
 			// Single-set mode: use phylotree's getSelection API
@@ -373,6 +566,10 @@
 		internalSelectedBranches = current_selection.map((node) => {
 			return node.data?.name || node.name || `node_${node.id || Math.random()}`;
 		});
+
+		// Keep the list view in step with the tree: both are views of the same phylotree state, so a
+		// click on a branch has to move the corresponding row's <select>, and vice versa.
+		refreshBranchRows();
 
 		// Generate tagged Newick string
 		const taggedNewick = generateTaggedNewick();
@@ -527,13 +724,93 @@
 		</div>
 	{/if}
 
-	<div
-		id={containerId}
-		bind:this={treeContainer}
-		class="tree-container"
-		class:tree-disabled={disabled}
-		style="height: {height}px; width: {width}px;"
-	></div>
+	<div class="view-toggle" role="group" aria-label="Branch selection view">
+		<button
+			type="button"
+			data-testid="branch-view-tree"
+			class="view-toggle-btn"
+			class:active={view === 'tree'}
+			aria-pressed={view === 'tree'}
+			on:click={() => setView('tree')}
+			{disabled}
+		>
+			Tree
+		</button>
+		<button
+			type="button"
+			data-testid="branch-view-list"
+			class="view-toggle-btn"
+			class:active={view === 'list'}
+			aria-pressed={view === 'list'}
+			on:click={() => setView('list')}
+			{disabled}
+		>
+			List
+		</button>
+	</div>
+
+	<!--
+		The pan box is always parent-sized (width: 100%) and scrolls horizontally. The tree inside it
+		keeps its own, larger width. If this box were ever sized by the tree, the ResizeObserver would
+		feed the tree's width back into renderWidth and oscillate.
+
+		It stays mounted in list view (hidden, not destroyed) so that switching views does not throw
+		away the rendered phylotree — which is the shared source of truth for both views.
+	-->
+	<div class="tree-pan" bind:this={hostEl} class:hidden-view={view !== 'tree'}>
+		<div
+			id={containerId}
+			bind:this={treeContainer}
+			class="tree-container"
+			class:tree-disabled={disabled}
+			style="height: {height}px; width: {renderWidth}px;"
+		></div>
+	</div>
+
+	{#if view === 'list'}
+		<div class="branch-list" data-testid="branch-list">
+			<label class="branch-filter-label" for="{containerId}-filter">
+				Filter branches
+				<input
+					id="{containerId}-filter"
+					type="search"
+					bind:value={branchFilter}
+					placeholder="Search by name"
+					{disabled}
+				/>
+			</label>
+
+			{#if filteredBranchRows.length === 0}
+				<p class="no-data-message">
+					{branchRows.length === 0 ? 'No branches to assign yet.' : 'No branches match that filter.'}
+				</p>
+			{:else}
+				<ul class="branch-rows">
+					{#each filteredBranchRows as row (row.name)}
+						<li class="branch-row">
+							<label class="branch-row-label" for="{containerId}-row-{row.name}">
+								<span class="branch-row-name">{row.name}</span>
+								<span class="branch-row-kind">{row.isLeaf ? 'leaf' : 'internal'}</span>
+							</label>
+							<select
+								id="{containerId}-row-{row.name}"
+								data-testid="branch-row-select"
+								data-branch={row.name}
+								value={row.set}
+								on:change={(e) => handleRowAssignment(row.name, e.currentTarget.value)}
+								{disabled}
+							>
+								<option value="">—</option>
+								{#each rowSetOptions as setName}
+									<option value={setName}>{setName}</option>
+								{/each}
+							</select>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
 
 	{#if !treeData}
 		<p class="no-data-message">No tree data provided</p>
@@ -558,12 +835,126 @@
 		pointer-events: none;
 	}
 
+	/* Parent-driven width only — see the comment on the markup. */
+	.tree-pan {
+		width: 100%;
+		max-width: 100%;
+		overflow-x: auto;
+		overflow-y: hidden;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.tree-pan.hidden-view {
+		display: none;
+	}
+
 	.tree-container {
 		background: #f9fafb;
 		overflow: auto;
 		border: 1px solid #ccc;
 		border-radius: 4px;
 	}
+
+	.view-toggle {
+		display: flex;
+		gap: 0.25rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.view-toggle-btn {
+		padding: 0.5rem 1rem;
+		min-height: 44px;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		background: white;
+		font-size: 14px;
+		cursor: pointer;
+	}
+
+	.view-toggle-btn.active {
+		background: #1d4ed8;
+		border-color: #1d4ed8;
+		color: white;
+		font-weight: 600;
+	}
+
+	.branch-list {
+		margin-top: 0.75rem;
+	}
+
+	.branch-filter-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: #374151;
+		margin-bottom: 0.5rem;
+	}
+
+	.branch-filter-label input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		font-size: 14px;
+	}
+
+	.branch-rows {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 20rem;
+		overflow-y: auto;
+		border: 1px solid #e5e7eb;
+		border-radius: 4px;
+	}
+
+	.branch-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border-bottom: 1px solid #f3f4f6;
+	}
+
+	.branch-row:last-child {
+		border-bottom: none;
+	}
+
+	.branch-row-label {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.branch-row-name {
+		font-size: 0.875rem;
+		color: #111827;
+		overflow-wrap: anywhere;
+	}
+
+	.branch-row-kind {
+		font-size: 0.75rem;
+		color: #9ca3af;
+	}
+
+	.branch-row select {
+		min-height: 44px;
+		padding: 0.25rem 0.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		font-size: 14px;
+	}
+
+	/*
+	 * Node hit targets are enlarged by the d3 attribute pass in enforceMinNodeRadius, NOT here.
+	 * `r` as a CSS geometry property is SVG2: unsupported on older engines, and svelte-check flags
+	 * it as an unknown property. Do not "simplify" that pass into a CSS rule — it would silently
+	 * restore the 6px tap target on exactly the browsers least able to hit it.
+	 */
 
 	.tree-container.tree-disabled {
 		pointer-events: none;

--- a/src/lib/FileCard.svelte
+++ b/src/lib/FileCard.svelte
@@ -181,9 +181,12 @@
 	$: fileTypeLabel = getFileTypeLabel(file.filename, file.contentType);
 	$: timeAgo = getTimeAgo(file.createdAt);
 
-	// Toggle details visibility
-	function toggleDetails(event) {
-		event.stopPropagation();
+	// aria-controls target for the disclosure button. Per-file so several cards can be open at once.
+	$: detailsId = `file-details-${file.id}`;
+
+	// Toggle details visibility. No stopPropagation: the card body is no longer clickable, so there
+	// is nothing above this to stop.
+	function toggleDetails() {
 		showDetails = !showDetails;
 	}
 
@@ -193,8 +196,7 @@
 	}
 
 	// Delete the file
-	function deleteFile(event) {
-		event.stopPropagation();
+	function deleteFile() {
 		if (confirm(`Are you sure you want to delete "${file.filename}"?`)) {
 			dispatch('delete', { id: file.id });
 		}
@@ -207,9 +209,22 @@
 	class:ring-1={isActive}
 	class:ring-brand-muted={isActive}
 >
-	<div class="cursor-pointer p-3 sm:p-premium-md" on:click={selectFile}>
+	<div class="p-3 sm:p-premium-md">
 		<div class="flex items-center justify-between gap-2">
-			<div class="flex min-w-0 flex-1 items-center">
+			<!--
+				The whole card body used to be a `<div on:click>` — unfocusable, unlabelled, and invisible
+				to the keyboard. It cannot simply become a <button>, because it contains the details and
+				delete buttons and nested buttons are invalid HTML. So the icon + name block is the button
+				and the actions are its sibling: that also puts selection BEFORE the destructive Delete in
+				tab order, which the old DOM order got backwards.
+			-->
+			<button
+				type="button"
+				data-testid="file-select"
+				class="flex min-w-0 flex-1 items-center rounded-premium-sm text-left focus:outline-none focus:ring-2 focus:ring-brand-royal"
+				on:click={selectFile}
+				aria-current={isActive ? 'true' : undefined}
+			>
 				<!-- File icon based on type -->
 				<div
 					class="mr-2 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg sm:mr-premium-md sm:h-10 sm:w-10 sm:rounded-premium-sm {fileTypeColor}"
@@ -227,6 +242,14 @@
 							class="hidden flex-shrink-0 rounded-full bg-brand-whisper px-1.5 py-0.5 text-[10px] text-text-slate xs:inline sm:rounded-premium-xl sm:px-premium-sm sm:text-premium-caption"
 							>{fileTypeLabel}</span
 						>
+						<!-- Selected state was signalled by border colour alone; give it a text channel too. -->
+						{#if isActive}
+							<span
+								data-testid="file-selected-chip"
+								class="flex-shrink-0 rounded-full bg-brand-royal px-1.5 py-0.5 text-[10px] font-semibold text-white sm:rounded-premium-xl sm:px-premium-sm sm:text-premium-caption"
+								>Selected</span
+							>
+						{/if}
 					</div>
 					<div class="flex items-center text-[11px] text-text-silver sm:text-premium-caption">
 						<span>{formatFileSize(file.size)}</span>
@@ -234,7 +257,7 @@
 						<span title={formatDate(file.createdAt)}>{timeAgo}</span>
 					</div>
 				</div>
-			</div>
+			</button>
 
 			<!-- Actions -->
 			<div class="flex flex-shrink-0 items-center gap-0.5 sm:gap-1">
@@ -243,6 +266,8 @@
 					class="flex h-9 w-9 items-center justify-center rounded-lg text-text-slate transition-all duration-premium hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal focus:ring-offset-1 sm:h-11 sm:w-11 sm:rounded-premium-sm"
 					title={showDetails ? 'Hide details' : 'Show details'}
 					aria-label={showDetails ? 'Hide details' : 'Show details'}
+					aria-expanded={showDetails}
+					aria-controls={detailsId}
 				>
 					{#if showDetails}
 						<ChevronUp class="h-4 w-4 sm:h-5 sm:w-5" />
@@ -264,7 +289,7 @@
 
 		<!-- Details panel (conditional) -->
 		{#if showDetails}
-			<div class="details-panel mt-premium-md rounded-premium bg-brand-whisper p-premium-md">
+			<div id={detailsId} class="details-panel mt-premium-md rounded-premium bg-brand-whisper p-premium-md">
 				<!-- File preview, if available -->
 				{#if preview}
 					<div class="mb-premium-md">

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1149,14 +1149,21 @@
 		});
 	}
 
-	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged
+	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged.
+	//
+	// Read through methodOptions[selectedMethod], NOT methodOptions.relax: this map is keyed by the
+	// method string exactly as the dropdown supplies it ('RELAX'), which initializeMethodOptions and
+	// handleBranchSelectionChange both use. The lowercase lookup was always undefined, so
+	// relaxHasTestBranches was permanently false and RELAX's Run button could never be enabled no
+	// matter what the user tagged. contrastFelBranchesValid below already uses the indexed form.
+	$: relaxOptions = selectedMethod ? methodOptions?.[selectedMethod] : null;
 	$: relaxHasTestBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		methodOptions?.relax?.interactiveTree?.includes('{TEST}');
+		relaxOptions?.interactiveTree?.includes('{TEST}');
 	$: relaxHasReferenceBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		(methodOptions?.relax?.interactiveTree?.includes('{REFERENCE}') ||
-			methodOptions?.relax?.referenceBranches === 'All');
+		(relaxOptions?.interactiveTree?.includes('{REFERENCE}') ||
+			relaxOptions?.referenceBranches === 'All');
 	$: relaxBranchesValid =
 		selectedMethod?.toLowerCase() !== 'relax' ||
 		(relaxHasTestBranches && relaxHasReferenceBranches);
@@ -1602,10 +1609,13 @@
 				{#if selectedTreeData}
 					<div class="tree-selector-wrapper">
 						{#key selectedMethod}
+							<!-- No `width`: BranchSelector measures its own pan box and draws at least
+							     minWidth, scrolling inside the box. The hard-coded 1000px used to push the
+							     PAGE 693px wider than a 393px phone. Do NOT widen this {#key} to include a
+							     width — every resize would remount and discard the current selection. -->
 							<BranchSelector
 								treeData={selectedTreeData}
 								height={500}
-								width={1000}
 								mode={selectedMethod?.toLowerCase() === 'contrast-fel' ||
 								selectedMethod?.toLowerCase() === 'relax'
 									? 'multi-set'

--- a/src/lib/SmartTabNavigation.svelte
+++ b/src/lib/SmartTabNavigation.svelte
@@ -41,6 +41,41 @@
 	$: isAnalyzeDisabled = !hasFiles || currentFileFailedValidation;
 	$: isResultsDisabled = !hasAnalyses;
 
+	// Roving tabindex: the tab bar is ONE tab stop, and Arrow/Home/End move between tabs. This is
+	// the WAI-ARIA tabs pattern; without it a keyboard user cannot tell the three buttons form a
+	// group, and the gate reason was hover-only (a `title` tooltip), i.e. invisible to them entirely.
+	const TAB_ORDER = ['data', 'analyze', 'results'];
+
+	function focusTabAt(index) {
+		const name = TAB_ORDER[(index + TAB_ORDER.length) % TAB_ORDER.length];
+		const el = document.getElementById(`tab-${name}`);
+		el?.focus();
+	}
+
+	function handleTabKeydown(event) {
+		const currentIndex = TAB_ORDER.indexOf(activeTab);
+		const from = currentIndex === -1 ? 0 : currentIndex;
+
+		switch (event.key) {
+			case 'ArrowRight':
+				event.preventDefault();
+				focusTabAt(from + 1);
+				break;
+			case 'ArrowLeft':
+				event.preventDefault();
+				focusTabAt(from - 1);
+				break;
+			case 'Home':
+				event.preventDefault();
+				focusTabAt(0);
+				break;
+			case 'End':
+				event.preventDefault();
+				focusTabAt(TAB_ORDER.length - 1);
+				break;
+		}
+	}
+
 	// Function to handle tab clicks with context-aware behavior
 	function handleTabClick(tabName) {
 		// Data tab is always accessible
@@ -69,7 +104,7 @@
 
 <div class="mb-4 sm:mb-premium-xl">
 	<div class="rounded-premium bg-brand-ghost p-1 sm:p-premium-xs">
-		<div class="flex border-b border-border-platinum">
+		<div class="flex border-b border-border-platinum" role="tablist" aria-label="Analysis workflow">
 			<!-- Data Tab - Always Enabled -->
 			<button
 				class="relative min-h-[48px] flex-1 px-2 py-3 text-xs font-semibold transition-all duration-premium sm:flex-none sm:px-premium-xl sm:py-premium-lg sm:text-premium-brand"
@@ -79,6 +114,12 @@
 				class:hover:bg-brand-whisper={activeTab !== 'data'}
 				on:click={() => handleTabClick('data')}
 				title="Manage sequence data"
+				role="tab"
+				id="tab-data"
+				aria-selected={activeTab === 'data'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'data' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -113,6 +154,12 @@
 				on:click={() => handleTabClick('analyze')}
 				title={isAnalyzeDisabled ? 'Upload data first' : 'Run analysis on selected data'}
 				aria-disabled={isAnalyzeDisabled}
+				role="tab"
+				id="tab-analyze"
+				aria-selected={activeTab === 'analyze'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'analyze' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -150,6 +197,12 @@
 				on:click={() => handleTabClick('results')}
 				title={isResultsDisabled ? 'Run analysis first' : 'View analysis results'}
 				aria-disabled={isResultsDisabled}
+				role="tab"
+				id="tab-results"
+				aria-selected={activeTab === 'results'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'results' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -177,6 +230,27 @@
 				{/if}
 			</button>
 		</div>
+
+		<!--
+			Why a locked tab is locked, stated in the page rather than in a `title` tooltip: hover does
+			not exist on touch and is not reachable by keyboard. The three-way split matters —
+			isAnalyzeDisabled is true for two different reasons, and a file that failed validation must
+			NOT be told to load a file it has already loaded (issue #189).
+		-->
+		{#if currentFileFailedValidation || isAnalyzeDisabled || isResultsDisabled}
+			<p
+				data-testid="tab-gate-hint"
+				class="px-2 pt-2 text-xs text-text-slate sm:px-premium-xl sm:pt-premium-sm sm:text-premium-caption"
+			>
+				{#if currentFileFailedValidation}
+					This file could not be read — load a different alignment to unlock Analyze.
+				{:else if isAnalyzeDisabled}
+					Load a file on the Data tab to unlock Analyze.
+				{:else}
+					Run an analysis to unlock Results.
+				{/if}
+			</p>
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/utils/branchSetTagging.js
+++ b/src/lib/utils/branchSetTagging.js
@@ -1,0 +1,90 @@
+/**
+ * Branch-set tagging, extracted from BranchSelector so it can be unit-tested without a DOM.
+ *
+ * Phylotree keeps set membership on the d3 hierarchy nodes as `node._selectionSet`, and
+ * `tree.getNewick(annotator)` turns that into the `name{TEST}:0.1` tags HyPhy reads. The rule that
+ * matters and is easy to get wrong: sets are MUTUALLY EXCLUSIVE, so assigning a branch that is
+ * already in one set must MOVE its tag, never add a second. `tree.display.addToSet` enforces that
+ * for the interactive tree; these helpers enforce the same thing for the list view and for the case
+ * where no display exists yet.
+ *
+ * Note on shape: an earlier version of this code traversed `tree.json`. That property does not
+ * exist on phylotree 2.2.1 — the tree is `tree.nodes`, a d3 hierarchy — so every one of those
+ * traversals was dead code. These functions take the descendant ARRAY
+ * (`tree.nodes.descendants()`), which keeps them free of both the DOM and phylotree itself.
+ */
+
+/** Name of a hierarchy node, tolerating both `{data:{name}}` and plain `{name}` shapes. */
+export function branchNameOf(node) {
+	if (!node) return '';
+	return node.data?.name ?? node.name ?? '';
+}
+
+/** The set a branch currently belongs to, or '' when it is unassigned. */
+export function branchSetOf(node) {
+	return node?._selectionSet || '';
+}
+
+/**
+ * Assign one branch to one set, or clear it when `setName` is falsy.
+ *
+ * @param {Array} nodes      descendants of the tree (tree.nodes.descendants())
+ * @param {string} branchName name of the branch to change
+ * @param {string} setName    target set, or '' / null to unassign
+ * @param {string[]} allSets  every set name in play; their legacy per-set boolean flags are cleared
+ *                            too, because generateTaggedNewick still falls back to reading them
+ * @returns {boolean} whether a matching branch was found
+ */
+export function assignBranchToSet(nodes, branchName, setName, allSets = []) {
+	if (!Array.isArray(nodes) || !branchName) return false;
+
+	const node = nodes.find((n) => branchNameOf(n) === branchName);
+	if (!node) return false;
+
+	// Clear first, unconditionally: this is what makes reassignment a MOVE rather than an
+	// accumulation, and it is the behaviour the tagged Newick depends on ({TEST,REFERENCE} on one
+	// branch is not a thing HyPhy accepts).
+	delete node._selectionSet;
+	allSets.forEach((s) => {
+		delete node[s];
+	});
+
+	if (setName) {
+		node._selectionSet = setName;
+	}
+	return true;
+}
+
+/**
+ * Rows for the list view, in tree order.
+ *
+ * The root is excluded: it has no branch, so there is nothing to tag. Unnamed nodes are excluded
+ * for the same practical reason — a branch with no name cannot be identified in the Newick output,
+ * so offering it in the list would produce an assignment that silently goes nowhere.
+ *
+ * @returns {Array<{name: string, set: string, isLeaf: boolean}>}
+ */
+export function listBranches(nodes) {
+	if (!Array.isArray(nodes)) return [];
+
+	return nodes
+		.filter((n) => (n.depth ?? 0) > 0)
+		.map((n) => ({
+			name: branchNameOf(n),
+			set: branchSetOf(n),
+			isLeaf: !(n.children && n.children.length)
+		}))
+		.filter((row) => row.name);
+}
+
+/**
+ * The `{SET}` suffix for a node, shared by the tree and list paths so both produce the same Newick.
+ * Falls back to the legacy per-set boolean properties for trees tagged before `_selectionSet`.
+ */
+export function multiSetTag(node, allSets = []) {
+	const direct = branchSetOf(node);
+	if (direct) return `{${direct}}`;
+
+	const legacy = allSets.filter((s) => node && node[s]);
+	return legacy.length > 0 ? `{${legacy.join(',')}}` : '';
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -97,42 +97,53 @@
 				<span class="rounded bg-accent-copper px-1.5 py-0.5 text-xs font-semibold text-white">BETA</span>
 			</a>
 
-			<!-- Mobile menu button -->
-			<button
-				type="button"
-				class="inline-flex h-11 w-11 items-center justify-center rounded-premium-sm text-text-slate hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal sm:hidden"
-				aria-controls="mobile-menu"
-				aria-expanded={mobileMenuOpen}
-				onclick={toggleMobileMenu}
-			>
-				<span class="sr-only">Open main menu</span>
-				{#if mobileMenuOpen}
-					<X class="h-6 w-6" />
-				{:else}
-					<Menu class="h-6 w-6" />
-				{/if}
-			</button>
+			<div class="flex items-center gap-2 sm:gap-premium-lg">
+				<!--
+					Analysis Status Indicator — deliberately NOT width-gated, and deliberately a single
+					instance. It used to live only inside the `hidden … sm:flex` group, so on a phone the
+					one cross-tab signal that an analysis had finished (or failed) was display:none and
+					reachable only by opening the hamburger. It also has to stay a single instance at every
+					width: e2e/fixtures/helpers.js and 07-wasm-analysis.spec.js count
+					`button[aria-label="View all analyses"]` and its colour spans, so a mobile copy alongside
+					the desktop one would break them. It self-hides when there is nothing to report, so the
+					first-visit header is unchanged.
+				-->
+				<AnalysisStatusIndicator onNavigate={closeMobileMenu} />
 
-			<!-- Desktop navigation -->
-			<div class="hidden items-center space-x-premium-lg sm:flex">
-				<ul class="flex items-center space-x-premium-lg">
-					<li>
-						<a
-							class="rounded-premium-sm px-3 py-2 text-premium-brand font-medium text-text-rich transition-colors duration-premium hover:bg-brand-whisper hover:text-brand-royal"
-							href="http://help.datamonkey.org"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Help
-						</a>
-					</li>
-				</ul>
+				<!-- Desktop navigation -->
+				<div class="hidden items-center space-x-premium-lg sm:flex">
+					<ul class="flex items-center space-x-premium-lg">
+						<li>
+							<a
+								class="rounded-premium-sm px-3 py-2 text-premium-brand font-medium text-text-rich transition-colors duration-premium hover:bg-brand-whisper hover:text-brand-royal"
+								href="http://help.datamonkey.org"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Help
+							</a>
+						</li>
+					</ul>
 
-				<!-- Analysis Status Indicator -->
-				<AnalysisStatusIndicator />
+					<!-- Backend Connectivity Indicator -->
+					<BackendConnectivityIndicator />
+				</div>
 
-				<!-- Backend Connectivity Indicator -->
-				<BackendConnectivityIndicator />
+				<!-- Mobile menu button -->
+				<button
+					type="button"
+					class="inline-flex h-11 w-11 items-center justify-center rounded-premium-sm text-text-slate hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal sm:hidden"
+					aria-controls="mobile-menu"
+					aria-expanded={mobileMenuOpen}
+					onclick={toggleMobileMenu}
+				>
+					<span class="sr-only">Open main menu</span>
+					{#if mobileMenuOpen}
+						<X class="h-6 w-6" />
+					{:else}
+						<Menu class="h-6 w-6" />
+					{/if}
+				</button>
 			</div>
 		</div>
 
@@ -153,7 +164,7 @@
 					<div class="flex items-center justify-between">
 						<span class="text-sm text-text-slate">Status</span>
 						<div class="flex items-center space-x-3">
-							<AnalysisStatusIndicator />
+							<!-- No AnalysisStatusIndicator here: it now sits in the header at every width. -->
 							<BackendConnectivityIndicator />
 						</div>
 					</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1424,44 +1424,48 @@
 			<SmartTabNavigation {activeTab} onChange={changeTab} />
 
 			<!-- Tab Content with Progressive Enhancement -->
-			{#if activeTab === 'data'}
-				<!-- Data Tab -->
-				<DataTab
-					{handleFileUpload}
-					{handleDemoFileSelect}
-					{validationError}
-					{fileMetricsJSON}
-					{handleValidated}
-					{handleUseRepaired}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'analyze'}
-				<!-- Analyze Tab -->
-				<AnalyzeTab
-					{methodConfig}
-					{runMethod}
-					{selectedMethod}
-					{hyphyOut}
-					{isStdOutVisible}
-					{toggleStdOut}
-					{showAllHistory}
-					{selectAnalysis}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'results'}
-				<!-- Results Tab -->
-				<ResultsTab
-					{selectedAnalysisId}
-					{selectAnalysis}
-					{showAllHistory}
-					{showBatchExport}
-					{toggleBatchExport}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{/if}
+			<!-- Single panel for all three tabs: only one is mounted at a time, so `aria-controls`
+			     on every tab resolves here and aria-labelledby tracks whichever tab is active. -->
+			<div id="tab-panel" role="tabpanel" aria-labelledby={'tab-' + activeTab}>
+				{#if activeTab === 'data'}
+					<!-- Data Tab -->
+					<DataTab
+						{handleFileUpload}
+						{handleDemoFileSelect}
+						{validationError}
+						{fileMetricsJSON}
+						{handleValidated}
+						{handleUseRepaired}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'analyze'}
+					<!-- Analyze Tab -->
+					<AnalyzeTab
+						{methodConfig}
+						{runMethod}
+						{selectedMethod}
+						{hyphyOut}
+						{isStdOutVisible}
+						{toggleStdOut}
+						{showAllHistory}
+						{selectAnalysis}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'results'}
+					<!-- Results Tab -->
+					<ResultsTab
+						{selectedAnalysisId}
+						{selectAnalysis}
+						{showAllHistory}
+						{showBatchExport}
+						{toggleBatchExport}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{/if}
+			</div>
 		</div>
 	{/if}
 </div>

--- a/src/test/branch-set-tagging.test.js
+++ b/src/test/branch-set-tagging.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import * as phylotree from 'phylotree';
+import {
+	assignBranchToSet,
+	branchSetOf,
+	listBranches,
+	multiSetTag
+} from '../lib/utils/branchSetTagging.js';
+
+const NEWICK = '((A:0.1,B:0.2)AB:0.3,(C:0.1,D:0.2)CD:0.3)root;';
+const SETS = ['TEST', 'REFERENCE'];
+
+/** A real phylotree, no DOM: only `render()` touches the document. */
+function makeTree() {
+	const tree = new phylotree.phylotree(NEWICK);
+	return { tree, nodes: tree.nodes.descendants() };
+}
+
+function taggedNewick(tree) {
+	return tree.getNewick((node) => multiSetTag(node, SETS));
+}
+
+describe('assignBranchToSet', () => {
+	it('tags exactly the assigned branches in the Newick', () => {
+		const { tree, nodes } = makeTree();
+
+		expect(assignBranchToSet(nodes, 'A', 'TEST', SETS)).toBe(true);
+		expect(assignBranchToSet(nodes, 'CD', 'REFERENCE', SETS)).toBe(true);
+
+		const out = taggedNewick(tree);
+		expect(out).toContain('A{TEST}');
+		expect(out).toContain('CD{REFERENCE}');
+		// And nothing else picked up a tag.
+		expect(out.match(/\{/g)).toHaveLength(2);
+		expect(out).toContain('B:0.2');
+	});
+
+	it('MOVES a tag on reassignment instead of accumulating two', () => {
+		const { tree, nodes } = makeTree();
+
+		assignBranchToSet(nodes, 'A', 'TEST', SETS);
+		assignBranchToSet(nodes, 'A', 'REFERENCE', SETS);
+
+		const out = taggedNewick(tree);
+		expect(out).toContain('A{REFERENCE}');
+		expect(out).not.toContain('{TEST}');
+		expect(out).not.toContain('{TEST,REFERENCE}');
+		expect(out.match(/\{/g)).toHaveLength(1);
+	});
+
+	it('clears a branch when the target set is empty', () => {
+		const { tree, nodes } = makeTree();
+
+		assignBranchToSet(nodes, 'A', 'TEST', SETS);
+		assignBranchToSet(nodes, 'A', '', SETS);
+
+		expect(taggedNewick(tree)).not.toContain('{');
+		expect(branchSetOf(nodes.find((n) => n.data.name === 'A'))).toBe('');
+	});
+
+	it('clears legacy per-set boolean flags so they cannot resurrect a stale tag', () => {
+		const { tree, nodes } = makeTree();
+		const a = nodes.find((n) => n.data.name === 'A');
+
+		// How sets were recorded before _selectionSet existed. multiSetTag still reads these as a
+		// fallback, so merely SETTING _selectionSet on top would mask the stale flag rather than
+		// remove it — and unassigning the branch later would resurrect the old tag.
+		a.TEST = true;
+		expect(taggedNewick(tree)).toContain('A{TEST}');
+
+		assignBranchToSet(nodes, 'A', 'REFERENCE', SETS);
+		expect(taggedNewick(tree)).toContain('A{REFERENCE}');
+
+		assignBranchToSet(nodes, 'A', '', SETS);
+		expect(taggedNewick(tree)).not.toContain('{');
+	});
+
+	it('reports a miss for an unknown branch name and changes nothing', () => {
+		const { tree, nodes } = makeTree();
+		expect(assignBranchToSet(nodes, 'NOT_A_BRANCH', 'TEST', SETS)).toBe(false);
+		expect(taggedNewick(tree)).not.toContain('{');
+	});
+});
+
+describe('listBranches', () => {
+	it('lists every named branch except the root, with its current set', () => {
+		const { nodes } = makeTree();
+		assignBranchToSet(nodes, 'B', 'TEST', SETS);
+
+		const rows = listBranches(nodes);
+		const names = rows.map((r) => r.name);
+
+		expect(names).not.toContain('root');
+		expect(names).toEqual(expect.arrayContaining(['A', 'B', 'C', 'D', 'AB', 'CD']));
+		expect(rows.find((r) => r.name === 'B').set).toBe('TEST');
+		expect(rows.find((r) => r.name === 'A').set).toBe('');
+		expect(rows.find((r) => r.name === 'A').isLeaf).toBe(true);
+		expect(rows.find((r) => r.name === 'AB').isLeaf).toBe(false);
+	});
+
+	it('survives a tree that has not been parsed', () => {
+		expect(listBranches(null)).toEqual([]);
+		expect(listBranches(undefined)).toEqual([]);
+	});
+});


### PR DESCRIPTION
Implements UX audit items **6.3, 6.4, 6.5**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

Status indicator visible on phones rather than buried two taps into the hamburger; file selection and the Analyze panel keyboard-operable; RELAX and Contrast-FEL branch selection usable below ~700px.

Interacts with merged work: the mobile-chrome e2e project was restricted to `14-responsive` and `10-branch-selector` in #185, so three status-indicator tests stopped running entirely. Worth checking whether this branch lets them come back.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 609 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
