### PR TITLE
Stop losing runs and configurations across the run lifecycle

### DIFF
--- a/e2e/21-config-persistence.spec.js
+++ b/e2e/21-config-persistence.spec.js
@@ -1,0 +1,134 @@
+/**
+ * A configuration must survive looking at another tab.
+ *
+ * +page.svelte mounts <AnalyzeTab> inside {#if activeTab === 'analyze'}, so Svelte destroys it — and
+ * every local in MethodSelector — on every tab switch. Choosing MEME, setting its rate classes, then
+ * glancing at Results used to drop all of it on the floor: the dropdown came back on "Select an
+ * analysis method" as though nothing had been chosen.
+ *
+ * The assertions here are the SELECT'S VALUE and a specific input's value, never page-body text. The
+ * string "MEME" is present in the option list either way, so a text assertion would pass on the
+ * broken build — which is exactly the trap this suite has fallen into before.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	goToResultsTab,
+	selectMethod
+} from './fixtures/helpers.js';
+
+/** The number input rendered for an advanced option, found by its label. */
+const optionInput = (page, label) =>
+	page.locator('label.option-label', { hasText: label }).locator('input');
+
+/**
+ * An interrupted MEME run against the file the page has loaded, carrying the settings it was
+ * configured with — the shape WasmAnalysisRunner persists (`parameters` IS the UI config).
+ */
+async function seedInterruptedMeme(page) {
+	return await page.evaluate(async () => {
+		const db = await new Promise((resolve, reject) => {
+			const req = indexedDB.open('datamonkey-db', 2);
+			req.onsuccess = () => resolve(req.result);
+			req.onerror = () => reject(req.error);
+		});
+		const files = await new Promise((resolve, reject) => {
+			const req = db.transaction('files', 'readonly').objectStore('files').getAll();
+			req.onsuccess = () => resolve(req.result || []);
+			req.onerror = () => reject(req.error);
+		});
+		const fileId = files[files.length - 1]?.id;
+		const id = `seeded-meme-${Date.now()}`;
+		const tx = db.transaction('analyses', 'readwrite');
+		tx.objectStore('analyses').put({
+			id,
+			fileId,
+			method: 'MEME',
+			status: 'interrupted',
+			createdAt: Date.now(),
+			metadata: {
+				executionMode: 'wasm',
+				arguments: {
+					parameters: { geneticCode: 'Universal', rates: 6, pvalue: 0.05 }
+				}
+			}
+		});
+		await new Promise((resolve) => {
+			tx.oncomplete = resolve;
+		});
+		db.close();
+		return id;
+	});
+}
+
+test.describe('analysis configuration', () => {
+	test.setTimeout(120000);
+
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+	});
+
+	test('survives a round trip through the Results tab', async ({ page }) => {
+		await selectMethod(page, 'MEME');
+
+		const rates = optionInput(page, 'Rate classes');
+		await expect(rates).toHaveValue('2');
+		await rates.fill('5');
+		await rates.dispatchEvent('input');
+		await expect(rates).toHaveValue('5');
+
+		await goToResultsTab(page);
+		await goToAnalyzeTab(page);
+
+		// The dropdown's VALUE, not the presence of the word MEME anywhere on the page.
+		await expect(page.locator('[data-testid="method-dropdown"]')).toHaveValue('MEME');
+		// And the option the user actually changed, not merely the method.
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('5');
+	});
+
+	test('Re-run brings back the settings that run was configured with', async ({ page }) => {
+		// The whole chain: AnalysisCard dispatches the analysisId, AnalysisHistory forwards it,
+		// +page.svelte looks the record up and hands it to analysisConfig.restoreFrom, MethodSelector
+		// hydrates from the store. Before this, every hop but the last existed and the settings were
+		// still dropped: AnalyzeTab took a `selectedMethod` prop and never forwarded it.
+		await seedInterruptedMeme(page);
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+
+		// Results tab carries the history, and an interrupted run is the case that offers Re-run.
+		await goToResultsTab(page);
+		const rerun = page.getByRole('button', { name: /Re-run/i }).first();
+		await expect(rerun).toBeVisible({ timeout: 30000 });
+		await rerun.click();
+
+		await expect(page.locator('[data-testid="method-dropdown"]')).toHaveValue('MEME', {
+			timeout: 30000
+		});
+		// The settings, not just the method — this is the part "Re-run" never used to do.
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('6');
+		await expect(page.locator('[data-testid="restored-settings-notice"]')).toContainText(
+			/rate classes 6/i
+		);
+	});
+
+	test('still resets options when the user switches methods', async ({ page }) => {
+		// The store keeps one option bag PER METHOD, exactly as the component's own state did, so
+		// choosing a different method must still show that method's own defaults.
+		await selectMethod(page, 'MEME');
+		await optionInput(page, 'Rate classes').fill('7');
+
+		await selectMethod(page, 'FEL');
+		await expect(page.locator('label.option-label', { hasText: 'Rate classes' })).toHaveCount(0);
+
+		await selectMethod(page, 'MEME');
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('7');
+	});
+});

--- a/e2e/22-second-tab.spec.js
+++ b/e2e/22-second-tab.spec.js
@@ -1,0 +1,200 @@
+/**
+ * Opening a second tab must not kill the first tab's running analysis.
+ *
+ * IndexedDB is shared across tabs of an origin; the in-memory list of active runs is not. Every tab
+ * runs cleanupInterruptedAnalyses at onMount, and a local run's persisted record sits at
+ * 'pending'/'wasm' for its whole duration — so a second tab used to reap the first tab's live work,
+ * discard hours of compute and offer a Re-run that would duplicate it.
+ *
+ * The test carries its own positive control. Two records are seeded before the second tab opens: one
+ * with a fresh heartbeat (another tab is alive and stamping it) and one with none (a session that is
+ * gone). The stale one MUST be reaped — that is the proof the sweep actually ran — and the live one
+ * must be untouched. Without both, "nothing was reaped" could just mean "the sweep never happened",
+ * which is exactly how this kind of test passes while proving nothing.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	selectMethod,
+	clickRunAnalysis
+} from './fixtures/helpers.js';
+
+const DB_NAME = 'datamonkey-db';
+const DB_VERSION = 2;
+
+/** Put an analysis record straight into the shared database, as another tab would have left it. */
+async function seedAnalysisRecord(page, record) {
+	return await page.evaluate(
+		async ({ record, dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onupgradeneeded = (e) => {
+					const d = e.target.result;
+					if (!d.objectStoreNames.contains('files'))
+						d.createObjectStore('files', { keyPath: 'id' });
+					if (!d.objectStoreNames.contains('analyses'))
+						d.createObjectStore('analyses', { keyPath: 'id' });
+				};
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const tx = db.transaction('analyses', 'readwrite');
+			tx.objectStore('analyses').put(record);
+			await new Promise((resolve) => {
+				tx.oncomplete = resolve;
+			});
+			db.close();
+			return record.id;
+		},
+		{ record, dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+/** Read every analysis record's id and status out of the shared database. */
+async function readStatuses(page) {
+	return await page.evaluate(
+		async ({ dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const all = await new Promise((resolve, reject) => {
+				const req = db.transaction('analyses', 'readonly').objectStore('analyses').getAll();
+				req.onsuccess = () => resolve(req.result || []);
+				req.onerror = () => reject(req.error);
+			});
+			db.close();
+			return all.map((a) => ({ id: a.id, status: a.status }));
+		},
+		{ dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+/** Read the heartbeat stamp of every local run record. */
+async function readHeartbeats(page) {
+	return await page.evaluate(
+		async ({ dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const all = await new Promise((resolve, reject) => {
+				const req = db.transaction('analyses', 'readonly').objectStore('analyses').getAll();
+				req.onsuccess = () => resolve(req.result || []);
+				req.onerror = () => reject(req.error);
+			});
+			db.close();
+			return all
+				.filter((a) => a.metadata?.executionMode === 'wasm')
+				.map((a) => ({ id: a.id, lastHeartbeatAt: a.lastHeartbeatAt }));
+		},
+		{ dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+const statusOf = (rows, id) => rows.find((r) => r.id === id)?.status;
+
+test.describe('a second browser tab', () => {
+	test.setTimeout(180000);
+
+	test('reaps a dead session’s run but leaves a live one alone', async ({ page, context }) => {
+		await freshStart(page);
+
+		const now = Date.now();
+		const liveId = `live-run-${now}`;
+		const staleId = `stale-run-${now}`;
+
+		// Another tab is running this right now and stamping it every ten seconds.
+		await seedAnalysisRecord(page, {
+			id: liveId,
+			fileId: `file-${now}`,
+			method: 'AXOMEME',
+			status: 'running',
+			metadata: { executionMode: 'wasm' },
+			createdAt: now - 30_000,
+			lastHeartbeatAt: now
+		});
+
+		// POSITIVE CONTROL: no pulse at all, so its tab is gone and it must still be cleaned up.
+		await seedAnalysisRecord(page, {
+			id: staleId,
+			fileId: `file-${now}`,
+			method: 'FEL',
+			status: 'running',
+			metadata: { executionMode: 'wasm' },
+			createdAt: now - 600_000
+		});
+
+		// The second tab. Same context, so the same IndexedDB.
+		const second = await context.newPage();
+		await second.goto('/');
+		await second.waitForSelector('.sample-card', { timeout: 60000 });
+
+		// Wait for the sweep to have run, evidenced by the stale record being reaped.
+		await expect(async () => {
+			const rows = await readStatuses(second);
+			expect(statusOf(rows, staleId), 'the interrupted sweep never ran').toBe('interrupted');
+		}).toPass({ timeout: 30000 });
+
+		// The live run is what this is all about: still running, still re-runnable by nobody.
+		const rows = await readStatuses(second);
+		expect(statusOf(rows, liveId), 'the second tab reaped a run another tab is still running').toBe(
+			'running'
+		);
+
+		await second.close();
+	});
+
+	test('leaves a pulse on a real run that another tab can see', async ({ page, context }) => {
+		// The other half of the mechanism, and the half a seeded record cannot prove: that a REAL local
+		// run stamps `lastHeartbeatAt` into the shared database at all. Without it, the gate in the
+		// first test would protect nothing, because no live run would ever carry a pulse.
+		//
+		// Deliberately NOT written as "start a run, open a tab, race the sweep": every local run on the
+		// demo alignments finishes in a few seconds, which is faster than a second tab can load, so
+		// that version passes on a broken build too — the completed record is not reapable either way.
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+		await selectMethod(page, 'FEL');
+
+		expect(await clickRunAnalysis(page), 'run button was not clickable').toBe(true);
+		const row = page.locator('[data-testid="run-row"]').first();
+		await expect(row).toBeVisible({ timeout: 60000 });
+
+		const second = await context.newPage();
+		await second.goto('/');
+		await second.waitForSelector('.sample-card', { timeout: 60000 });
+		// Give the second tab's onMount sweep time to do its worst.
+		await second.waitForTimeout(3000);
+
+		const rows = await readStatuses(second);
+		expect(
+			rows.filter((r) => r.status === 'interrupted'),
+			'the second tab interrupted a run started in another tab'
+		).toEqual([]);
+
+		// The pulse itself, read from the second tab — the same database the sweep consults.
+		const pulses = await readHeartbeats(second);
+		expect(pulses.length, 'no analysis record was written at all').toBeGreaterThan(0);
+		for (const p of pulses) {
+			expect(p.lastHeartbeatAt, `run ${p.id} left no heartbeat, so any tab would reap it`).toEqual(
+				expect.any(Number)
+			);
+			expect(Date.now() - p.lastHeartbeatAt).toBeLessThan(60_000);
+		}
+
+		// And the first tab's run still finishes, on the row where it was started.
+		await expect(row).toHaveAttribute('data-status', 'completed', { timeout: 150000 });
+
+		await second.close();
+	});
+});

--- a/src/lib/AnalysisHistory.svelte
+++ b/src/lib/AnalysisHistory.svelte
@@ -146,12 +146,15 @@
 
 	// Handle re-run action (for interrupted analyses)
 	function handleRerun(event) {
-		const { method, fileId } = event.detail;
+		// analysisId travels too. Without it the Analyze tab knows only WHICH method to preselect and
+		// has no way back to the settings that run was configured with, so "Re-run" meant "start over".
+		const { analysisId, method, fileId } = event.detail;
 		// Dispatch event to switch to Analyze tab with the method pre-selected
 		dispatchEvent(
 			new CustomEvent('switchTab', {
 				detail: {
 					tabName: 'analyze',
+					analysisId,
 					method,
 					fileId,
 					rerun: true

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -28,7 +28,8 @@
 	// Props
 	export let methodConfig = {};
 	export let runMethod = () => {};
-	export let selectedMethod = 'FEL'; // Default method for configuration
+	// No `selectedMethod` prop. It was accepted here and never forwarded to MethodSelector, which is
+	// why a Re-run preselected nothing; the analysisConfig store is now the single channel for it.
 	export let hyphyOut = '';
 	export let isStdOutVisible = false;
 	export let toggleStdOut = () => {};

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1,7 +1,9 @@
 <!-- src/lib/MethodSelector.svelte -->
 <script>
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { backendConnectivity } from '../stores/backendConnectivity.js';
+	import { analysisConfig } from '../stores/analysisConfig.js';
+	import { METHOD_ADVANCED_OPTIONS } from './config/methodAdvancedOptions.js';
 	import { fileMetricsStore } from '../stores/fileInfo';
 	import { treeStore } from '../stores/tree';
 	import BranchSelector from './BranchSelector.svelte';
@@ -203,797 +205,67 @@
 		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
 	];
 
-	// Method-specific advanced options configurations
-	const METHOD_ADVANCED_OPTIONS = {
-		// AxoMEME exposes almost nothing on purpose. It is a fitted model with one set of weights:
-		// there are no branch sets to select (it consumes the whole tree as a distance matrix), no
-		// rate-variation switch, and no genetic code choice — the code table is baked into the
-		// model's tokenizer as the universal one. Offering knobs that do not reach the model would be
-		// worse than offering none. Calling mode is the one real choice, because it is a threshold
-		// applied AFTER inference and genuinely changes what gets reported.
-		axomeme: {
-			callMode: {
-				type: 'select',
-				label: 'How to rank sites',
-				// percentile, not the reference driver's pvalue default. The model's predicted LRT does
-				// not reach the chi-square gates pvalue compares against — measured across 12 real
-				// submissions, one site in 662 cleared 3.12 and none cleared 4.45 — so pvalue makes the
-				// method silent. See CALL_DEFAULTS in postprocess.js.
-				default: 'percentile',
-				options: ['percentile', 'zscore', 'pvalue'],
-				description:
-					'percentile and zscore rank sites within this alignment, which is what the model is built to do. pvalue compares against fixed LRT gates (4.45 / 3.12) that its scores rarely reach — it will usually report nothing.'
-			}
-		},
-		fel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No']
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple']
-			},
-			siteMultihit: {
-				type: 'select',
-				label: 'Site Multihit',
-				default: 'Estimate',
-				options: ['Estimate', 'Global'],
-				dependsOn: 'multipleHits',
-				enabledWhen: ['Double', 'Double+Triple']
-			},
-			// Advanced parameters (matching the form structure)
-			resample: {
-				type: 'number',
-				label: 'Resample (parametric bootstrap replicates)',
-				default: 0,
-				min: 0,
-				max: 1000,
-				step: 1,
-				description:
-					'Advanced setting - will result in MUCH SLOWER run time. Recommended for small to medium (<30 sequences) datasets.'
-			},
-			confidenceIntervals: {
-				type: 'boolean',
-				label: 'Compute confidence intervals',
-				default: false,
-				description: 'Compute profile likelihood confidence intervals for each variable site'
-			},
-			// Keep existing parameters for backward compatibility
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			}
-		},
-		meme: {
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'P-value threshold for calling a site under selection'
-			},
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 2,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of site rate classes'
-			},
-			multiple_hits: {
-				type: 'select',
-				label: 'Multiple hits',
-				default: 'None',
-				options: ['None', 'Double', 'Triple', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			site_multihit: {
-				type: 'select',
-				label: 'Site multiple hits',
-				default: 'Estimate',
-				options: ['Estimate', 'None'],
-				description: 'How to handle multiple hits per site'
-			},
-			impute_states: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Impute ancestral states for internal nodes'
-			}
-		},
-		slac: {
-			// Branch selection options (similar to FEL)
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// SLAC-specific parameters
-			samples: {
-				type: 'number',
-				label: 'Ancestral reconstruction samples',
-				default: 100,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Number of samples for ancestral reconstruction uncertainty'
-			},
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for selection'
-			}
-		},
-		fubar: {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Specifies the number of grid points for the Bayesian analysis'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description:
-					'The concentration parameter for the Dirichlet prior in the Bayesian estimation'
-			},
-			posteriorThreshold: {
-				type: 'number',
-				label: 'Posterior probability threshold',
-				default: 0.9,
-				min: 0.5,
-				max: 0.99,
-				step: 0.01,
-				description:
-					'Sites with posterior probability above this threshold are considered under positive selection'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		absrel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test (default: All)'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core aBSREL parameters
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			srv: {
-				type: 'select',
-				label: 'Synonymous Rate Variation',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation'
-			},
-			// Advanced parameters
-			blb: {
-				type: 'number',
-				label: 'Bag of Little Bootstrap (BLB) Rate',
-				default: 1.0,
-				min: 0.0,
-				max: 1.0,
-				step: 0.1,
-				description: '[Advanced] Bag of little bootstrap alignment resampling rate'
-			}
-		},
-		busted: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Foreground Branches',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description:
-					'Select foreground branches to test for positive selection. All other branches will be treated as background.'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom foreground branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern for foreground branches'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select foreground branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them as foreground branches for testing'
-			},
-			// Core BUSTED parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (BUSTED-S)',
-				default: 'Yes',
-				options: ['Yes', 'No', 'Branch-site'],
-				description: 'Include variations in synonymous substitution rates'
-			},
-			errorSink: {
-				type: 'select',
-				label: 'Error protection (BUSTED-E)',
-				default: 'No',
-				options: ['Yes', 'No'],
-				description: 'Enhance robustness against alignment errors'
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Support for handling multiple nucleotide substitutions'
-			},
-			// Advanced parameters
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes in the model'
-			},
-			synRates: {
-				type: 'number',
-				label: 'Synonymous rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of synonymous rate classes in the model'
-			},
-			gridSize: {
-				type: 'number',
-				label: 'Grid size',
-				default: 250,
-				min: 50,
-				max: 1000,
-				step: 50,
-				description: 'Number of points in initial distributional guess for likelihood fitting'
-			},
-			startingPoints: {
-				type: 'number',
-				label: 'Starting points',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of initial random guesses to seed rate values optimization'
-			}
-		},
-		gard: {
-			datatype: {
-				type: 'select',
-				label: 'Data type',
-				default: 'nucleotide',
-				options: ['codon', 'nucleotide', 'protein'],
-				description: 'Type of data to analyze for recombination'
-			},
-			model: {
-				type: 'select',
-				label: 'Substitution model',
-				default: 'GTR',
-				options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
-				filteredOptionsBy: 'datatype',
-				filteredOptions: {
-					codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
-				},
-				filteredDefaults: {
-					codon: 'GTR',
-					nucleotide: 'GTR',
-					protein: 'JTT'
-				},
-				description: 'Substitution model to use for the analysis'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Normal',
-				options: ['Normal', 'Faster'],
-				description: 'Normal: thorough analysis; Faster: quicker but less comprehensive'
-			},
-			rv: {
-				type: 'select',
-				label: 'Site-to-site rate variation',
-				default: 'None',
-				options: ['None', 'GDD', 'Gamma'],
-				description: 'Model for rate variation among sites (None, General Discrete, Beta-Gamma)'
-			},
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 4,
-				min: 2,
-				max: 10,
-				description: 'Number of discrete rate classes for rate variation'
-			}
-		},
-		bgm: {
-			steps: {
-				type: 'number',
-				label: 'Chain length steps',
-				default: 10000,
-				min: 1000,
-				max: 100000000,
-				step: 1000,
-				description: 'Length of each MCMC chain'
-			},
-			burnIn: {
-				type: 'number',
-				label: 'Burn-in samples',
-				default: 1000,
-				min: 100,
-				max: 100000,
-				step: 100,
-				description: 'Number of burn-in samples to discard'
-			},
-			samples: {
-				type: 'number',
-				label: 'Samples',
-				default: 100,
-				min: 10,
-				max: 10000,
-				step: 10,
-				description: 'Number of samples to collect'
-			},
-			maxParents: {
-				type: 'number',
-				label: 'Maximum parents per node',
-				default: 1,
-				min: 0,
-				max: 10,
-				step: 1,
-				description: 'Maximum number of parents allowed per node in the graphical model'
-			},
-			minSubs: {
-				type: 'number',
-				label: 'Minimum substitutions per site',
-				default: 1,
-				min: 1,
-				max: 100,
-				step: 1,
-				description: 'Minimum number of substitutions required per site'
-			}
-		},
-		fade: {
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			},
-			gridPoints: { type: 'number', label: 'Grid points', default: 20, min: 5, max: 50 },
-			mcmcChains: { type: 'number', label: 'MCMC chains', default: 5, min: 2, max: 20 },
-			mcmcSamples: {
-				type: 'number',
-				label: 'MCMC samples',
-				default: 2000000,
-				min: 100000,
-				max: 10000000,
-				step: 100000
-			}
-		},
-		relax: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Interactive'],
-				description: 'Select TEST and REFERENCE branches interactively on the tree'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select TEST and REFERENCE branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to TEST or REFERENCE sets'
-			},
-			// RELAX-specific parameters
-			models: {
-				type: 'select',
-				label: 'Analysis models',
-				default: 'All',
-				options: ['All', 'Minimal'],
-				description: 'All: descriptive models and RELAX test; Minimal: RELAX test only'
-			},
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Classic mode',
-				options: ['Classic mode'],
-				description: 'RELAX analysis mode'
-			},
-			killZeroLengths: {
-				type: 'select',
-				label: 'Kill zero-length branches',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'How to handle zero-length branches'
-			}
-		},
-		'multi-hit': {
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 3,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes to include in the model'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use separate rate parameter for synonymous triple-hit substitutions'
-			}
-		},
-		nrm: {
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of rate classes for the analysis'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use triple islands for the analysis'
-			}
-		},
-		prime: {
-			// PRIME variant selection
-			variant: {
-				type: 'select',
-				label: 'PRIME Variant',
-				default: 'S-PRIME',
-				options: [
-					'S-PRIME',
-					{ value: 'G-PRIME', label: 'G-PRIME (coming soon)', disabled: true },
-					{ value: 'E-PRIME', label: 'E-PRIME (coming soon)', disabled: true }
-				],
-				description: 'S-PRIME: site-level property-informed model'
-			},
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Interactive'],
-				description: 'Which branches to test for property-dependent selection'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Property set selection
-			propertySet: {
-				type: 'select',
-				label: 'Amino Acid Property Set',
-				default: '5PROP',
-				options: ['5PROP', '4PROP', '3PROP', '2PROP', 'Atchley', 'LCAP'],
-				description:
-					'Set of amino acid properties to model (5PROP: hydrophobicity, polarity, volume, charge, iso-electric point)'
-			},
-			// P-value threshold
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for property-dependent selection'
-			},
-			// Impute states
-			imputeStates: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use site-level model fits to impute likely character states'
-			}
-		},
-		'contrast-fel': {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Custom', 'Interactive'],
-				description: 'How to specify branch sets for comparison'
-			},
-			// Custom branch set configuration (when not using Interactive)
-			branchSet1: {
-				type: 'text',
-				label: 'Branch Set 1 (Source)',
-				default: 'Source',
-				placeholder: 'e.g. Source, Internal, Leaves',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'First group of branches to compare'
-			},
-			branchSet2: {
-				type: 'text',
-				label: 'Branch Set 2 (Test)',
-				default: 'Test',
-				placeholder: 'e.g. Test, Unlabeled, Custom',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Second group of branches to compare'
-			},
-			branchSet3: {
-				type: 'text',
-				label: 'Branch Set 3 (optional)',
-				default: '',
-				placeholder: 'e.g. Reference, Background',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Optional third group of branches for comparison'
-			},
-			// Interactive tree selection
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branch sets on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to different sets for comparison'
-			},
-			// Core Contrast-FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation in the model'
-			},
-			permutations: {
-				type: 'select',
-				label: 'Perform permutation tests',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Use permutation tests to evaluate significance'
-			},
-			// Statistical thresholds
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.05,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Significance value for site tests'
-			},
-			qvalue: {
-				type: 'number',
-				label: 'Q-value threshold (FDR)',
-				default: 0.2,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'False Discovery Rate threshold for reporting'
-			},
-			// Output options
-			output: {
-				type: 'text',
-				label: 'Output file name (optional)',
-				default: '',
-				placeholder: 'e.g. contrast_results.json',
-				description: 'Custom name for output file (defaults to automatic naming)'
-			}
-		}
-	};
-
 	// Method-specific advanced options state
 	let methodOptions = {};
+
+	// SURVIVING A TAB SWITCH.
+	//
+	// This component is mounted inside {#if activeTab === 'analyze'} in +page.svelte, so Svelte
+	// destroys it — and every local below — the moment the user looks at Results. The five values are
+	// kept as plain locals because ~60 references and two bind:value depend on them; they are hydrated
+	// from the store here and mirrored back on every change.
+	//
+	// Hydration happens in onMount rather than at declaration ON PURPOSE. The reactive block that
+	// initialises a method's option bag is gated on the bag being ABSENT
+	// (`if (selectedMethod && !methodOptions[selectedMethod])`) because initializeMethodOptions
+	// overwrites it wholesale with defaults. Restoring before that block first runs is what lets the
+	// restored options survive it. Keep that gate.
+	let restoredNotice = null;
+	let hydrated = false;
+
+	onMount(() => {
+		const saved = analysisConfig.current();
+		if (saved.selectedMethod) selectedMethod = saved.selectedMethod;
+		if (saved.geneticCode) geneticCode = saved.geneticCode;
+		if (Number.isFinite(saved.geneticCodeId)) geneticCodeId = saved.geneticCodeId;
+		// Restoring 'backend' onto a session where the server is unreachable would arm a run that
+		// fails at submission. Clamp it; the radio is still there for the user to change back.
+		if (saved.executionMode) {
+			executionMode =
+				saved.executionMode === 'backend' && !$backendConnectivity?.isConnected
+					? 'local'
+					: saved.executionMode;
+		}
+		if (saved.methodOptions) methodOptions = { ...saved.methodOptions };
+
+		if (saved.restoredFromAnalysisId && saved.selectedMethod) {
+			// AxoMEME records carry no arguments at all, so there is nothing to claim was restored.
+			// Say what is true and no more.
+			restoredNotice = saved.restoredSummary
+				? `Restored your ${saved.selectedMethod.toUpperCase()} settings — ${saved.restoredSummary}.`
+				: `Selected ${saved.selectedMethod.toUpperCase()}.`;
+		}
+
+		// Announce a restore once, not on every subsequent tab switch.
+		analysisConfig.update((state) => ({ ...state, restoredFromAnalysisId: null }));
+		hydrated = true;
+	});
+
+	// Mirror back. One assignment, so the store can never hold half a configuration.
+	//
+	// Gated on `hydrated` because reactive statements run during the FIRST render, before onMount:
+	// ungated, this would write the component's blank defaults over the very state it is about to
+	// read back, and the feature would silently do nothing.
+	$: if (hydrated) {
+		analysisConfig.update((state) => ({
+			...state,
+			selectedMethod,
+			geneticCode,
+			geneticCodeId,
+			executionMode,
+			methodOptions
+		}));
+	}
 
 	// Tree data from store (auto-subscription; Svelte cleans it up on destroy)
 	$: trees = $treeStore;
@@ -1358,6 +630,20 @@
 				{/each}
 			</select>
 		</div>
+
+		<!-- What a Re-run actually brought back. Built from the restored values, never from a fixed
+		     field list, so it cannot claim to have restored something it did not. -->
+		{#if restoredNotice}
+			<div class="restored-notice" data-testid="restored-settings-notice">
+				<span>{restoredNotice}</span>
+				<button
+					type="button"
+					class="restored-dismiss"
+					aria-label="Dismiss"
+					on:click={() => (restoredNotice = null)}>×</button
+				>
+			</div>
+		{/if}
 
 		<!-- Method Description -->
 		{#if currentMethod}
@@ -1760,6 +1046,30 @@
 		font-size: 0.8125rem;
 		line-height: 1.4;
 		color: #475569;
+	}
+
+	.restored-notice {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin-top: 8px;
+		padding: 6px 10px;
+		border: 1px solid #cbd5e0;
+		border-radius: 6px;
+		background: #f7fafc;
+		color: #2d3748;
+		font-size: 13px;
+	}
+
+	.restored-dismiss {
+		border: none;
+		background: none;
+		color: #4a5568;
+		cursor: pointer;
+		font-size: 16px;
+		line-height: 1;
+		padding: 0 2px;
 	}
 
 	.method-dropdown {

--- a/src/lib/config/methodAdvancedOptions.js
+++ b/src/lib/config/methodAdvancedOptions.js
@@ -1,0 +1,796 @@
+/**
+ * METHOD_ADVANCED_OPTIONS — the per-method advanced-option schema.
+ *
+ * Lifted out of MethodSelector.svelte because it is data, not markup, and two places now need it:
+ * the selector renders it, and analysisConfig.restoreFrom filters a re-run's saved settings against
+ * it so an option a later release removed cannot resurrect a control that no longer exists.
+ *
+ * Adding a method still means adding a section here — same content, one file over.
+ */
+
+export const METHOD_ADVANCED_OPTIONS = {
+	// AxoMEME exposes almost nothing on purpose. It is a fitted model with one set of weights:
+	// there are no branch sets to select (it consumes the whole tree as a distance matrix), no
+	// rate-variation switch, and no genetic code choice — the code table is baked into the
+	// model's tokenizer as the universal one. Offering knobs that do not reach the model would be
+	// worse than offering none. Calling mode is the one real choice, because it is a threshold
+	// applied AFTER inference and genuinely changes what gets reported.
+	axomeme: {
+		callMode: {
+			type: 'select',
+			label: 'How to rank sites',
+			// percentile, not the reference driver's pvalue default. The model's predicted LRT does
+			// not reach the chi-square gates pvalue compares against — measured across 12 real
+			// submissions, one site in 662 cleared 3.12 and none cleared 4.45 — so pvalue makes the
+			// method silent. See CALL_DEFAULTS in postprocess.js.
+			default: 'percentile',
+			options: ['percentile', 'zscore', 'pvalue'],
+			description:
+				'percentile and zscore rank sites within this alignment, which is what the model is built to do. pvalue compares against fixed LRT gates (4.45 / 3.12) that its scores rarely reach — it will usually report nothing.'
+		}
+	},
+	fel: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test for positive selection'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Core FEL parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (recommended)',
+			default: 'Yes',
+			options: ['Yes', 'No']
+		},
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple']
+		},
+		siteMultihit: {
+			type: 'select',
+			label: 'Site Multihit',
+			default: 'Estimate',
+			options: ['Estimate', 'Global'],
+			dependsOn: 'multipleHits',
+			enabledWhen: ['Double', 'Double+Triple']
+		},
+		// Advanced parameters (matching the form structure)
+		resample: {
+			type: 'number',
+			label: 'Resample (parametric bootstrap replicates)',
+			default: 0,
+			min: 0,
+			max: 1000,
+			step: 1,
+			description:
+				'Advanced setting - will result in MUCH SLOWER run time. Recommended for small to medium (<30 sequences) datasets.'
+		},
+		confidenceIntervals: {
+			type: 'boolean',
+			label: 'Compute confidence intervals',
+			default: false,
+			description: 'Compute profile likelihood confidence intervals for each variable site'
+		},
+		// Keep existing parameters for backward compatibility
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001
+		}
+	},
+	meme: {
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'P-value threshold for calling a site under selection'
+		},
+		rates: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 2,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of site rate classes'
+		},
+		multiple_hits: {
+			type: 'select',
+			label: 'Multiple hits',
+			default: 'None',
+			options: ['None', 'Double', 'Triple', 'Double+Triple'],
+			description: 'Include support for multiple nucleotide substitutions'
+		},
+		site_multihit: {
+			type: 'select',
+			label: 'Site multiple hits',
+			default: 'Estimate',
+			options: ['Estimate', 'None'],
+			description: 'How to handle multiple hits per site'
+		},
+		impute_states: {
+			type: 'select',
+			label: 'Impute states',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Impute ancestral states for internal nodes'
+		}
+	},
+	slac: {
+		// Branch selection options (similar to FEL)
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test for positive selection'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// SLAC-specific parameters
+		samples: {
+			type: 'number',
+			label: 'Ancestral reconstruction samples',
+			default: 100,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Number of samples for ancestral reconstruction uncertainty'
+		},
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The p-value threshold to use when testing for selection'
+		}
+	},
+	fubar: {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Specifies the number of grid points for the Bayesian analysis'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The concentration parameter for the Dirichlet prior in the Bayesian estimation'
+		},
+		posteriorThreshold: {
+			type: 'number',
+			label: 'Posterior probability threshold',
+			default: 0.9,
+			min: 0.5,
+			max: 0.99,
+			step: 0.01,
+			description:
+				'Sites with posterior probability above this threshold are considered under positive selection'
+		}
+	},
+	'b-still': {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Grid points per dimension (total grid = D²)'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Dirichlet prior concentration parameter'
+		},
+		method: {
+			type: 'select',
+			label: 'Posterior estimation method',
+			default: 'Variational-Bayes',
+			options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
+			description: 'Method for estimating the posterior distribution'
+		},
+		ebf: {
+			type: 'number',
+			label: 'EBF threshold',
+			default: 10,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Empirical Bayes Factor threshold for reporting invariant sites'
+		},
+		radius_threshold: {
+			type: 'number',
+			label: 'Radius threshold',
+			default: 0.5,
+			min: 0,
+			max: 10,
+			step: 0.1,
+			description: 'Expected substitution multiplier for near-zero regime'
+		}
+	},
+	'b-still': {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Grid points per dimension (total grid = D²)'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Dirichlet prior concentration parameter'
+		},
+		method: {
+			type: 'select',
+			label: 'Posterior estimation method',
+			default: 'Variational-Bayes',
+			options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
+			description: 'Method for estimating the posterior distribution'
+		},
+		ebf: {
+			type: 'number',
+			label: 'EBF threshold',
+			default: 10,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Empirical Bayes Factor threshold for reporting invariant sites'
+		},
+		radius_threshold: {
+			type: 'number',
+			label: 'Radius threshold',
+			default: 0.5,
+			min: 0,
+			max: 10,
+			step: 0.1,
+			description: 'Expected substitution multiplier for near-zero regime'
+		}
+	},
+	absrel: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test (default: All)'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Core aBSREL parameters
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple'],
+			description: 'Include support for multiple nucleotide substitutions'
+		},
+		srv: {
+			type: 'select',
+			label: 'Synonymous Rate Variation',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Include synonymous rate variation'
+		},
+		// Advanced parameters
+		blb: {
+			type: 'number',
+			label: 'Bag of Little Bootstrap (BLB) Rate',
+			default: 1.0,
+			min: 0.0,
+			max: 1.0,
+			step: 0.1,
+			description: '[Advanced] Bag of little bootstrap alignment resampling rate'
+		}
+	},
+	busted: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Foreground Branches',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description:
+				'Select foreground branches to test for positive selection. All other branches will be treated as background.'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom foreground branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern for foreground branches'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select foreground branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them as foreground branches for testing'
+		},
+		// Core BUSTED parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (BUSTED-S)',
+			default: 'Yes',
+			options: ['Yes', 'No', 'Branch-site'],
+			description: 'Include variations in synonymous substitution rates'
+		},
+		errorSink: {
+			type: 'select',
+			label: 'Error protection (BUSTED-E)',
+			default: 'No',
+			options: ['Yes', 'No'],
+			description: 'Enhance robustness against alignment errors'
+		},
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple'],
+			description: 'Support for handling multiple nucleotide substitutions'
+		},
+		// Advanced parameters
+		rates: {
+			type: 'number',
+			label: 'Omega rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes in the model'
+		},
+		synRates: {
+			type: 'number',
+			label: 'Synonymous rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of synonymous rate classes in the model'
+		},
+		gridSize: {
+			type: 'number',
+			label: 'Grid size',
+			default: 250,
+			min: 50,
+			max: 1000,
+			step: 50,
+			description: 'Number of points in initial distributional guess for likelihood fitting'
+		},
+		startingPoints: {
+			type: 'number',
+			label: 'Starting points',
+			default: 1,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of initial random guesses to seed rate values optimization'
+		}
+	},
+	gard: {
+		datatype: {
+			type: 'select',
+			label: 'Data type',
+			default: 'nucleotide',
+			options: ['codon', 'nucleotide', 'protein'],
+			description: 'Type of data to analyze for recombination'
+		},
+		model: {
+			type: 'select',
+			label: 'Substitution model',
+			default: 'GTR',
+			options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
+			filteredOptionsBy: 'datatype',
+			filteredOptions: {
+				codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
+				nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
+				protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
+			},
+			filteredDefaults: {
+				codon: 'GTR',
+				nucleotide: 'GTR',
+				protein: 'JTT'
+			},
+			description: 'Substitution model to use for the analysis'
+		},
+		mode: {
+			type: 'select',
+			label: 'Run mode',
+			default: 'Normal',
+			options: ['Normal', 'Faster'],
+			description: 'Normal: thorough analysis; Faster: quicker but less comprehensive'
+		},
+		rv: {
+			type: 'select',
+			label: 'Site-to-site rate variation',
+			default: 'None',
+			options: ['None', 'GDD', 'Gamma'],
+			description: 'Model for rate variation among sites (None, General Discrete, Beta-Gamma)'
+		},
+		rate_classes: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 4,
+			min: 2,
+			max: 10,
+			description: 'Number of discrete rate classes for rate variation'
+		}
+	},
+	bgm: {
+		steps: {
+			type: 'number',
+			label: 'Chain length steps',
+			default: 10000,
+			min: 1000,
+			max: 100000000,
+			step: 1000,
+			description: 'Length of each MCMC chain'
+		},
+		burnIn: {
+			type: 'number',
+			label: 'Burn-in samples',
+			default: 1000,
+			min: 100,
+			max: 100000,
+			step: 100,
+			description: 'Number of burn-in samples to discard'
+		},
+		samples: {
+			type: 'number',
+			label: 'Samples',
+			default: 100,
+			min: 10,
+			max: 10000,
+			step: 10,
+			description: 'Number of samples to collect'
+		},
+		maxParents: {
+			type: 'number',
+			label: 'Maximum parents per node',
+			default: 1,
+			min: 0,
+			max: 10,
+			step: 1,
+			description: 'Maximum number of parents allowed per node in the graphical model'
+		},
+		minSubs: {
+			type: 'number',
+			label: 'Minimum substitutions per site',
+			default: 1,
+			min: 1,
+			max: 100,
+			step: 1,
+			description: 'Minimum number of substitutions required per site'
+		}
+	},
+	fade: {
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001
+		},
+		gridPoints: { type: 'number', label: 'Grid points', default: 20, min: 5, max: 50 },
+		mcmcChains: { type: 'number', label: 'MCMC chains', default: 5, min: 2, max: 20 },
+		mcmcSamples: {
+			type: 'number',
+			label: 'MCMC samples',
+			default: 2000000,
+			min: 100000,
+			max: 10000000,
+			step: 100000
+		}
+	},
+	relax: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branch Selection Mode',
+			default: 'Interactive',
+			options: ['Interactive'],
+			description: 'Select TEST and REFERENCE branches interactively on the tree'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select TEST and REFERENCE branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to assign them to TEST or REFERENCE sets'
+		},
+		// RELAX-specific parameters
+		models: {
+			type: 'select',
+			label: 'Analysis models',
+			default: 'All',
+			options: ['All', 'Minimal'],
+			description: 'All: descriptive models and RELAX test; Minimal: RELAX test only'
+		},
+		rates: {
+			type: 'number',
+			label: 'Omega rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes'
+		},
+		mode: {
+			type: 'select',
+			label: 'Run mode',
+			default: 'Classic mode',
+			options: ['Classic mode'],
+			description: 'RELAX analysis mode'
+		},
+		killZeroLengths: {
+			type: 'select',
+			label: 'Kill zero-length branches',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'How to handle zero-length branches'
+		}
+	},
+	'multi-hit': {
+		rates: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 3,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes to include in the model'
+		},
+		triple_islands: {
+			type: 'select',
+			label: 'Triple islands',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use separate rate parameter for synonymous triple-hit substitutions'
+		}
+	},
+	nrm: {
+		rate_classes: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 1,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of rate classes for the analysis'
+		},
+		triple_islands: {
+			type: 'select',
+			label: 'Triple islands',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use triple islands for the analysis'
+		}
+	},
+	prime: {
+		// PRIME variant selection
+		variant: {
+			type: 'select',
+			label: 'PRIME Variant',
+			default: 'S-PRIME',
+			options: [
+				'S-PRIME',
+				{ value: 'G-PRIME', label: 'G-PRIME (coming soon)', disabled: true },
+				{ value: 'E-PRIME', label: 'E-PRIME (coming soon)', disabled: true }
+			],
+			description: 'S-PRIME: site-level property-informed model'
+		},
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Interactive'],
+			description: 'Which branches to test for property-dependent selection'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Property set selection
+		propertySet: {
+			type: 'select',
+			label: 'Amino Acid Property Set',
+			default: '5PROP',
+			options: ['5PROP', '4PROP', '3PROP', '2PROP', 'Atchley', 'LCAP'],
+			description:
+				'Set of amino acid properties to model (5PROP: hydrophobicity, polarity, volume, charge, iso-electric point)'
+		},
+		// P-value threshold
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The p-value threshold to use when testing for property-dependent selection'
+		},
+		// Impute states
+		imputeStates: {
+			type: 'select',
+			label: 'Impute states',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use site-level model fits to impute likely character states'
+		}
+	},
+	'contrast-fel': {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branch Selection Mode',
+			default: 'Interactive',
+			options: ['Custom', 'Interactive'],
+			description: 'How to specify branch sets for comparison'
+		},
+		// Custom branch set configuration (when not using Interactive)
+		branchSet1: {
+			type: 'text',
+			label: 'Branch Set 1 (Source)',
+			default: 'Source',
+			placeholder: 'e.g. Source, Internal, Leaves',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'First group of branches to compare'
+		},
+		branchSet2: {
+			type: 'text',
+			label: 'Branch Set 2 (Test)',
+			default: 'Test',
+			placeholder: 'e.g. Test, Unlabeled, Custom',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Second group of branches to compare'
+		},
+		branchSet3: {
+			type: 'text',
+			label: 'Branch Set 3 (optional)',
+			default: '',
+			placeholder: 'e.g. Reference, Background',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Optional third group of branches for comparison'
+		},
+		// Interactive tree selection
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branch sets on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to assign them to different sets for comparison'
+		},
+		// Core Contrast-FEL parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (recommended)',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Include synonymous rate variation in the model'
+		},
+		permutations: {
+			type: 'select',
+			label: 'Perform permutation tests',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Use permutation tests to evaluate significance'
+		},
+		// Statistical thresholds
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.05,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Significance value for site tests'
+		},
+		qvalue: {
+			type: 'number',
+			label: 'Q-value threshold (FDR)',
+			default: 0.2,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'False Discovery Rate threshold for reporting'
+		},
+		// Output options
+		output: {
+			type: 'text',
+			label: 'Output file name (optional)',
+			default: '',
+			placeholder: 'e.g. contrast_results.json',
+			description: 'Custom name for output file (defaults to automatic naming)'
+		}
+	}
+};

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -56,11 +56,28 @@ function stripEmbeddedTrees(alignmentData) {
 	return result;
 }
 
+/**
+ * How long a submission may sit with no word from the server before we go and ask about it.
+ *
+ * Generous on purpose. The server acknowledges a spawn as soon as the job row exists, but a busy
+ * scheduler can take a while to get there, and declaring a job lost that is merely queued is far
+ * worse than a minute of silence. Expiry does NOT fail the run — it triggers a probe (see
+ * probeSubmission), which is the only thing that can distinguish "queued" from "never accepted".
+ */
+const SUBMISSION_ACK_TIMEOUT_MS = 60000;
+
+/** Ack window on the job:status probe itself. Matches the reconnect path's timeout (issue #177). */
+const STATUS_PROBE_TIMEOUT_MS = 10000;
+
 class BackendAnalysisRunner extends BaseAnalysisRunner {
 	constructor() {
 		super();
 		this.socket = null;
 		this.serverUrl = DATAMONKEY_SERVER_URL;
+
+		// jobId -> timeoutId, for jobs submitted but not yet acknowledged by the server.
+		// Armed only by runAnalysis; reconnectToJobs has its own 10s ack and must not arm these.
+		this.submissionWatchdogs = new Map();
 	}
 
 	/**
@@ -113,6 +130,8 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// Try to find the analysis ID for this status update
 			if (statusJobId && this.activeAnalyses.has(statusJobId)) {
 				const analysisId = this.activeAnalyses.get(statusJobId);
+				// Any word from the server about this job is proof it was accepted.
+				this.clearSubmissionWatchdog(statusJobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -122,6 +141,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			} else if (this.activeAnalyses.size === 1) {
 				// If only one analysis is running, we can safely assume it's for that one
 				const [jobId, analysisId] = this.activeAnalyses.entries().next().value;
+				this.clearSubmissionWatchdog(jobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -168,10 +188,12 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 
 			if (jobId && this.activeAnalyses.has(jobId)) {
 				const analysisId = this.activeAnalyses.get(jobId);
+				this.clearSubmissionWatchdog(jobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(jobId);
 			} else if (!jobId && this.activeAnalyses.size === 1) {
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -203,6 +225,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			const errorJobId = error.jobId || error.id;
 			if (errorJobId && this.activeAnalyses.has(errorJobId)) {
 				const analysisId = this.activeAnalyses.get(errorJobId);
+				this.clearSubmissionWatchdog(errorJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(errorJobId);
 			} else if (!errorJobId && this.activeAnalyses.size === 1) {
@@ -211,6 +234,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				// sitting at "running" forever. With two or more it is genuinely ambiguous, so the
 				// branch below still refuses rather than killing an innocent concurrent job.
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -229,10 +253,183 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// This is handled per-analysis in runAnalysis method
 		});
 
-		this.socket.on('job queue', (jobs) => {
-			console.log('📋 Backend job queue:', jobs);
-			// Could update UI with queue information
+		// THE SUBMISSION ACKNOWLEDGEMENT. Not dead code — do not delete.
+		//
+		// The server already tells us it accepted a job; we used to throw that away. app/hyphyjob.js
+		// (262-299) publishes `{ type:'job created', id, torque_id, status, scheduler, created_time,
+		// sites, sequences }` on the redis channel keyed by the job id the moment the job row exists,
+		// and lib/clientsocket.js:60 forwards it to this socket verbatim. `job metadata` (hyphyjob.js
+		// 489-513) carries the same shape later in the job's life.
+		//
+		// `id` is the jobId WE generated and sent in `job.id` — analysis-factory.js:117-124 resolves
+		// `params.job.id || params.id` — so it routes exactly, with no single-job heuristic needed.
+		//
+		// This is the only positive confirmation a spawn was accepted, and it is what disarms the
+		// submission watchdog.
+		this.socket.on('job created', (packet) => this.handleServerAck(packet));
+		this.socket.on('job metadata', (packet) => this.handleServerAck(packet));
+
+		// DELIBERATELY NOT LISTENING FOR / EMITTING `job queue`.
+		//
+		// server.js:54-59 answers a `job queue` request with `socket.emit('job queue', jobs);
+		// socket.disconnect();` — asking the server where we are in the queue tears down the socket
+		// carrying every in-flight job's status stream. Queue position is not worth that.
+		//
+		// The `status` field on `job created` / `job metadata` above already reports whether this
+		// particular job is queued or running, which is the part the user actually needs, at no
+		// protocol cost.
+	}
+
+	/**
+	 * Handle `job created` / `job metadata` — the server confirming it took the job.
+	 *
+	 * Moves the run off the bare "Job submitted" state and onto what the scheduler says: Torque/PBS
+	 * reports 'Q' while queued and 'R' once it is running (some deployments spell them out). Anything
+	 * unrecognised is treated as queued, because a job that has been acknowledged but not started is
+	 * exactly that.
+	 */
+	handleServerAck(packet) {
+		const jobId = packet?.id ?? packet?.jobId;
+		if (!jobId || !this.activeAnalyses.has(jobId)) return;
+
+		const analysisId = this.activeAnalyses.get(jobId);
+		this.clearSubmissionWatchdog(jobId);
+
+		const reported = String(packet?.status ?? '').toLowerCase();
+		const isRunning = reported === 'r' || reported === 'running';
+
+		console.log(`📨 Server acknowledged job ${jobId} (status: ${packet?.status ?? 'unreported'})`);
+
+		this.updateProgress(
+			analysisId,
+			isRunning ? 'running' : 'pending',
+			10,
+			isRunning ? 'Running on the server' : 'Queued on the server'
+		);
+	}
+
+	/**
+	 * Start the clock on an unacknowledged submission.
+	 *
+	 * MUST be called only from runAnalysis. Jobs restored by reconnectToJobs already have their own
+	 * 10s job:status ack and arming this for them would double-probe.
+	 */
+	armSubmissionWatchdog(analysisId, jobId, submittedAt = Date.now()) {
+		this.clearSubmissionWatchdog(jobId);
+		const timer = setTimeout(() => {
+			this.submissionWatchdogs.delete(jobId);
+			this.probeSubmission(analysisId, jobId, submittedAt);
+		}, SUBMISSION_ACK_TIMEOUT_MS);
+		this.submissionWatchdogs.set(jobId, timer);
+	}
+
+	clearSubmissionWatchdog(jobId) {
+		const timer = this.submissionWatchdogs.get(jobId);
+		if (timer) {
+			clearTimeout(timer);
+			this.submissionWatchdogs.delete(jobId);
+		}
+	}
+
+	clearAllSubmissionWatchdogs() {
+		for (const timer of this.submissionWatchdogs.values()) {
+			clearTimeout(timer);
+		}
+		this.submissionWatchdogs.clear();
+	}
+
+	/**
+	 * The watchdog expired: ask the server whether it has this job, and DO NOT assume it does not.
+	 *
+	 * Silence is not loss. The spawn event is fire-and-forget (see the emit in runAnalysis for why it
+	 * must stay that way), and the ack we listen for rides a redis subscription that can attach a beat
+	 * late — so a perfectly healthy job can arrive here. `job:status` is genuinely ack-capable
+	 * (server.js:62 `socket.on('job:status', function (params, callback)`) and reads the persisted
+	 * hash, so it can answer for a job whose events we missed.
+	 */
+	probeSubmission(analysisId, jobId, submittedAt) {
+		// Completed, failed or cancelled while we were waiting — nothing to chase.
+		if (!this.activeAnalyses.has(jobId)) return;
+
+		if (!this.socket) {
+			this.markSubmissionLost(analysisId, jobId, 'The server never confirmed this job.');
+			return;
+		}
+
+		this.socket
+			.timeout(STATUS_PROBE_TIMEOUT_MS)
+			.emit('job:status', { jobId }, async (err, response) => {
+				try {
+					if (err || !response) {
+						// No answer at all: the socket is not carrying anything for this job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server never confirmed this job.'
+						);
+						return;
+					}
+
+					if (response.status === 'not_found') {
+						// The one unambiguous negative. The server looked and has no such job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server has no record of this job. It was never accepted.'
+						);
+						return;
+					}
+
+					if (response.status === 'completed' && response.results) {
+						// We missed the whole event stream for this job but the results are sitting there.
+						// Same recovery the reconnect path performs.
+						console.log(`✅ Job ${jobId} had already completed; collecting results from probe`);
+						this.clearSubmissionWatchdog(jobId);
+						this.activeAnalyses.delete(jobId);
+						await this.completeAnalysis(analysisId, true, response.results);
+						return;
+					}
+
+					// EVERYTHING ELSE MEANS KEEP WAITING — and 'unknown' above all.
+					//
+					// This is where this handler deliberately differs from reconnectToJobs, which treats an
+					// unrecognised status as connection_lost. app/hyphyjob.js:91 hSets the `params` field the
+					// instant init() runs, before any `status` field exists, so server.js:76 answers
+					// `status:'unknown'` for a perfectly healthy job sitting in the submit -> qsub window.
+					// Failing on that would kill good jobs on a busy scheduler.
+					const waitedMinutes = Math.max(1, Math.round((Date.now() - submittedAt) / 60000));
+					const running = response.status === 'running';
+					this.updateProgress(
+						analysisId,
+						running ? 'running' : 'pending',
+						running ? 10 : 5,
+						running
+							? 'Running on the server'
+							: `Waiting for the server to start this job (queued ${waitedMinutes} min)`
+					);
+					this.armSubmissionWatchdog(analysisId, jobId, submittedAt);
+				} catch (error) {
+					console.error(`Error probing submission for job ${jobId}:`, error);
+				}
+			});
+	}
+
+	/**
+	 * Resolve a job we can no longer account for.
+	 *
+	 * Reuses `connection_lost` rather than inventing a status: AnalysisCard and runStatusLine already
+	 * render it, and it already offers a Re-run.
+	 */
+	async markSubmissionLost(analysisId, jobId, message) {
+		console.warn(`⏱️ Submission for job ${jobId} unconfirmed: ${message}`);
+		this.clearSubmissionWatchdog(jobId);
+		await analysisStore.updateAnalysis(analysisId, {
+			status: 'connection_lost',
+			error: message,
+			updatedAt: Date.now()
 		});
+		this.activeAnalyses.delete(jobId);
+		analysisStore.removeFromActiveAnalyses(analysisId);
 	}
 
 	/**
@@ -303,10 +500,27 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				}
 			};
 
+			// TWO ARGUMENTS, NEVER THREE. Do not "improve" this into
+			// `socket.timeout(ms).emit(eventName, submitData, cb)`.
+			//
+			// The server registers every spawn event through a stream wrapper: lib/router.js:26 is
+			// `socket.on(key, function (stream, data))`. A third argument makes socket.io deliver
+			// stream=submitData and data=<ack function>, the adjustment guard at router.js:29
+			// (`data === undefined`) does not fire, and analysis-routes.js:47-51 then reads `params` as
+			// the ack function — so `!params.job` is true and EVERY submission is answered with
+			// 'Invalid job parameters'. The server never calls the ack either, so the timeout would
+			// also fire on every healthy run.
+			//
+			// The acknowledgement therefore cannot ride the emit. It arrives as the `job created`
+			// event (see setupGlobalHandlers), and armSubmissionWatchdog below covers its absence.
 			this.socket.emit(eventName, submitData);
 
 			// Update progress
 			this.updateProgress(analysisId, 'pending', 5, `Job submitted - ID: ${jobId}`);
+
+			// Nothing else ever revisited this state before: a job the server silently dropped sat at
+			// "pending" until the user gave up. Start the clock.
+			this.armSubmissionWatchdog(analysisId, jobId);
 
 			return {
 				analysisId,
@@ -315,6 +529,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			};
 		} catch (error) {
 			console.error('❌ Backend analysis submission failed:', error);
+			this.clearSubmissionWatchdog(jobId);
 			await this.completeAnalysis(analysisId, false, null, `Submission failed: ${error.message}`);
 			this.activeAnalyses.delete(jobId);
 			throw error;
@@ -726,6 +941,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				if (this.socket && this.socket.connected) {
 					this.socket.emit('cancel', { jobId });
 				}
+				this.clearSubmissionWatchdog(jobId);
 				this.activeAnalyses.delete(jobId);
 				break;
 			}
@@ -770,6 +986,9 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			this.socket.disconnect();
 			this.socket = null;
 		}
+		// Drop the timers with the socket. Left armed they would fire against a dead connection —
+		// and in a test suite that reuses this singleton they leak across cases.
+		this.clearAllSubmissionWatchdogs();
 		this.activeAnalyses.clear();
 	}
 

--- a/src/lib/utils/runStatusLine.js
+++ b/src/lib/utils/runStatusLine.js
@@ -112,6 +112,22 @@ export function runStatusLine({
 
 	// --- still running ---
 
+	// A server job that has been submitted but not started is QUEUED, not running. Saying "on the
+	// server · running" for a job sitting in the scheduler is a lie, and the specific lie that makes a
+	// slow queue look like a slow analysis — the user waits on a machine that has not begun.
+	//
+	// Only the backend gets this branch: a wasm run has no queue, so 'pending' there is genuinely the
+	// first moments of execution.
+	if (executionMode === 'backend' && (status === 'pending' || status === 'initializing')) {
+		return {
+			label,
+			detail: 'queued on the server',
+			tone: 'running',
+			clock: elapsedSeconds < CLOCK_AFTER_SECONDS ? null : clock,
+			showDetails: false
+		};
+	}
+
 	if (elapsedSeconds < CLOCK_AFTER_SECONDS) {
 		return {
 			label,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 		activeAnalysisProgress,
 		activeAnalyses
 	} from '../stores/analyses';
+	import { analysisConfig } from '../stores/analysisConfig';
 	import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
 	import { treeStore, addTree, updateTaggedTree, resetTrees } from '../stores/tree';
 	import { syncDescriptorStoresForFile as syncDescriptorStores } from '../lib/utils/descriptorSync.js';
@@ -57,7 +58,6 @@
 	let showAllHistory = false;
 	let activeTab = 'data'; // 'data', 'analyze', or 'results'
 	let selectedTree = 'nj';
-	let selectedMethod = 'FEL'; // Default selected method for configuration
 	let treeData = {};
 	let showBatchExport = false;
 	let analysisStartTime = null; // Track analysis start time for duration calculation
@@ -210,6 +210,10 @@
 			description: 'Estimation of selection pressure.'
 		}
 	};
+
+	// The dropdown's exact ids ('AxoMEME', 'aBSREL', ...). Analyses are stored upper-cased, so a
+	// restore has to be matched back to these or the <select> falls through to its placeholder.
+	const methodKeys = Object.keys(methodConfig);
 
 	// WHICH ANALYSIS THE DETAIL PANE SHOWS.
 	//
@@ -1238,12 +1242,16 @@
 				selectAnalysis(event.detail.analysisId);
 			}
 
-			// Handle re-run: set the method and file for the Analyze tab
+			// Handle re-run: restore the configuration that run was made with, not just its method.
 			if (event.detail.rerun && event.detail.tabName === 'analyze') {
-				// Set the method if provided
-				if (event.detail.method) {
-					selectedMethod = event.detail.method.toUpperCase();
-				}
+				// ONE source of truth for the configuration: the analysisConfig store. The page-level
+				// `selectedMethod` used to be a second one, and it never reached MethodSelector anyway
+				// (AnalyzeTab took the prop and did not forward it), which is how "Re-run" came to
+				// restore nothing at all.
+				const record = ($analysisStore.analyses ?? []).find(
+					(a) => a.id === event.detail.analysisId
+				);
+				analysisConfig.restoreFrom(record ?? { method: event.detail.method }, methodKeys);
 
 				// Set the current file if provided, and resync the descriptor stores so
 				// alignment/metrics/tree describe the re-run file rather than the
@@ -1441,7 +1449,6 @@
 				<AnalyzeTab
 					{methodConfig}
 					{runMethod}
-					{selectedMethod}
 					{hyphyOut}
 					{isStdOutVisible}
 					{toggleStdOut}

--- a/src/stores/analyses.js
+++ b/src/stores/analyses.js
@@ -2,6 +2,54 @@ import { derived, writable } from 'svelte/store';
 import { analysisStorage } from '../lib/utils/indexedDBStorage';
 import { browser } from '$app/environment';
 
+/**
+ * LIVENESS, and why a local run needs a pulse.
+ *
+ * IndexedDB is shared by every tab of the origin, but `activeAnalyses` is per-tab memory. So a
+ * second tab opening while the first tab is mid-run used to read the first tab's record — which sits
+ * at 'pending'/'wasm' for the whole run, because progress updates are in-memory only — and mark it
+ * 'interrupted', throwing away hours of compute in a tab it does not own and offering a Re-run that
+ * would duplicate it.
+ *
+ * The owning tab therefore stamps `lastHeartbeatAt` while it is actually running, and the sweep only
+ * reaps records whose pulse has stopped.
+ */
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * How long a record may go unstamped before another tab may declare it dead.
+ *
+ * Six missed ticks, not three. AxoMEME runs on the main thread and only yields between batches
+ * (AxomemeAnalysisRunner.yieldToBrowser), so a healthy run can starve the interval for seconds at a
+ * time. A margin that is too tight reaps live work; one that is too loose only delays cleanup of a
+ * genuinely dead tab's record by a few seconds.
+ */
+const HEARTBEAT_STALE_MS = 60_000;
+
+/** Statuses the interrupted-sweep considers unfinished. */
+const REAPABLE_STATUSES = ['pending', 'initializing', 'running', 'processing', 'saving'];
+
+/** Statuses a run can stop in — a record in one of these is nobody's live work. */
+const TERMINAL_STATUSES = ['completed', 'error', 'cancelled', 'interrupted', 'connection_lost'];
+
+/**
+ * Is this stored record safe for THIS tab to mark interrupted?
+ *
+ * One function, used by both the filter and the map below, because when those were two copies of the
+ * same predicate they could drift apart silently.
+ *
+ * The `?? 0` is load-bearing twice: a record written before heartbeats existed has no pulse and is by
+ * definition from a session that is gone, so it must still be reaped — and that is also what keeps
+ * every pre-existing cleanup test meaningful without hand-editing fixtures.
+ */
+function isReapable(analysis) {
+	return (
+		analysis?.metadata?.executionMode === 'wasm' &&
+		REAPABLE_STATUSES.includes(analysis.status) &&
+		Date.now() - (analysis.lastHeartbeatAt ?? 0) > HEARTBEAT_STALE_MS
+	);
+}
+
 function createAnalysisStore() {
 	const { subscribe, set, update } = writable({
 		analyses: [],
@@ -11,6 +59,58 @@ function createAnalysisStore() {
 		// Single unified tracking for active analyses
 		activeAnalyses: [] // Array of active analysis objects with progress tracking
 	});
+
+	/** Interval that stamps this tab's live local runs. Null whenever there are none. */
+	let heartbeatTimer = null;
+
+	/** Read state synchronously. `update` with an unchanged return is the pattern used below. */
+	function readState() {
+		let snapshot;
+		update((state) => {
+			snapshot = state;
+			return state;
+		});
+		return snapshot;
+	}
+
+	function liveLocalRuns() {
+		return (readState().activeAnalyses || []).filter(
+			(a) => a?.metadata?.executionMode === 'wasm' && !TERMINAL_STATUSES.includes(a.status)
+		);
+	}
+
+	async function heartbeatTick() {
+		// Iterate activeAnalyses ONLY. Walking the full analyses list would rewrite completed records,
+		// which carry their whole result payload — megabytes, every ten seconds.
+		for (const entry of liveLocalRuns()) {
+			try {
+				const stored = await analysisStorage.getAnalysis(entry.id);
+				if (!stored) continue;
+				// Read-modify-write: a completion landing between this read and the write would be
+				// written back as unfinished, so never touch a record that has already stopped.
+				if (TERMINAL_STATUSES.includes(stored.status)) continue;
+				await analysisStorage.saveAnalysis({ ...stored, lastHeartbeatAt: Date.now() });
+			} catch (error) {
+				// A missed beat costs nothing; HEARTBEAT_STALE_MS allows for six of them.
+				console.error(`Error stamping heartbeat for ${entry.id}:`, error);
+			}
+		}
+	}
+
+	function startHeartbeat() {
+		if (!browser || heartbeatTimer) return;
+		heartbeatTimer = setInterval(() => {
+			heartbeatTick();
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+
+	/** Stop the pulse once this tab has no local run left to vouch for. */
+	function stopHeartbeatIfIdle() {
+		if (!heartbeatTimer) return;
+		if (liveLocalRuns().length > 0) return;
+		clearInterval(heartbeatTimer);
+		heartbeatTimer = null;
+	}
 
 	return {
 		subscribe,
@@ -240,6 +340,8 @@ function createAnalysisStore() {
 					...state,
 					activeAnalyses: (state.activeAnalyses || []).filter((a) => a.id !== analysisId)
 				}));
+
+				stopHeartbeatIfIdle();
 			} catch (error) {
 				console.error('Error cancelling analysis:', error);
 				throw error;
@@ -347,6 +449,12 @@ function createAnalysisStore() {
 				};
 			});
 
+			// A local run must be protected from the instant it starts, not from the first tick ten
+			// seconds later — otherwise a tab opened in that window still reaps it.
+			if (metadata.executionMode === 'wasm') {
+				startHeartbeat();
+			}
+
 			// Persist metadata to IndexedDB (executionMode, jobId, etc.)
 			// This is critical for cleanupInterruptedAnalyses and backend reconnection to work
 			if (browser && metadata.executionMode) {
@@ -361,6 +469,12 @@ function createAnalysisStore() {
 							},
 							updatedAt: Date.now()
 						};
+
+						// Only local runs get a pulse. A server job's liveness is the server's to report,
+						// and the sweep never touches backend records.
+						if (metadata.executionMode === 'wasm') {
+							updatedAnalysis.lastHeartbeatAt = Date.now();
+						}
 						await analysisStorage.saveAnalysis(updatedAnalysis);
 						console.log(
 							`📊 [AnalysisStore] Persisted metadata (executionMode=${metadata.executionMode}, jobId=${metadata.jobId || 'n/a'}) for ${analysisId.slice(0, 8)}...`
@@ -603,6 +717,9 @@ function createAnalysisStore() {
 				};
 			});
 
+			// The entry is terminal now, so this tab may have nothing left to vouch for.
+			stopHeartbeatIfIdle();
+
 			// Persist to IndexedDB and server
 			const currentLogs = activeAnalysisData?.logs || [];
 			const currentResult = activeAnalysisData?.result || null;
@@ -656,6 +773,7 @@ function createAnalysisStore() {
 					activeAnalyses: newActiveAnalyses
 				};
 			});
+			stopHeartbeatIfIdle();
 		},
 
 		// Clear all analyses
@@ -703,12 +821,11 @@ function createAnalysisStore() {
 				return;
 			}
 
-			// Find WASM analyses that were running/pending (these were interrupted)
-			const interruptedAnalyses = analyses.filter(
-				(a) =>
-					a.metadata?.executionMode === 'wasm' &&
-					['pending', 'initializing', 'running', 'processing', 'saving'].includes(a.status)
-			);
+			// Find local runs that stopped without finishing.
+			//
+			// The heartbeat check is what keeps this tab out of another tab's business: IndexedDB is
+			// shared across tabs, so without it, opening a second tab reaped the first tab's live run.
+			const interruptedAnalyses = analyses.filter(isReapable);
 
 			if (interruptedAnalyses.length === 0) {
 				console.log('📊 [AnalysisStore] No interrupted analyses found');
@@ -720,25 +837,29 @@ function createAnalysisStore() {
 			);
 
 			// Update each interrupted analysis
+			const reapedIds = new Set(interruptedAnalyses.map((a) => a.id));
 			const updatedAnalyses = analyses.map((analysis) => {
-				if (
-					analysis.metadata?.executionMode === 'wasm' &&
-					['pending', 'initializing', 'running', 'processing', 'saving'].includes(analysis.status)
-				) {
+				if (isReapable(analysis)) {
 					return {
 						...analysis,
 						status: 'interrupted',
 						interruptedAt: new Date().getTime(),
-						error: 'Analysis was interrupted by page refresh',
+						// True of both causes. A reaped record is no longer necessarily a refresh — it may
+						// be a tab that was closed, or one whose heartbeat stopped.
+						error: 'This run stopped when its browser tab closed or reloaded.',
 						updatedAt: new Date().getTime()
 					};
 				}
 				return analysis;
 			});
 
-			// Persist updated analyses to IndexedDB
+			// Persist the records this sweep actually changed.
+			//
+			// Keyed on the ids reaped above, not on `status === 'interrupted'`: that test also matched
+			// records interrupted in some earlier session, so every page load rewrote them — whole
+			// objects, results and all — for no change.
 			for (const analysis of updatedAnalyses) {
-				if (analysis.status === 'interrupted') {
+				if (reapedIds.has(analysis.id)) {
 					try {
 						await analysisStorage.saveAnalysis(analysis);
 						console.log(

--- a/src/stores/analysisConfig.js
+++ b/src/stores/analysisConfig.js
@@ -1,0 +1,161 @@
+/**
+ * analysisConfig — the analysis configuration a user has built up, held outside the component.
+ *
+ * WHY THIS EXISTS. +page.svelte mounts <AnalyzeTab> inside an {#if activeTab === 'analyze'} block, so
+ * Svelte destroys it on every tab switch. MethodSelector kept the whole configuration in component
+ * locals, which meant a glance at the Results tab silently discarded the method, the genetic code,
+ * the execution mode and every advanced option — and the dropdown came back on "Select an analysis
+ * method" as though nothing had been chosen.
+ *
+ * Deliberately NOT localStorage. Nothing in src/ persists to it, and the defect is tab switching
+ * within a session, not reload. A configuration that outlived a reload would also outlive the file it
+ * was built for, which is worse than losing it.
+ */
+
+import { writable, get } from 'svelte/store';
+import { METHOD_ADVANCED_OPTIONS } from '../lib/config/methodAdvancedOptions.js';
+
+const DEFAULTS = {
+	selectedMethod: null,
+	geneticCode: 'Universal',
+	geneticCodeId: 0,
+	executionMode: 'local',
+	methodOptions: {},
+	// Set by restoreFrom so the selector can say what it put back, and cleared once it has.
+	restoredFromAnalysisId: null
+};
+
+/** Keys that belong to the top level of the configuration rather than to a method's option bag. */
+const TOP_LEVEL_KEYS = new Set(['method', 'geneticCode', 'geneticCodeId', 'executionMode']);
+
+function defaults() {
+	return { ...DEFAULTS, methodOptions: {} };
+}
+
+/**
+ * The settings a re-run should restore, from whichever shape the runner persisted.
+ *
+ * ORDER IS LOAD-BEARING. BackendAnalysisRunner stores `parameters` in the BACKEND's shape
+ * (gencodeid, 'ds-variation', 'branch-set') and keeps the UI's own config under `originalConfig`;
+ * WasmAnalysisRunner stores the UI config directly as `parameters`. Feeding backend-shaped keys into
+ * methodOptions would inject controls the UI never had and silently change what the next run
+ * submits, so originalConfig wins whenever it exists.
+ */
+function savedSettingsFor(analysis) {
+	const args = analysis?.metadata?.arguments;
+	if (!args) return null;
+	return args.originalConfig ?? args.parameters ?? null;
+}
+
+function createAnalysisConfigStore() {
+	const store = writable(defaults());
+	const { subscribe, set, update } = store;
+
+	return {
+		subscribe,
+		set,
+		update,
+
+		/** Back to a blank configuration (a new file, or a test). */
+		reset() {
+			set(defaults());
+		},
+
+		/**
+		 * Rehydrate from a previous analysis so "Re-run" means what it says.
+		 *
+		 * `methodKeys` is the dropdown's own list of method ids (Object.keys(methodConfig)). Analyses
+		 * are stored with `method.toUpperCase()`, but the selector's values are the config's exact
+		 * casing — 'AxoMEME', 'aBSREL' — so without this the restored method would never match an
+		 * <option> and the dropdown would fall back to its placeholder.
+		 *
+		 * Returns `{ method, restoredSettings }`. `restoredSettings` is false when the record carries
+		 * no arguments at all — AxomemeAnalysisRunner calls startAnalysisTracking with four arguments,
+		 * so its records have no `metadata.arguments` — and the caller must not then claim settings
+		 * were restored.
+		 */
+		restoreFrom(analysis, methodKeys = []) {
+			const raw = analysis?.method ? String(analysis.method) : null;
+			const method = raw
+				? (methodKeys.find((k) => k.toLowerCase() === raw.toLowerCase()) ?? raw)
+				: null;
+			const saved = savedSettingsFor(analysis);
+
+			update((state) => {
+				const next = {
+					...state,
+					selectedMethod: method ?? state.selectedMethod,
+					restoredFromAnalysisId: analysis?.id ?? null,
+					restoredSummary: ''
+				};
+
+				if (!saved || !method) return next;
+
+				if (typeof saved.geneticCode === 'string') next.geneticCode = saved.geneticCode;
+				if (Number.isFinite(saved.geneticCodeId)) next.geneticCodeId = saved.geneticCodeId;
+				if (saved.executionMode === 'local' || saved.executionMode === 'backend') {
+					next.executionMode = saved.executionMode;
+				}
+
+				// Everything else is a method option — but only if the method still HAS that option.
+				// An option removed in a later release must not resurrect a control that no longer
+				// exists, and a backend-shaped key must never reach the UI's bag.
+				const schema = METHOD_ADVANCED_OPTIONS[method.toLowerCase()] ?? {};
+				const restored = {};
+				for (const [key, value] of Object.entries(saved)) {
+					if (TOP_LEVEL_KEYS.has(key)) continue;
+					if (!(key in schema)) continue;
+					restored[key] = value;
+				}
+
+				next.methodOptions = {
+					...state.methodOptions,
+					[method]: { ...(state.methodOptions?.[method] ?? {}), ...restored }
+				};
+				// Built HERE, from the values that actually came back — not later from store state,
+				// where a default would be indistinguishable from a restored value and the notice
+				// would claim to have restored settings a record never carried.
+				next.restoredSummary = describeRestoredSettings(method, {
+					geneticCode: typeof saved.geneticCode === 'string' ? saved.geneticCode : null,
+					options: restored
+				});
+				return next;
+			});
+
+			return { method, restoredSettings: Boolean(saved && method) };
+		},
+
+		/** Current value, for the one place that hydrates component locals (MethodSelector.onMount). */
+		current() {
+			return get(store);
+		}
+	};
+}
+
+export const analysisConfig = createAnalysisConfigStore();
+
+/**
+ * A one-line, human summary of what a restore actually put back.
+ *
+ * Takes the RESTORED values, not the store's current state: a default and a restored value look
+ * identical once they are in the store, and a summary built from state would tell an AxoMEME re-run
+ * that its genetic code had been restored when the record carried no settings at all.
+ *
+ * @param {string} method
+ * @param {{geneticCode: string|null, options: Record<string, unknown>}} restored
+ */
+export function describeRestoredSettings(method, restored) {
+	const parts = [];
+	const schema = METHOD_ADVANCED_OPTIONS[String(method ?? '').toLowerCase()] ?? {};
+	if (restored?.geneticCode) parts.push(`genetic code ${restored.geneticCode}`);
+	for (const [key, value] of Object.entries(restored?.options ?? {})) {
+		if (value === '' || value === null || value === undefined) continue;
+		// Interactive-tree payloads are newick strings and branch-name arrays; naming them is
+		// meaningless to a reader and unbounded in length.
+		if (schema[key]?.type === 'interactive-tree' || Array.isArray(value)) continue;
+		if (typeof value === 'object') continue;
+		parts.push(`${(schema[key]?.label ?? key).toLowerCase()} ${value}`);
+	}
+	// Three is a line, not a manifest. The controls themselves are right below it.
+	return parts.slice(0, 3).join(', ');
+}

--- a/src/test/analysis-config-store.test.js
+++ b/src/test/analysis-config-store.test.js
@@ -1,0 +1,157 @@
+/**
+ * analysisConfig.restoreFrom — what "Re-run" is allowed to bring back.
+ *
+ * The dangerous part of this feature is not losing settings, it is restoring the WRONG ones. A
+ * backend run persists its parameters in the SERVER's shape (gencodeid, 'ds-variation', 'branch-set')
+ * and keeps the UI's own config alongside under `originalConfig`. Feeding the former into the option
+ * bag would inject controls the UI never had and silently change what the next run submits — a
+ * scientific result computed with parameters the user never chose.
+ *
+ * So these tests are mostly about what must NOT come back.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { analysisConfig, describeRestoredSettings } from '../stores/analysisConfig.js';
+
+const METHOD_KEYS = ['FEL', 'MEME', 'AxoMEME', 'GARD'];
+
+/** A backend FEL record: server-shaped `parameters`, UI-shaped `originalConfig`. */
+const backendFelRecord = {
+	id: 'analysis-fel-1',
+	method: 'FEL',
+	metadata: {
+		arguments: {
+			parameters: { gencodeid: 0, 'ds-variation': 2, pvalue: 0.1 },
+			originalConfig: {
+				method: 'FEL',
+				geneticCode: 'Universal',
+				geneticCodeId: 0,
+				executionMode: 'backend',
+				branchesToTest: 'Internal',
+				pValueThreshold: 0.05
+			}
+		}
+	}
+};
+
+describe('analysisConfig.restoreFrom', () => {
+	beforeEach(() => {
+		analysisConfig.reset();
+	});
+
+	it('prefers the UI config over the backend-shaped parameters', () => {
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const state = get(analysisConfig);
+
+		expect(state.selectedMethod).toBe('FEL');
+		expect(state.methodOptions.FEL.branchesToTest).toBe('Internal');
+		expect(state.methodOptions.FEL.pValueThreshold).toBe(0.05);
+
+		// The backend's own vocabulary must never reach the UI's option bag.
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('gencodeid');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('ds-variation');
+	});
+
+	it('lifts the shared settings to the top level rather than into the option bag', () => {
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const state = get(analysisConfig);
+
+		expect(state.geneticCode).toBe('Universal');
+		expect(state.executionMode).toBe('backend');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('geneticCode');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('executionMode');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('method');
+	});
+
+	it('drops an option the method no longer has', () => {
+		// A release that removes a control must not have it resurrected by an old record.
+		analysisConfig.restoreFrom(
+			{
+				id: 'analysis-fel-2',
+				method: 'FEL',
+				metadata: {
+					arguments: {
+						originalConfig: { branchesToTest: 'All', thisOptionWasRemovedInV4: 'boom' }
+					}
+				}
+			},
+			METHOD_KEYS
+		);
+
+		const opts = get(analysisConfig).methodOptions.FEL;
+		expect(opts.branchesToTest).toBe('All');
+		expect(Object.keys(opts)).not.toContain('thisOptionWasRemovedInV4');
+	});
+
+	it('degrades to method-only for a record with no arguments, and says so', () => {
+		// AxomemeAnalysisRunner calls startAnalysisTracking with four arguments, so `args` is null and
+		// its records carry no metadata.arguments at all. Claiming settings were restored would be a
+		// lie the user cannot check.
+		const result = analysisConfig.restoreFrom(
+			{ id: 'analysis-axo-1', method: 'AXOMEME', metadata: {} },
+			METHOD_KEYS
+		);
+
+		expect(result.restoredSettings).toBe(false);
+		expect(get(analysisConfig).selectedMethod).toBe('AxoMEME');
+		expect(get(analysisConfig).methodOptions.AxoMEME).toBeUndefined();
+	});
+
+	it('matches the stored upper-cased method back to the dropdown’s own casing', () => {
+		// Records are written with method.toUpperCase(); the <select> values are 'AxoMEME', 'aBSREL'.
+		// Without this the option never matches and the dropdown shows its placeholder.
+		analysisConfig.restoreFrom({ id: 'a', method: 'AXOMEME' }, METHOD_KEYS);
+		expect(get(analysisConfig).selectedMethod).toBe('AxoMEME');
+	});
+
+	it('restores a wasm record, whose parameters ARE the UI config', () => {
+		// WasmAnalysisRunner persists `parameters: config` with no originalConfig, so the fallback
+		// side of the precedence has to work too.
+		analysisConfig.restoreFrom(
+			{
+				id: 'analysis-meme-1',
+				method: 'MEME',
+				metadata: {
+					arguments: { parameters: { geneticCode: 'Universal', rates: 3, pvalue: 0.05 } }
+				}
+			},
+			METHOD_KEYS
+		);
+
+		const state = get(analysisConfig);
+		expect(state.methodOptions.MEME.rates).toBe(3);
+		expect(state.methodOptions.MEME.pvalue).toBe(0.05);
+	});
+
+	it('keeps other methods’ option bags untouched', () => {
+		analysisConfig.update((s) => ({
+			...s,
+			methodOptions: { MEME: { rates: 4 } }
+		}));
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+
+		expect(get(analysisConfig).methodOptions.MEME.rates).toBe(4);
+	});
+});
+
+describe('describeRestoredSettings', () => {
+	it('names what actually came back', () => {
+		analysisConfig.reset();
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const text = get(analysisConfig).restoredSummary;
+
+		expect(text).toContain('genetic code Universal');
+		expect(text).toMatch(/internal/i);
+	});
+
+	it('says nothing at all when nothing was restored', () => {
+		// THE TRAP: a summary built from store state would read the DEFAULT genetic code back out and
+		// tell an AxoMEME re-run that its settings had been restored. They were not; the record has no
+		// arguments to restore.
+		analysisConfig.reset();
+		analysisConfig.restoreFrom({ id: 'a', method: 'AXOMEME' }, METHOD_KEYS);
+		expect(get(analysisConfig).restoredSummary).toBe('');
+		expect(describeRestoredSettings('AxoMEME', { geneticCode: null, options: {} })).toBe('');
+	});
+});

--- a/src/test/multi-tab-liveness.test.js
+++ b/src/test/multi-tab-liveness.test.js
@@ -1,0 +1,203 @@
+/**
+ * A second browser tab must not kill the first tab's running analysis.
+ *
+ * IndexedDB is shared across tabs of the origin; `activeAnalyses` is not. A local run's persisted
+ * record sits at 'pending'/'wasm' for its entire duration (progress updates are in-memory only), so
+ * the interrupted-sweep that every tab runs at onMount used to reap live work belonging to another
+ * tab — discarding hours of compute and offering a Re-run that would duplicate it.
+ *
+ * The fix is a heartbeat: the owning tab stamps `lastHeartbeatAt` while it is running, and the sweep
+ * only reaps records whose pulse has stopped. These tests pin both halves — that a live run survives,
+ * and that a genuinely dead one is still cleaned up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('../lib/utils/indexedDBStorage', () => ({
+	analysisStorage: {
+		getAllAnalyses: vi.fn(),
+		saveAnalysis: vi.fn(),
+		getAnalysis: vi.fn(),
+		deleteAnalysis: vi.fn(),
+		clearAllAnalyses: vi.fn()
+	}
+}));
+
+import { analysisStore } from '../stores/analyses';
+import { analysisStorage } from '../lib/utils/indexedDBStorage';
+
+const resetStore = () =>
+	analysisStore.update(() => ({
+		analyses: [],
+		currentAnalysisId: null,
+		isLoading: false,
+		error: null,
+		activeAnalyses: []
+	}));
+
+const wasmRun = (overrides = {}) => ({
+	id: 'wasm-run-1',
+	fileId: 'file-1',
+	method: 'FEL',
+	status: 'running',
+	metadata: { executionMode: 'wasm' },
+	createdAt: Date.now() - 60_000,
+	...overrides
+});
+
+describe('multi-tab liveness', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		resetStore();
+		vi.clearAllMocks();
+		analysisStorage.saveAnalysis.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		// Drop any heartbeat interval this test started before handing the timers back.
+		resetStore();
+		analysisStore.removeFromActiveAnalyses('cleanup-noop');
+		vi.useRealTimers();
+	});
+
+	describe("cleanupInterruptedAnalyses respects another tab's pulse", () => {
+		it('leaves a run alone while its tab is still stamping it', async () => {
+			// THE ACTUAL BUG. Five seconds since the last beat: that run is alive in another tab.
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ lastHeartbeatAt: Date.now() - 5_000 })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+			expect(get(analysisStore).analyses[0]?.status).not.toBe('interrupted');
+		});
+
+		it('still reaps a run whose tab stopped stamping it', async () => {
+			// Not "never reap": two minutes of silence is a dead tab, and its record must be cleaned up.
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ lastHeartbeatAt: Date.now() - 120_000 })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'wasm-run-1',
+					status: 'interrupted',
+					error: 'This run stopped when its browser tab closed or reloaded.'
+				})
+			);
+		});
+
+		it('reaps a record written before heartbeats existed', async () => {
+			// A record with no pulse at all is by definition from a session that is gone.
+			analysisStorage.getAllAnalyses.mockResolvedValue([wasmRun()]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wasm-run-1', status: 'interrupted' })
+			);
+		});
+
+		it('never touches a server job, heartbeat or not', async () => {
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ id: 'backend-run', metadata: { executionMode: 'backend' } })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('the pulse itself', () => {
+		it('stamps the record the moment the run starts, not ten seconds later', async () => {
+			// Without this, a tab opened inside the first interval still reaps a brand new run.
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'pending',
+				metadata: {}
+			});
+
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({ lastHeartbeatAt: expect.any(Number) })
+			);
+		});
+
+		it('keeps stamping a newer time while the run is active, and stops when it finishes', async () => {
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'running',
+				metadata: { executionMode: 'wasm' }
+			});
+
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			const beats = analysisStorage.saveAnalysis.mock.calls.map((c) => c[0].lastHeartbeatAt);
+			expect(beats.length).toBeGreaterThanOrEqual(2);
+			for (let i = 1; i < beats.length; i++) {
+				expect(beats[i]).toBeGreaterThan(beats[i - 1]);
+			}
+
+			// Once the run finishes there is nothing left to vouch for, and the timer must stop —
+			// otherwise every completed run leaves an interval rewriting IndexedDB forever.
+			await analysisStore.completeAnalysisProgressById('wasm-run-1', true, 'done');
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+
+		it('does not stamp a record that has already stopped', async () => {
+			// Read-modify-write guard: a completion landing between the read and the write would
+			// otherwise be written back as unfinished.
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'completed',
+				metadata: { executionMode: 'wasm' }
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+
+		it('does not start a pulse for a server job', async () => {
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'backend-run',
+				status: 'pending',
+				metadata: {}
+			});
+
+			await analysisStore.startAnalysisProgress('backend-run', 'Starting…', 'FEL', {
+				executionMode: 'backend',
+				jobId: 'FEL-123'
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/test/page-refresh-handling.test.js
+++ b/src/test/page-refresh-handling.test.js
@@ -68,7 +68,9 @@ describe('Page Refresh Handling', () => {
 				expect.objectContaining({
 					id: 'wasm-analysis-1',
 					status: 'interrupted',
-					error: 'Analysis was interrupted by page refresh'
+					// Reworded with the heartbeat gate: a reaped record is no longer necessarily a
+					// refresh — it may be a tab that was closed. See multi-tab-liveness.test.js.
+					error: 'This run stopped when its browser tab closed or reloaded.'
 				})
 			);
 

--- a/src/test/run-status-line.test.js
+++ b/src/test/run-status-line.test.js
@@ -122,6 +122,46 @@ describe('a running row', () => {
 	});
 });
 
+describe('a server job that has not started yet', () => {
+	// Submitted is not started. A job sitting in the scheduler that reads "on the server · running"
+	// makes a slow queue look like a slow analysis, and the user waits on a machine that has not begun.
+	const queued = (status, elapsed) =>
+		runStatusLine({ method: 'FEL', status, executionMode: 'backend', elapsedSeconds: elapsed });
+
+	it('says it is queued, not running', () => {
+		const r = queued('pending', 90);
+		expect(r.detail).toBe('queued on the server');
+		expect(r.clock).toBe('1:30');
+		expect(r.tone).toBe('running');
+	});
+
+	it('covers initializing too, and still hides the clock in the first ten seconds', () => {
+		expect(queued('initializing', 90).detail).toBe('queued on the server');
+		expect(queued('pending', 3).detail).toBe('queued on the server');
+		expect(queued('pending', 3).clock).toBeNull();
+	});
+
+	it('leaves local runs alone — there is no queue in this tab', () => {
+		const r = runStatusLine({
+			method: 'FEL',
+			status: 'pending',
+			executionMode: 'wasm',
+			elapsedSeconds: 90
+		});
+		expect(r.detail).toBe('in this tab · running');
+	});
+
+	it('stops claiming a queue once the job is actually running', () => {
+		const r = runStatusLine({
+			method: 'FEL',
+			status: 'running',
+			executionMode: 'backend',
+			elapsedSeconds: 90
+		});
+		expect(r.detail).toBe('on the server · running');
+	});
+});
+
 describe('a finished row', () => {
 	it('reports elapsed as a fact and drops the running clock', () => {
 		const r = runStatusLine({

--- a/src/test/submission-watchdog.test.js
+++ b/src/test/submission-watchdog.test.js
@@ -1,0 +1,229 @@
+/**
+ * The submission watchdog: what happens between "Job submitted" and the server saying anything.
+ *
+ * Before this, a spawn the server silently dropped left the run sitting at 'pending' forever — there
+ * was no ack, no timer and nothing that ever revisited the state. These tests pin the three
+ * decisions that make the fix correct rather than merely present:
+ *
+ *  1. The ack the server ALREADY sends (`job created`) disarms the watchdog, so a healthy job is
+ *     never probed.
+ *  2. Expiry does not fail the run. It probes `job:status`, and only an unambiguous 'not_found' (or
+ *     no answer at all) is treated as loss. 'unknown' means keep waiting — see the comment in
+ *     probeSubmission for why a healthy job answers 'unknown'.
+ *  3. The spawn emit takes exactly two arguments. A third turns it into an ack request, which the
+ *     server's stream router misreads as the job parameters and rejects. That one is a regression
+ *     guard against a "fix" that would break every backend submission.
+ *
+ * NOT NAMED backend-*.test.js ON PURPOSE: vite.config.ts:21-26 excludes both `src/test/backend-*`
+ * and `src/test/*-backend*` from the vitest run, so a file named for what it tests would never
+ * execute.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
+import { analysisStore } from '../stores/analyses.js';
+
+// Ack replies from the job:status probe, per test.
+let ackReply = [null, { status: 'unknown' }];
+const ackEmit = vi.fn((event, payload, cb) => cb(...ackReply));
+
+const mockSocket = {
+	connected: true,
+	connect: vi.fn(),
+	disconnect: vi.fn(),
+	emit: vi.fn(),
+	on: vi.fn(),
+	off: vi.fn(),
+	timeout: vi.fn(() => ({ emit: ackEmit }))
+};
+
+vi.mock('socket.io-client', () => ({
+	default: vi.fn(() => mockSocket)
+}));
+
+vi.mock('../stores/analyses.js', () => ({
+	analysisStore: {
+		// BaseAnalysisRunner.completeAnalysis does a svelte `get()` on this store, so the mock has to
+		// honour the store contract, not just the method surface.
+		subscribe: (run) => {
+			run({ analyses: [], activeAnalyses: [] });
+			return () => {};
+		},
+		createAnalysis: vi.fn(),
+		updateAnalysis: vi.fn(),
+		startAnalysisProgress: vi.fn(),
+		updateAnalysisProgress: vi.fn(),
+		updateAnalysisProgressById: vi.fn(),
+		completeAnalysisProgress: vi.fn(),
+		completeAnalysisProgressById: vi.fn(),
+		removeFromActiveAnalyses: vi.fn(),
+		cancelAnalysis: vi.fn()
+	}
+}));
+
+const FASTA = '>seq1\nACGACG\n>seq2\nACGACG';
+const TREE = '(seq1:0.1,seq2:0.1);';
+
+/** Register the global handlers against the mock socket without going through connect(). */
+function attachSocket() {
+	backendAnalysisRunner.socket = mockSocket;
+	mockSocket.connected = true;
+	backendAnalysisRunner.setupGlobalHandlers();
+}
+
+/** The handler setupGlobalHandlers registered for a given socket event. */
+function handlerFor(event) {
+	const call = [...mockSocket.on.mock.calls].reverse().find((c) => c[0] === event);
+	expect(call?.[1], `no socket handler registered for '${event}'`).toBeTypeOf('function');
+	return call[1];
+}
+
+async function submitFel() {
+	analysisStore.createAnalysis.mockResolvedValue('analysis-1');
+	const { jobId, analysisId } = await backendAnalysisRunner.runAnalysis(
+		'FEL',
+		{ geneticCode: 'Universal', executionMode: 'backend' },
+		FASTA,
+		TREE,
+		'file-1'
+	);
+	return { jobId, analysisId };
+}
+
+const connectionLostCalls = () =>
+	analysisStore.updateAnalysis.mock.calls.filter((c) => c[1]?.status === 'connection_lost');
+
+describe('backend submission watchdog', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		ackReply = [null, { status: 'unknown' }];
+		backendAnalysisRunner.activeAnalyses.clear();
+		backendAnalysisRunner.clearAllSubmissionWatchdogs();
+		backendAnalysisRunner.socket = null;
+	});
+
+	afterEach(() => {
+		backendAnalysisRunner.disconnect();
+		vi.useRealTimers();
+	});
+
+	it('does not probe a job the server acknowledged', async () => {
+		attachSocket();
+		const { jobId } = await submitFel();
+
+		// `job created` is what the server already publishes on acceptance
+		// (app/hyphyjob.js -> lib/clientsocket.js). Feeding it back disarms the watchdog.
+		handlerFor('job created')({ id: jobId, status: 'queued' });
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('reports the acknowledged queue state instead of a bare job id', async () => {
+		attachSocket();
+		const { jobId, analysisId } = await submitFel();
+
+		handlerFor('job created')({ id: jobId, status: 'Q' });
+		expect(analysisStore.updateAnalysisProgressById).toHaveBeenCalledWith(
+			analysisId,
+			'pending',
+			10,
+			'Queued on the server'
+		);
+
+		handlerFor('job metadata')({ id: jobId, status: 'R' });
+		expect(analysisStore.updateAnalysisProgressById).toHaveBeenCalledWith(
+			analysisId,
+			'running',
+			10,
+			'Running on the server'
+		);
+	});
+
+	it('marks the run connection_lost when the server has no record of the job', async () => {
+		attachSocket();
+		const { analysisId } = await submitFel();
+		ackReply = [null, { status: 'not_found' }];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(ackEmit).toHaveBeenCalledWith('job:status', expect.any(Object), expect.any(Function));
+		expect(analysisStore.updateAnalysis).toHaveBeenCalledWith(
+			analysisId,
+			expect.objectContaining({
+				status: 'connection_lost',
+				error: 'The server has no record of this job. It was never accepted.'
+			})
+		);
+		expect(backendAnalysisRunner.activeAnalyses.size).toBe(0);
+	});
+
+	it('marks the run connection_lost when the probe itself goes unanswered', async () => {
+		attachSocket();
+		const { analysisId } = await submitFel();
+		ackReply = [new Error('operation has timed out'), undefined];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(analysisStore.updateAnalysis).toHaveBeenCalledWith(
+			analysisId,
+			expect.objectContaining({
+				status: 'connection_lost',
+				error: 'The server never confirmed this job.'
+			})
+		);
+	});
+
+	it("keeps waiting on 'unknown', which a healthy queued job reports", async () => {
+		attachSocket();
+		await submitFel();
+		ackReply = [null, { status: 'unknown' }];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(ackEmit).toHaveBeenCalledTimes(1);
+		expect(connectionLostCalls()).toHaveLength(0);
+
+		// And it re-arms rather than giving up silently.
+		await vi.advanceTimersByTimeAsync(61_000);
+		expect(ackEmit).toHaveBeenCalledTimes(2);
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('submits the spawn with exactly two arguments and no ack request', async () => {
+		// REGRESSION GUARD. `socket.timeout(ms).emit(spawn, data, cb)` arrives at the server's stream
+		// router (lib/router.js:26) as stream=data, data=ackFn, so analysis-routes.js reads the ack
+		// function as the job parameters and answers 'Invalid job parameters' for every submission.
+		attachSocket();
+		await submitFel();
+
+		const call = mockSocket.emit.mock.calls.find((c) => c[0] === 'fel:spawn');
+		expect(call, 'the spawn must go out on socket.emit, not socket.timeout().emit').toBeDefined();
+		expect(call).toHaveLength(2);
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+	});
+
+	it('stops chasing a job that completed while unacknowledged', async () => {
+		attachSocket();
+		const { jobId } = await submitFel();
+
+		handlerFor('completed')({ jobId, results: { some: 'result' } });
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('never asks the server for the job queue, which would disconnect the socket', async () => {
+		// server.js:54-59 answers `job queue` with a reply followed by socket.disconnect(), tearing
+		// down the status stream for every in-flight job.
+		attachSocket();
+		await submitFel();
+
+		const queueEmits = mockSocket.emit.mock.calls.filter((c) => c[0] === 'job queue');
+		expect(queueEmits).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Implements UX audit items **3.3, 3.4, 3.5**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

Server job submission acknowledgement and queue state; configuration destroyed by tab switching with Re-run restoring none of it; and a second browser tab marking the first tab's live local run as "Interrupted".

**3.3 was verified as only partly-fixed**, not fixed: #177 added the ack timeout to the reconnect `job:status` emit, but not to submission. The verifier explicitly rejected the audit's literal proposal here — see the commit message for what it did instead and why.

The largest branch in the set (2,415 insertions); worth the closest read.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 631 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
