### PR TITLE
Make the Data tab tell the truth about the user's file

### DIFF
--- a/e2e/21-data-tab-facts.spec.js
+++ b/e2e/21-data-tab-facts.spec.js
@@ -1,0 +1,84 @@
+/**
+ * The Data tab's claims about a file, end to end.
+ *
+ * Each assertion below pins a statement that was WRONG on the page before this spec existed:
+ *
+ *  - the upload limits ("Max 5,000 sequences ... >500 sequences require an embedded tree" against
+ *    real gates of 25,000 and 10,000),
+ *  - the "N raw -> M processed" sites row, which is one alignment measured in two units,
+ *  - the bare integer where the genetic code's name belongs,
+ *  - and the fact that datareader renamed or collapsed sequences, which only ever went to
+ *    ./datareader.log — a file nothing in the app reads.
+ *
+ * The last two need the real WASM datareader to run, so they upload a fixture and read what came
+ * back rather than a fixture-shaped mock.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, uploadFile, TEST_FILES } from './fixtures/helpers.js';
+import path from 'path';
+
+const SPECIAL_CHARS = path.resolve('static/test-data/validation-tests/special-chars.fna');
+const DUPLICATES = path.resolve('static/test-data/validation-tests/duplicates.fna');
+
+test.describe('Data tab facts', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('the upload limits are the ones datareader enforces', async ({ page }) => {
+		await expect(page.getByText(/25,000 sequences/)).toBeVisible();
+		await expect(page.getByText(/Above 10,000 sequences/)).toBeVisible();
+
+		// The exact strings the old copy used. '25,000 sequences' CONTAINS '5,000 sequences', so a
+		// bare /5,000 sequences/ here would match the fixed page — hence the full old phrases.
+		await expect(page.getByText(/Max 5,000 sequences/)).toHaveCount(0);
+		await expect(page.getByText(/>500 sequences require an embedded tree/)).toHaveCount(0);
+	});
+
+	test('the sites row states one length in two units, and the code has a name', async ({
+		page
+	}) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+
+		const seqInfo = page.locator('[data-testid="sequence-info"]');
+		await expect(seqInfo).toBeVisible({ timeout: 30000 });
+		await seqInfo.getByRole('button', { name: /Show details/ }).click();
+
+		await expect(seqInfo).toContainText(/\d+ nucleotides \(\d+ codons\)/);
+		await expect(seqInfo).not.toContainText('processed');
+		await expect(seqInfo).toContainText('Universal code');
+
+		// datareader computes dType and never emitted it; the row was permanently dark.
+		await expect(seqInfo).toContainText('Data Type');
+		await expect(seqInfo).toContainText('codon');
+	});
+
+	test('renamed sequences are named, not just counted', async ({ page }) => {
+		await uploadFile(page, SPECIAL_CHARS);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		// special-chars.fna has 'Seq:1|sample'. normalizeSequenceID maps every character outside
+		// [a-zA-Z0-9_] to '_' AND upper-cases the result (the `&& 1` operator in
+		// ReadDelimitedFiles.bf:219), so the new name is SEQ_1_SAMPLE. Before this change nothing in
+		// the app could tell you WHICH name had changed, or to what.
+		await expect(page.getByText(/Seq:1\|sample -> SEQ_1_SAMPLE/)).toBeVisible({ timeout: 15000 });
+	});
+
+	test('collapsed duplicates are named, and nothing offers to edit the alignment', async ({
+		page
+	}) => {
+		await uploadFile(page, DUPLICATES);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		// duplicates.fna: Seq2 and Seq4 are byte-identical to Seq1.
+		await expect(page.getByText(/Seq2 = Seq1/)).toBeVisible({ timeout: 15000 });
+
+		// The maintainer's rule, checked where the user actually reads it: describe, never offer to
+		// modify the user's data.
+		const warningsText = await page.locator('body').innerText();
+		const warningsSection = warningsText.slice(warningsText.indexOf('Sequence Warnings'));
+		expect(warningsSection).not.toMatch(/\brepair\b/i);
+		expect(warningsSection).not.toMatch(/\bwe can\b/i);
+	});
+});

--- a/e2e/22-file-conflict.spec.js
+++ b/e2e/22-file-conflict.spec.js
@@ -1,0 +1,67 @@
+/**
+ * Re-uploading a file whose name is already taken.
+ *
+ * The store finds the existing record by FILENAME and replaces its bytes in place, keeping the id.
+ * For a corrected version of the same alignment that is exactly right — the analysis history stays
+ * attached. For a genuinely different file that happens to share a name it is not: every earlier
+ * FEL/MEME run silently ends up filed under contents it never saw, with nothing on screen saying
+ * so. The user was never asked which of the two they meant.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, uploadFile, TEST_FILES } from './fixtures/helpers.js';
+
+const PROMPT = '[data-testid="file-conflict-prompt"]';
+
+test.describe('Same-name upload', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('asks which file the user meant, and can keep both', async ({ page }) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(1);
+
+		// Same name again. No prompt existed before: this silently overwrote.
+		await page.locator('input[type="file"]').setInputFiles(TEST_FILES['CD2-slim.fna']);
+
+		await expect(page.locator(PROMPT)).toBeVisible({ timeout: 15000 });
+		await expect(page.getByRole('button', { name: 'Replace it' })).toBeVisible();
+		const keepBoth = page.getByRole('button', { name: /Keep both/ });
+		await expect(keepBoth).toContainText('CD2-slim (2).fna');
+
+		await keepBoth.click();
+		await expect(page.locator(PROMPT)).toHaveCount(0);
+
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(2);
+		await expect(page.locator('.file-card').filter({ hasText: 'CD2-slim.fna' })).toHaveCount(1);
+		await expect(page.locator('.file-card').filter({ hasText: 'CD2-slim (2).fna' })).toHaveCount(1);
+	});
+
+	test('replacing keeps a single record, as before', async ({ page }) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		await page.locator('input[type="file"]').setInputFiles(TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator(PROMPT)).toBeVisible({ timeout: 15000 });
+		await page.getByRole('button', { name: 'Replace it' }).click();
+
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(1);
+	});
+
+	test('a demo file replaces silently — the prompt is for uploads only', async ({ page }) => {
+		// Demo, repair and alignment-edit saves are deliberate in-place replacements of a file the
+		// user just acted on. Prompting there would be noise.
+		const card = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+		await card.click();
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		await card.click();
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator(PROMPT)).toHaveCount(0);
+		await expect(page.locator('.file-card')).toHaveCount(1);
+	});
+});

--- a/src/data/datareader.bf
+++ b/src/data/datareader.bf
@@ -9,6 +9,17 @@ function notify(type, msg) {
 	return 0;
 }
 
+/* Make a user-supplied sequence name safe to drop into the JSON record.
+   to_json below concatenates strings with no escaping, and PRE-rename names are arbitrary user
+   text: a single double quote in a header would produce invalid JSON and the whole upload would
+   fail with "File analysis produced invalid results". Post-rename names cannot hit this because
+   normalizeSequenceID (ReadDelimitedFiles.bf:218) maps everything outside [a-zA-Z0-9_] to '_'. */
+function jsonSafeName (rawName) {
+	_safeName = rawName ^ {{"[\"\\\\]",""}};
+	_safeName = _safeName ^ {{"[\n\t]"," "}};
+	return _safeName;
+}
+
 function except(msg) {
 	fprintf (jsonOutput,CLEAR_FILE);
 	fprintf (jsonOutput, "{" );
@@ -356,9 +367,21 @@ if (genCodeID >= 0 && filteredData.sites*3 < ds.sites)
 	}
 }
 
+/* filteredData is the CODON filter here when genCodeID >= 0 (created above with unit 3), so
+   filteredData.sites counts codons, not nucleotides. Naming the unit stops the message from
+   claiming a 12,000-nucleotide ceiling that is really 12,000 codons. */
+sizeUnit = "sites";
+if (genCodeID >= 0)
+{
+	sizeUnit = "codons";
+}
+
 if (filteredData.species > maxUploadSize || filteredData.sites > maxDMSites)
 {
-  except("Your data set is too large ("+filteredData.species+" species and "+filteredData.sites+" sites). We currently reject files with more than " + maxSLACSize + " sequences or " + maxDMSites + " sites. " +  
+  /* The rejection gate is maxUploadSize; quoting maxSLACSize here told a user rejected at
+     25,001 sequences that the limit was 10,000. maxSLACSize is the tree-inference ceiling and
+     is reported separately at the "must include prebuilt trees" branch below. */
+  except("Your data set is too large ("+filteredData.species+" sequences and "+filteredData.sites+" "+sizeUnit+"). We currently reject files with more than " + maxUploadSize + " sequences or " + maxDMSites + " " + sizeUnit + ". " +
                   "We'll increase the numbers when we acquire better dedicated hardware. Alternatively, you can download hyphy at: http://www.hyphy.org/downloads/ and perform selection analyses locally.");
 	return 1;
 }
@@ -380,6 +403,18 @@ renames		     = 0;
 padWarning       = 0;
 removedSequences = {};
 
+/* Plain, JSON-safe lists of WHICH sequences were changed, for the UI.
+   Deliberately separate from DuplicateSequenceWarning / renameSequenceWarning above: those are
+   '*'-appended blobs carrying HTML (<DT class='DT1'>, &rarr;) built for the legacy web UI.
+   Capped because results.json is cached in IndexedDB and replayed on every file selection - a
+   5,000-sequence rename must not be carried around forever. */
+nameListCap             = 50;
+duplicateNames          = {};
+duplicateNamesTruncated = 0;
+renamedNames            = {};
+renamedNamesTruncated   = 0;
+paddedSequences         = 0;
+
 for (k=0; k<filteredData.species;k=k+1)
 {
 	newSeqName = normalizeSequenceID (sequenceNames[k],"seqNamesList");
@@ -387,8 +422,16 @@ for (k=0; k<filteredData.species;k=k+1)
 	{
 		renameSequenceWarning * ("<DT class = 'DT1'>" + sequenceNames[k] + "&rarr;" + newSeqName);
 		renames	= renames+1;
+		if (Abs(renamedNames) < nameListCap)
+		{
+			renamedNames[Abs(renamedNames)] = jsonSafeName(sequenceNames[k]) + " -> " + newSeqName;
+		}
+		else
+		{
+			renamedNamesTruncated = renamedNamesTruncated + 1;
+		}
 		SetParameter (ds,k,newSeqName);
-	}	
+	}
 	seqNamesMap[sequenceNames[k]&&1] = newSeqName;
 	GetDataInfo (thisSeqData, filteredData, k);
 	
@@ -399,6 +442,14 @@ for (k=0; k<filteredData.species;k=k+1)
 		seqMap[k] = z-1;
 		dupSeqCount = dupSeqCount + 1;
 		DuplicateSequenceWarning * ("<DT class = 'DT2'>" + sequenceNames[k] + " = " + sequenceNames[z-1]);
+		if (Abs(duplicateNames) < nameListCap)
+		{
+			duplicateNames[Abs(duplicateNames)] = jsonSafeName(sequenceNames[k]) + " = " + jsonSafeName(sequenceNames[z-1]);
+		}
+		else
+		{
+			duplicateNamesTruncated = duplicateNamesTruncated + 1;
+		}
 		removedSequences[sequenceNames[k]&&1] = 1;
 	}
 	else
@@ -408,6 +459,7 @@ for (k=0; k<filteredData.species;k=k+1)
 		if ((thisSeqData$"\\?+$")[0]>=0)
 		{
 			padWarning = 1;
+			paddedSequences = paddedSequences + 1;
 		}
 	}
 }
@@ -590,6 +642,9 @@ file_info_record = {};
 file_info_record ["partitions"] = _pCount;
 file_info_record ["gencodeid"] = genCodeID;
 file_info_record ["sites"] = filteredData.sites;
+/* dType has been computed since the data type check above; it was simply never emitted, which
+   left the Data tab's already-guarded "Data Type" row permanently dark. */
+file_info_record ["type"] = dType;
 
 DataSetFilter filteredData = CreateFilter (ds,1);
 
@@ -616,11 +671,31 @@ file_info_record["goodtree"] = goodTree;
 file_info_record["nj"] = treeString;
 file_info_record["rawsites"] = filteredData.sites;
 
-// Validation details - expose what datareader detected for UI display
+// Validation details - expose what datareader detected for UI display.
+//
+// Every key below is load-bearing for records ALREADY cached in IndexedDB, which descriptorSync
+// replays without a migration step - so nothing here may be renamed or dropped, only added to.
+// `ambiguous_sites` is misnamed: it has always been the boolean padWarning, never a count of
+// ambiguous characters. `padded_sequences` is the honest version; the old key stays for cached
+// records.
 file_info_record["duplicate_sequences"] = dupSeqCount;
 file_info_record["sequences_renamed"] = renames;
 file_info_record["ambiguous_sites"] = padWarning;
+file_info_record["padded_sequences"] = paddedSequences;
 file_info_record["stop_codons_stripped"] = terminalCodonsStripped;
+
+// WHICH sequences, not just how many. Emitted only when non-empty so results.json does not grow
+// two empty objects for every clean upload.
+if (Abs(duplicateNames))
+{
+	file_info_record["duplicate_names"] = duplicateNames;
+	file_info_record["duplicate_names_truncated"] = duplicateNamesTruncated;
+}
+if (Abs(renamedNames))
+{
+	file_info_record["renamed_names"] = renamedNames;
+	file_info_record["renamed_names_truncated"] = renamedNamesTruncated;
+}
 
 sequence_records = {};
 GetString(seqNames, filteredData, -1);

--- a/src/lib/AlignmentViewer.svelte
+++ b/src/lib/AlignmentViewer.svelte
@@ -1,14 +1,15 @@
 <script>
 	import { AliVibe } from 'alivibe';
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, createEventDispatcher } from 'svelte';
 	import { treeStore } from '../stores/tree';
-	import { alignmentFileStore } from '../stores/fileInfo';
-	import { persistentFileStore } from '../stores/fileInfo';
 	import { Save } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
+	import { buildEditedAlignmentFile } from './utils/alignmentEdits.js';
 
 	export let alignmentFile = null;
 	export let fileMetricsJSON = null;
+
+	const dispatch = createEventDispatcher();
 
 	let alivibe;
 	let mounted = false;
@@ -60,27 +61,18 @@
 
 		try {
 			const alignment = alivibe.getAlignment();
-			if (!alignment || !alignment.length) {
-				throw new Error('No alignment data to save');
-			}
-
-			// Build FASTA content
-			const fastaContent = alignment
-				.map(entry => `>${entry.name}\n${entry.seq}`)
-				.join('\n') + '\n';
-
-			// Create a new File object with the same name
 			const filename = alignmentFile.name || 'alignment.fasta';
-			const newFile = new File([fastaContent], filename, { type: 'text/plain' });
+			const newFile = buildEditedAlignmentFile(alignment, filename);
 
-			// Update the persistent store (handles overwriting by name)
-			await persistentFileStore.uploadFile(newFile);
-
-			// Update the in-memory alignment file store
-			alignmentFileStore.set(newFile);
-
-			saveMessage = 'saved';
-			setTimeout(() => { saveMessage = null; }, 2000);
+			// Hand the edited alignment to the parent instead of writing the stores here.
+			//
+			// Writing them here was the bug: it updated the bytes on disk and the viewer's own store
+			// while leaving fileMetricsStore — including canonicalFasta, the string every runner
+			// actually submits — describing the alignment before the edit. The parent re-runs the
+			// whole upload path, which regenerates all of it. There is no success message to set:
+			// that path clears alignmentFileStore, so this component is unmounted and remounted with
+			// the re-read alignment.
+			dispatch('editsSaved', { file: newFile, previous: alignmentFile });
 		} catch (err) {
 			console.error('Error saving alignment:', err);
 			saveMessage = 'error';
@@ -168,10 +160,11 @@
 			title="Save alignment edits back to file"
 		>
 			<Save size={14} />
+			<!-- No "Saved" state: a successful save unmounts this viewer while the edited alignment is
+			     re-read, and the old confirmation was the whole problem — it reported success for a
+			     save the analyses never saw. -->
 			{#if isSaving}
 				Saving...
-			{:else if saveMessage === 'saved'}
-				Saved
 			{:else if saveMessage === 'error'}
 				Save failed
 			{:else}

--- a/src/lib/AnalysisCard.svelte
+++ b/src/lib/AnalysisCard.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { persistentFileStore } from '../stores/fileInfo';
+	import { isStaleRun } from './utils/fileIdentity.js';
 	import {
 		File,
 		Clock,
@@ -31,6 +32,10 @@
 	$: if (analysis && analysis.fileId && $persistentFileStore.files) {
 		file = $persistentFileStore.files.find((f) => f.id === analysis.fileId);
 	}
+
+	// A same-name re-upload replaces a file's contents in place and keeps its id, so every earlier
+	// run stays filed under a name that now means different bytes. Nothing distinguished them.
+	$: staleRun = isStaleRun(analysis, file);
 
 	// Format date for display
 	function formatDate(timestamp) {
@@ -278,6 +283,13 @@
 					<File class="mr-1 h-3 w-3" />
 					<span class="truncate">{file ? file.filename : 'Unknown file'}</span>
 				</div>
+
+				{#if staleRun}
+					<div class="mt-0.5 flex items-center text-amber-700" data-testid="stale-run-badge">
+						<AlertCircle class="mr-1 h-3 w-3 flex-shrink-0" />
+						<span>Run on an earlier version of this file</span>
+					</div>
+				{/if}
 
 				<div class="mt-0.5 flex items-center">
 					<Clock class="mr-1 h-3 w-3" />

--- a/src/lib/DataTab.svelte
+++ b/src/lib/DataTab.svelte
@@ -10,7 +10,12 @@
 	import TabNavigation from './TabNavigation.svelte';
 	import FastaExport from './FastaExport.svelte';
 	import AlignmentViewer from './AlignmentViewer.svelte';
+	import { uploadLimitsCopy } from './config/uploadLimits.js';
 	import { ArrowRight, AlertTriangle, TreeDeciduous, Info } from 'lucide-svelte';
+
+	// Rendered from the constants rather than typed inline: the previous copy claimed 5,000
+	// sequences / >500-needs-a-tree, and both numbers were invented.
+	const limitsCopy = uploadLimitsCopy();
 
 	// Props
 	export let handleFileUpload = () => {};
@@ -19,6 +24,9 @@
 	export let fileMetricsJSON = null;
 	export let handleValidated = () => {};
 	export let handleUseRepaired = () => {};
+	export let handleAlignmentEdited = () => {};
+	// Actions attached to the validation-error card (e.g. restoring the pre-edit alignment).
+	export let validationErrorActions = [];
 
 	// Tab navigation
 	export let activeTab = 'data';
@@ -67,9 +75,8 @@
 		<div class="mt-premium-md flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm text-blue-700">
 			<Info class="mt-0.5 h-4 w-4 flex-shrink-0" />
 			<div>
-				<span class="font-medium">File limits:</span>
-				Max 5,000 sequences, 12,000 alignment sites.
-				Files with &gt;500 sequences require an embedded tree.
+				<span class="font-medium">Upload limits:</span>
+				{limitsCopy}
 			</div>
 		</div>
 
@@ -77,6 +84,8 @@
 		<ErrorHandler
 			error={validationError}
 			level={errorLevel}
+			suggestions={validationErrorActions}
+			on:suggestion={(e) => e.detail?.run?.()}
 			on:dismiss={() => (validationError = null)}
 		/>
 	</div>
@@ -111,7 +120,11 @@
 					Alignment Viewer
 				</h2>
 				<div class="rounded-premium border border-border-platinum bg-white shadow-premium overflow-hidden">
-					<AlignmentViewer alignmentFile={$alignmentFileStore} {fileMetricsJSON} />
+					<AlignmentViewer
+						alignmentFile={$alignmentFileStore}
+						{fileMetricsJSON}
+						on:editsSaved={handleAlignmentEdited}
+					/>
 				</div>
 			</div>
 		{/if}

--- a/src/lib/FileCard.svelte
+++ b/src/lib/FileCard.svelte
@@ -296,6 +296,13 @@
 						<div class="text-text-slate">Upload Date:</div>
 						<div class="font-medium text-text-rich">{formatDate(file.createdAt)}</div>
 
+						<!-- Written only when an upload replaced this record's contents in place, which is
+						     the one case where "Upload Date" no longer describes the bytes. -->
+						{#if file.updatedAt && file.updatedAt !== file.createdAt}
+							<div class="text-text-slate">Last modified:</div>
+							<div class="font-medium text-text-rich">{formatDate(file.updatedAt)}</div>
+						{/if}
+
 						<div class="text-text-slate">ID:</div>
 						<div class="font-mono text-[10px] text-text-silver opacity-70">{file.id}</div>
 					</div>

--- a/src/lib/FileConflictPrompt.svelte
+++ b/src/lib/FileConflictPrompt.svelte
@@ -1,0 +1,74 @@
+<!--
+	Shown when an UPLOAD would land on a filename that already has a record.
+
+	Not window.confirm, for two reasons: a store should not open a browser dialog, and a native
+	dialog cannot be driven from Playwright the way a real element can.
+
+	Deliberately two choices, no cancel. By the time this is on screen +page.svelte has already
+	cleared fileMetricsJSON / fileMetricsStore / alignmentFileStore for the incoming file, so a
+	cancel would leave the user looking at the empty state with nothing selected — a third button
+	that produces a worse outcome than either real answer.
+-->
+<script>
+	import { createEventDispatcher } from 'svelte';
+	import { AlertTriangle } from 'lucide-svelte';
+
+	/** @type {{ filename: string, keepBothName: string, analysisCount: number }|null} */
+	export let conflict = null;
+
+	const dispatch = createEventDispatcher();
+
+	function choose(choice) {
+		dispatch('choose', choice);
+	}
+</script>
+
+{#if conflict}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="file-conflict-title"
+		data-testid="file-conflict-prompt"
+	>
+		<div
+			class="w-full max-w-md rounded-premium border border-border-platinum bg-white p-6 shadow-premium"
+		>
+			<div class="flex items-start gap-3">
+				<div
+					class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-amber-100"
+				>
+					<AlertTriangle class="h-5 w-5 text-amber-600" />
+				</div>
+				<div class="min-w-0">
+					<h2 id="file-conflict-title" class="text-premium-body font-semibold text-text-rich">
+						You already have a file called {conflict.filename}
+					</h2>
+					<p class="mt-1 text-sm text-text-slate">
+						Replacing it keeps its history, so
+						{conflict.analysisCount === 1
+							? 'the 1 analysis already filed under this name'
+							: `the ${conflict.analysisCount} analyses already filed under this name`}
+						will be listed against the new contents. Keeping both starts a separate file with its own
+						history.
+					</p>
+				</div>
+			</div>
+
+			<div class="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+				<button
+					class="rounded-lg border border-border-platinum px-4 py-2 text-sm font-medium text-text-slate hover:bg-brand-whisper"
+					on:click={() => choose('replace')}
+				>
+					Replace it
+				</button>
+				<button
+					class="rounded-lg bg-brand-gradient px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-deep"
+					on:click={() => choose('keep-both')}
+				>
+					Keep both — save as {conflict.keepBothName}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -8,11 +8,13 @@
 	import RunOutlook from './RunOutlook.svelte';
 	import RunStrip from './RunStrip.svelte';
 	import { analysisStore } from '../stores/analyses';
-	import { currentFile } from '../stores/fileInfo';
+	import { currentFile, revalidatingFileId } from '../stores/fileInfo';
 	import { treeHasBranchLengths } from './services/prescreen/scope.js';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	// Shared with the Data tab, which needs to turn datareader's gencodeid back into a name.
+	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -177,31 +179,20 @@
 	);
 	$: localRunInFlight = liveRuns.some((a) => a.metadata?.executionMode !== 'backend');
 	$: wouldRunLocally = executionMode !== 'backend';
-	$: runBlockedReason = sameMethodRunning
-		? `${selectedMethod?.toUpperCase()} is already running on this file`
-		: localRunInFlight && wouldRunLocally
-			? 'Another analysis is running in this tab — only one can run here at a time'
-			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
+	//   - The current file is being re-read after an alignment edit -> block. This one is not in
+	//     liveRuns: MethodSelector filters datareader out of it (a file's own validation must never
+	//     look like a running analysis), so the re-read is invisible here without its own flag. For
+	//     the seconds it takes, fileMetricsStore is null and canonicalFasta does not exist, so a Run
+	//     started now would submit the user's original blob — the alignment they just edited away.
+	$: revalidatingThisFile =
+		Boolean($revalidatingFileId) && $revalidatingFileId === $currentFile?.id;
+	$: runBlockedReason = revalidatingThisFile
+		? 'Re-checking your edited alignment…'
+		: sameMethodRunning
+			? `${selectedMethod?.toUpperCase()} is already running on this file`
+			: localRunInFlight && wouldRunLocally
+				? 'Another analysis is running in this tab — only one can run here at a time'
+				: null;
 
 	// Method-specific advanced options configurations
 	const METHOD_ADVANCED_OPTIONS = {
@@ -1696,7 +1687,11 @@
 					Starting Analysis...
 				{:else if runBlockedReason}
 					<Loader2 class="run-icon spinning" />
-					{sameMethodRunning ? `${currentMethod?.info.name ?? ''} running` : 'Analysis running'}
+					{revalidatingThisFile
+						? 'Re-checking alignment…'
+						: sameMethodRunning
+							? `${currentMethod?.info.name ?? ''} running`
+							: 'Analysis running'}
 				{:else if currentMethod?.info.supported}
 					<Play class="run-icon" />
 					Run {currentMethod?.info.name || ''} Analysis

--- a/src/lib/SequenceWarnings.svelte
+++ b/src/lib/SequenceWarnings.svelte
@@ -1,6 +1,7 @@
 <!-- src/lib/SequenceWarnings.svelte -->
 <script>
 	import { AlertCircle, AlertTriangle, Info } from 'lucide-svelte';
+	import { buildWarnings } from './utils/datareaderWarnings.js';
 
 	export let fileMetricsJSON = null;
 
@@ -8,89 +9,13 @@
 	let warnings = [];
 	let showAllWarnings = false;
 
-	// Watch for changes in fileMetricsJSON
-	$: if (fileMetricsJSON) {
-		generateWarnings(fileMetricsJSON);
-	}
+	// The generator lives in datareaderWarnings.js: the copy is the whole point of these warnings,
+	// and inside a component there was no seam a test could reach it through.
+	$: warnings = buildWarnings(fileMetricsJSON?.FILE_INFO);
 
-	// Generate warnings based on file metrics
-	function generateWarnings(data) {
-		warnings = [];
-
-		if (!data || !data.FILE_INFO) return;
-
-		// Check for duplicate sequences
-		if (data.FILE_INFO.duplicate_sequences && data.FILE_INFO.duplicate_sequences > 0) {
-			warnings.push({
-				type: 'warning',
-				title: 'Duplicate Sequences Detected',
-				message: `Found ${data.FILE_INFO.duplicate_sequences} duplicate sequence${data.FILE_INFO.duplicate_sequences === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Duplicate sequences can affect the accuracy of selection analysis. Consider removing duplicates for more reliable results.',
-				action: null
-			});
-		}
-
-		// Check for short alignment
-		if (data.FILE_INFO.sites && data.FILE_INFO.sites < 30) {
-			warnings.push({
-				type: 'info',
-				title: 'Short Alignment',
-				message: `Your alignment has only ${data.FILE_INFO.sites} sites, which is relatively short.`,
-				details:
-					'Short alignments may have limited statistical power for detecting selection. Consider adding more sequences or sites if possible.',
-				action: null
-			});
-		}
-
-		// Check for small number of sequences
-		if (data.FILE_INFO.sequences && data.FILE_INFO.sequences < 8) {
-			warnings.push({
-				type: 'info',
-				title: 'Small Sample Size',
-				message: `Your alignment has only ${data.FILE_INFO.sequences} sequences, which is a small sample.`,
-				details:
-					'Selection analyses generally perform better with larger samples. Consider adding more sequences if possible.',
-				action: null
-			});
-		}
-
-		// Check for ambiguous characters
-		if (data.FILE_INFO.ambiguous_sites && data.FILE_INFO.ambiguous_sites > 0) {
-			warnings.push({
-				type: 'warning',
-				title: 'Ambiguous Characters',
-				message: `Found ${data.FILE_INFO.ambiguous_sites} ambiguous character${data.FILE_INFO.ambiguous_sites === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Ambiguous characters (like N, X, etc.) may cause issues with some analyses. Consider resolving these ambiguities if possible.',
-				action: null
-			});
-		}
-
-		// Check for stop codons
-		if (data.FILE_INFO.stop_codons && data.FILE_INFO.stop_codons > 0) {
-			warnings.push({
-				type: 'error',
-				title: 'Stop Codons Detected',
-				message: `Found ${data.FILE_INFO.stop_codons} stop codon${data.FILE_INFO.stop_codons === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Stop codons within the alignment may indicate frame shifts, sequencing errors, or pseudogenes. Verify your alignment and genetic code selection.',
-				action: null
-			});
-		}
-
-		// Check for frameshift issues (uneven codon count)
-		if (data.FILE_INFO.rawsites && data.FILE_INFO.rawsites % 3 !== 0) {
-			warnings.push({
-				type: 'error',
-				title: 'Alignment Length Not Divisible by 3',
-				message: `Your alignment length (${data.FILE_INFO.rawsites}) is not divisible by 3.`,
-				details:
-					'Codon-based analyses require sequence lengths to be multiples of 3. Check for frameshifts or alignment errors.',
-				action: null
-			});
-		}
-	}
+	// How many names to show inline before collapsing the rest into a count. Long enough to be
+	// useful on a hand-curated alignment, short enough not to bury the message.
+	const MAX_LISTED_NAMES = 10;
 
 	// Get the color class based on warning type
 	function getWarningColorClass(type) {
@@ -153,6 +78,21 @@
 						<h4 class="text-sm font-semibold">{warning.title}</h4>
 						<p class="text-sm">{warning.message}</p>
 
+						{#if warning.items && warning.items.length > 0}
+							<ul class="mt-1.5 space-y-0.5 font-mono text-xs opacity-90">
+								{#each warning.items.slice(0, MAX_LISTED_NAMES) as item}
+									<li class="break-all">{item}</li>
+								{/each}
+							</ul>
+							{#if warning.items.length > MAX_LISTED_NAMES || warning.truncated}
+								<p class="mt-1 text-xs opacity-70">
+									+{warning.items.length -
+										Math.min(warning.items.length, MAX_LISTED_NAMES) +
+										(warning.truncated || 0)} more not listed
+								</p>
+							{/if}
+						{/if}
+
 						{#if warning.details}
 							<p class="mt-1 text-xs opacity-80">{warning.details}</p>
 						{/if}
@@ -180,7 +120,7 @@
 	</div>
 
 	<p class="mt-2 text-xs text-text-silver">
-		These warnings are meant to help you improve your analysis results. Minor issues may not
-		significantly affect results.
+		These notes describe what your file contained and what the reader did with it before analysis.
+		They are not errors, and none of them changed the file you uploaded.
 	</p>
 {/if}

--- a/src/lib/config/geneticCodes.js
+++ b/src/lib/config/geneticCodes.js
@@ -1,0 +1,27 @@
+/**
+ * HyPhy's genetic code table, keyed by the numeric ID HyPhy uses on the command line and in
+ * datareader's FILE_INFO.gencodeid.
+ *
+ * This lived inside MethodSelector.svelte, which meant the Data tab had no way to turn a
+ * gencodeid back into a name and printed the bare integer instead. One home, two consumers.
+ * The `name` values are the option labels in the Analyze tab's dropdown and are mapped back to
+ * `id` there — do not reword them without checking that mapping.
+ */
+export const GENETIC_CODES = [
+	{ id: 0, name: 'Universal', label: 'Universal code' },
+	{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
+	{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
+	{
+		id: 3,
+		name: 'Mold mitochondrial',
+		label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
+	},
+	{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
+	{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
+	{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
+	{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
+	{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
+	{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
+	{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
+	{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
+];

--- a/src/lib/config/uploadLimits.js
+++ b/src/lib/config/uploadLimits.js
@@ -1,0 +1,34 @@
+/**
+ * The limits the upload path actually enforces.
+ *
+ * SOURCE OF TRUTH: src/data/shared/HyPhyGlobals.ibf
+ *   :10  maxDMSites     = 12000   -> rejects when the CODON filter has more sites than this
+ *   :15  maxSLACSize    = 10000   -> above this, datareader.bf:489 refuses to build an NJ tree,
+ *                                    so the file must carry its own
+ *   :33  maxUploadSize  = 25000   -> datareader.bf:359 rejects more sequences than this
+ *
+ * The copy these produce is deliberately about UPLOAD, not about analysis. Individual methods are
+ * lower (HyPhyGlobals.ibf:17 maxMEMESize = 10000, :27 maxGARDSize = 500), so advertising 25,000 as
+ * "the limit" full stop would swap one wrong number for another. The method-specific ceilings
+ * belong next to the method, not next to the file input.
+ */
+export const uploadLimits = {
+	maxSequences: 25000,
+	maxCodons: 12000,
+	treeRequiredAbove: 10000
+};
+
+const groupDigits = (n) => Number(n).toLocaleString('en-US');
+
+/**
+ * The single sentence shown under the file input. Built from the constants above so a limit change
+ * in HyPhyGlobals.ibf has exactly one place to land on this side.
+ * @returns {string}
+ */
+export function uploadLimitsCopy(limits = uploadLimits) {
+	return (
+		`Up to ${groupDigits(limits.maxSequences)} sequences and ${groupDigits(limits.maxCodons)} codons ` +
+		`(about ${groupDigits(limits.maxCodons * 3)} nucleotides). ` +
+		`Above ${groupDigits(limits.treeRequiredAbove)} sequences, your file must include a tree.`
+	);
+}

--- a/src/lib/dataReaderResults.svelte
+++ b/src/lib/dataReaderResults.svelte
@@ -1,5 +1,6 @@
 <script>
 	import PhyloTree from './phylotree.svelte';
+	import { formatAlignmentLength, formatGeneticCode } from './utils/fileMetricsDisplay.js';
 	import { AlertTriangle, Check, Info, ChevronRight, Copy } from 'lucide-svelte';
 
 	export let fileMetricsJSON = null;
@@ -103,14 +104,16 @@
 					<span class="font-medium text-text-rich">{fileMetricsJSON.FILE_INFO.partitions}</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-text-slate">Sites</span>
+					<span class="text-text-slate">Length</span>
 					<span class="font-medium text-text-rich">
-						{fileMetricsJSON.FILE_INFO.rawsites} raw → {fileMetricsJSON.FILE_INFO.sites} processed
+						{formatAlignmentLength(fileMetricsJSON.FILE_INFO)}
 					</span>
 				</div>
 				<div class="flex justify-between">
 					<span class="text-text-slate">Genetic Code</span>
-					<span class="font-medium text-text-rich">{fileMetricsJSON.FILE_INFO.gencodeid}</span>
+					<span class="font-medium text-text-rich"
+						>{formatGeneticCode(fileMetricsJSON.FILE_INFO.gencodeid)}</span
+					>
 				</div>
 				{#if fileMetricsJSON.FILE_INFO.type}
 					<div class="flex justify-between">
@@ -134,16 +137,22 @@
 						<span class="font-medium text-status-warning">{fileMetricsJSON.FILE_INFO.sequences_renamed}</span>
 					</div>
 				{/if}
-				{#if fileMetricsJSON.FILE_INFO.ambiguous_sites}
+				<!-- `padded_sequences` is a real count; `ambiguous_sites` is the legacy boolean that
+				     carried the same signal (datareader.bf padWarning) and is all a cached record has. -->
+				{#if fileMetricsJSON.FILE_INFO.padded_sequences || fileMetricsJSON.FILE_INFO.ambiguous_sites}
 					<div class="flex justify-between">
-						<span class="text-text-slate">Ambiguous Sites</span>
-						<span class="font-medium text-status-warning">Present</span>
+						<span class="text-text-slate">Sequences Padded</span>
+						<span class="font-medium text-status-warning">
+							{fileMetricsJSON.FILE_INFO.padded_sequences ?? 'Present'}
+						</span>
 					</div>
 				{/if}
-				{#if fileMetricsJSON.FILE_INFO.stop_codons_stripped > 0}
+				{#if fileMetricsJSON.FILE_INFO.stop_codons_stripped}
+					<!-- Boolean, not a count: datareader sets it to 1 when EVERY sequence ended in a
+					     stop codon and that whole final column was dropped. -->
 					<div class="flex justify-between">
-						<span class="text-text-slate">Stop Codons Stripped</span>
-						<span class="font-medium text-status-warning">{fileMetricsJSON.FILE_INFO.stop_codons_stripped}</span>
+						<span class="text-text-slate">Trailing Stop Codons Stripped</span>
+						<span class="font-medium text-status-warning">Yes</span>
 					</div>
 				{/if}
 			</div>

--- a/src/lib/utils/alignmentEdits.js
+++ b/src/lib/utils/alignmentEdits.js
@@ -1,0 +1,57 @@
+/**
+ * The seam between "Save edits" in the alignment viewer and the rest of the app.
+ *
+ * WHY THIS EXISTS. saveEdits() used to write the edited FASTA to IndexedDB and to
+ * alignmentFileStore, and stop. Nothing re-ran datareader, so `fileMetricsStore.canonicalFasta` —
+ * the exact bytes AnalyzeTab hands to every runner, local and remote — still held the PRE-edit
+ * alignment. The button said "Saved", the viewer showed the edit, and every subsequent analysis ran
+ * on the alignment the user had just changed. Deleting a contaminated sequence and hitting Run
+ * produced a result computed WITH that sequence.
+ *
+ * The fix is not to patch canonicalFasta: the metrics, the trees, the site count and the warnings
+ * are all derived from the file too. The edited alignment has to go back through the same upload
+ * path as any other file.
+ */
+import { fileMetricsStore } from '../../stores/fileInfo.js';
+
+/**
+ * Build the File that "Save edits" produces from AliVibe's rows.
+ * @param {Array<{name: string, seq: string}>} rows
+ * @param {string} filename - kept identical to the original so the store replaces in place and the
+ *   analysis history stays attached to the same file id.
+ * @returns {File}
+ */
+export function buildEditedAlignmentFile(rows, filename = 'alignment.fasta') {
+	if (!rows || !rows.length) {
+		throw new Error('No alignment data to save');
+	}
+	const fasta = rows.map((entry) => `>${entry.name}\n${entry.seq}`).join('\n') + '\n';
+	return new File([fasta], filename, { type: 'text/plain' });
+}
+
+/**
+ * Route an edited alignment back through validation.
+ *
+ * @param {File} newFile
+ * @param {{revalidate: (file: File) => Promise<any>|any, setRevalidating?: (id: string|null) => void, fileId?: string|null}} deps
+ *   `revalidate` is +page.svelte's handleFileUpload entry point; `setRevalidating` flips the flag
+ *   the Run button reads.
+ */
+export async function applyAlignmentEdits(newFile, { revalidate, setRevalidating, fileId } = {}) {
+	if (typeof revalidate !== 'function') {
+		throw new Error('applyAlignmentEdits requires a revalidate function');
+	}
+
+	// Drop the descriptor BEFORE awaiting anything. Between the click and the end of the re-read
+	// there is a window of several seconds on a large alignment, and for all of it the old
+	// canonicalFasta would otherwise still be the string a Run would submit. Gone is correct;
+	// stale is not.
+	fileMetricsStore.set(null);
+	setRevalidating?.(fileId ?? null);
+
+	try {
+		return await revalidate(newFile);
+	} finally {
+		setRevalidating?.(null);
+	}
+}

--- a/src/lib/utils/datareaderWarnings.js
+++ b/src/lib/utils/datareaderWarnings.js
@@ -1,0 +1,137 @@
+/**
+ * Turn datareader's FILE_INFO record into the warnings shown on the Data tab.
+ *
+ * TWO RULES GOVERN THE COPY HERE, and both are easy to undo by accident:
+ *
+ * 1. DESCRIBE, DO NOT RECOMMEND, AND NEVER OFFER TO MODIFY. Several of these conditions have more
+ *    than one cause - a padded sequence can mean an unaligned file, a non-standard gap character,
+ *    or a genuinely ragged region - and choosing between them is a question about the data, not
+ *    something the software should answer. There is a test asserting no warning text says
+ *    remove/fix/trim/repair. That assertion is the rule, not a lint.
+ *
+ * 2. THE KEYS ARE HISTORY. `ambiguous_sites` has never been a count of ambiguous characters: it is
+ *    datareader's boolean padWarning, set when a sequence had to be padded with '?'. It was
+ *    rendered as "Found 1 ambiguous character in your alignment", which is three kinds of wrong -
+ *    wrong count, wrong cause, wrong advice. `padded_sequences` is the honest replacement, and the
+ *    old key is still read because records cached in IndexedDB are replayed as-is
+ *    (descriptorSync.js) with no migration step.
+ *
+ * `stop_codons` is deliberately NOT read. datareader has never emitted it - the key it writes is
+ * `stop_codons_stripped`, which is a different thing (a boolean: every sequence ended in a stop and
+ * that final column was dropped). The old branch keyed on `stop_codons` could not fire, and
+ * reviving it would make an unfireable branch fire on a key that means something else.
+ */
+
+/** HyPhy serialises its lists as numerically-keyed objects, not JSON arrays. Accept both. */
+function toList(value) {
+	if (!value) return [];
+	if (Array.isArray(value)) return value.filter((v) => typeof v === 'string');
+	if (typeof value === 'object') {
+		return Object.keys(value)
+			.sort((a, b) => Number(a) - Number(b))
+			.map((k) => value[k])
+			.filter((v) => typeof v === 'string');
+	}
+	return [];
+}
+
+function count(value) {
+	const n = Number(value);
+	return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/**
+ * @param {Record<string, any>} FILE_INFO - datareader's FILE_INFO block
+ * @returns {Array<{type: string, title: string, message: string, details?: string, items?: string[], truncated?: number}>}
+ */
+export function buildWarnings(FILE_INFO) {
+	const info = FILE_INFO || {};
+	const warnings = [];
+
+	// Ordered so that "we changed your data" comes before "your data is small": SequenceWarnings
+	// shows only the first two until the user expands, and the changes are the ones nobody could
+	// find before (they went to datareader.log, which nothing reads).
+
+	const duplicateNames = toList(info.duplicate_names);
+	const duplicates = count(info.duplicate_sequences) || duplicateNames.length;
+	if (duplicates > 0) {
+		warnings.push({
+			type: 'warning',
+			title: 'Identical sequences collapsed',
+			message: `${plural(duplicates, 'sequence')} in your file were identical to another sequence, and each set was collapsed to a single copy before analysis.`,
+			details:
+				'Analyses ran on the collapsed alignment, so identical sequences are represented once. This is how the site has always handled exact duplicates; it is recorded here so the sequence count you see matches what you uploaded.',
+			items: duplicateNames,
+			truncated: count(info.duplicate_names_truncated)
+		});
+	}
+
+	const renamedNames = toList(info.renamed_names);
+	const renamed = count(info.sequences_renamed) || renamedNames.length;
+	if (renamed > 0) {
+		warnings.push({
+			type: 'warning',
+			title: 'Sequences renamed',
+			message: `${plural(renamed, 'sequence')} were renamed, because HyPhy sequence names may only contain letters, digits and underscores.`,
+			details:
+				'Every other character was replaced with an underscore. Results and trees use the new names, so a name you search for may not be the one in your original file.',
+			items: renamedNames,
+			truncated: count(info.renamed_names_truncated)
+		});
+	}
+
+	// `padded_sequences` is the count; `ambiguous_sites` is the legacy boolean carrying the same
+	// signal, and is all a cached record has.
+	const padded = count(info.padded_sequences);
+	if (padded > 0 || info.ambiguous_sites) {
+		const subject = padded > 0 ? plural(padded, 'sequence') : 'Some sequences';
+		warnings.push({
+			type: 'warning',
+			title: 'Sequences padded to equal length',
+			message: `${subject} ${padded === 1 ? 'was' : 'were'} shorter than the alignment and ${padded === 1 ? 'was' : 'were'} padded with '?' characters at the end.`,
+			details:
+				"This usually means the file is not aligned, or that a non-standard gap character was used: only '-' and '?' are recognised as gaps. '~' (BioEdit) and '_' are not, and are read as missing data.",
+			items: []
+		});
+	}
+
+	if (info.stop_codons_stripped) {
+		warnings.push({
+			type: 'warning',
+			title: 'Trailing stop codons stripped',
+			message:
+				'Every sequence ended in a stop codon, and that final codon column was excluded from the alignment.',
+			details:
+				'This happens only when the stop is terminal in every sequence and appears nowhere else. Codon models have no state for a stop codon, so the column cannot be scored.',
+			items: []
+		});
+	}
+
+	const sites = count(info.sites);
+	if (sites > 0 && sites < 30) {
+		warnings.push({
+			type: 'info',
+			title: 'Short alignment',
+			message: `Your alignment has ${plural(sites, 'site')}, which is short.`,
+			details:
+				'Short alignments carry limited statistical power for detecting selection, so a null result says less than it would on a longer alignment.',
+			items: []
+		});
+	}
+
+	const sequences = count(info.sequences);
+	if (sequences > 0 && sequences < 8) {
+		warnings.push({
+			type: 'info',
+			title: 'Small sample size',
+			message: `Your alignment has ${plural(sequences, 'sequence')}, which is a small sample.`,
+			details:
+				'Selection analyses generally have more power with larger samples; with this few sequences, only strong signals are detectable.',
+			items: []
+		});
+	}
+
+	return warnings;
+}

--- a/src/lib/utils/fileIdentity.js
+++ b/src/lib/utils/fileIdentity.js
@@ -1,0 +1,81 @@
+/**
+ * File identity helpers.
+ *
+ * A file is identified by its NAME in this app: persistentFileStore.uploadFile looks for an
+ * existing record with the same filename and replaces its bytes in place, keeping the id. That is
+ * deliberate for a repaired or edited version of the same alignment - the analysis history stays
+ * attached - but it is wrong when the user means "here is a different file that happens to be
+ * called alignment.fasta", because every earlier run silently ends up filed under the new contents.
+ * These two helpers are the seam for both halves of the fix: choosing a non-colliding name, and
+ * marking the runs that predate a replacement.
+ */
+
+/**
+ * Return `name` if free, otherwise the first "stem (n).ext" that is not taken.
+ *
+ * MUST run before `forceNew` reaches indexedDBStorage.saveFile: saveFile does its own
+ * findFileByName lookup, so two records sharing a name would make that lookup - used by every
+ * other caller - nondeterministic.
+ *
+ * @param {string} name
+ * @param {Iterable<string>} takenNames
+ * @returns {string}
+ */
+export function uniqueFilename(name, takenNames = []) {
+	const taken = new Set(takenNames);
+	if (!taken.has(name)) return name;
+
+	// Split on the LAST dot so "a.b.fasta" keeps ".fasta". A leading dot (".fasta") is a name, not
+	// an extension, hence > 0 rather than >= 0.
+	const dot = name.lastIndexOf('.');
+	const stem = dot > 0 ? name.slice(0, dot) : name;
+	const ext = dot > 0 ? name.slice(dot) : '';
+
+	// Strip an existing " (n)" so a third upload gives "alignment (3).fasta", not
+	// "alignment (2) (2).fasta".
+	const base = stem.replace(/ \(\d+\)$/, '');
+
+	for (let n = 2; n < 1000; n += 1) {
+		const candidate = `${base} (${n})${ext}`;
+		if (!taken.has(candidate)) return candidate;
+	}
+
+	// 999 same-named files is not a real case; fall back to something unique rather than loop.
+	return `${base} (${Date.now()})${ext}`;
+}
+
+/**
+ * Clear a file input so selecting the SAME path again fires another change event.
+ *
+ * Must be called from a `finally`, not from the happy path: a rejected file is exactly the one the
+ * user corrects outside the browser and re-selects, and without this that second selection is a
+ * no-op with no feedback at all.
+ *
+ * The instanceof guard is load-bearing — the demo, repair and alignment-edit callers pass a
+ * synthetic `{ target: { files: [...] } }` object with no `value` to clear.
+ *
+ * @param {{target?: any}} event
+ */
+export function resetFileInput(event) {
+	const target = event?.target;
+	if (typeof HTMLInputElement !== 'undefined' && target instanceof HTMLInputElement) {
+		target.value = '';
+	}
+}
+
+/**
+ * True when this analysis ran before the file's contents were last replaced.
+ *
+ * `updatedAt` is only written when an upload replaces an existing record, so a file that was never
+ * re-uploaded has none and nothing is ever marked stale.
+ *
+ * @param {{createdAt?: number}} analysis
+ * @param {{createdAt?: number, updatedAt?: number}} file
+ * @returns {boolean}
+ */
+export function isStaleRun(analysis, file) {
+	const updatedAt = Number(file?.updatedAt);
+	const createdAt = Number(analysis?.createdAt);
+	if (!Number.isFinite(updatedAt) || !Number.isFinite(createdAt)) return false;
+	return createdAt < updatedAt;
+}

--- a/src/lib/utils/fileMetricsDisplay.js
+++ b/src/lib/utils/fileMetricsDisplay.js
@@ -1,0 +1,59 @@
+/**
+ * Display formatters for datareader's FILE_INFO record.
+ *
+ * These exist because two of the Data tab's numbers were unreadable rather than wrong:
+ *
+ *  - `rawsites` and `sites` are the SAME alignment measured in two units. datareader.bf:608 takes
+ *    `sites` from the codon filter (unit 3) and :617 takes `rawsites` from a nucleotide filter
+ *    (unit 1) built from the same data, so `rawsites` is exactly 3 x `sites` for codon data. The
+ *    old "561 raw -> 187 processed" row read as if 374 sites had been thrown away.
+ *  - `gencodeid` was printed as a bare integer.
+ *
+ * Both are LABEL changes. The underlying `sites` value is consumed as the alignment-length term by
+ * BaseAnalysisRunner.js:41-46 and SequenceWarnings, so nothing here may alter it.
+ */
+import { GENETIC_CODES } from '../config/geneticCodes.js';
+
+const groupDigits = (n) => Number(n).toLocaleString('en-US');
+
+/**
+ * "561 nucleotides (187 codons)" for codon data, "561 sites" for anything else.
+ *
+ * Cached datareader records predating `rawsites` fall back to the codon count alone rather than
+ * rendering `NaN` — descriptorSync.js replays whatever IndexedDB holds, with no migration step.
+ *
+ * @param {Record<string, any>} FILE_INFO
+ * @returns {string}
+ */
+export function formatAlignmentLength(FILE_INFO = {}) {
+	const sites = Number(FILE_INFO?.sites);
+	if (!Number.isFinite(sites)) return 'Unknown';
+
+	// datareader hardcodes genCodeID = 0 today; treat a missing gencodeid as codon data, which is
+	// what every record it has ever written actually is.
+	const isCodon = Number(FILE_INFO?.gencodeid ?? 0) >= 0;
+	const rawsites = Number(FILE_INFO?.rawsites);
+
+	if (isCodon && Number.isFinite(rawsites) && rawsites !== sites) {
+		return `${groupDigits(rawsites)} nucleotides (${groupDigits(sites)} codons)`;
+	}
+
+	return `${groupDigits(sites)} ${isCodon ? 'codons' : 'sites'}`;
+}
+
+/**
+ * Turn a gencodeid into the name of the code. -1 and -2 are datareader's sentinels for
+ * non-codon data (datareader.bf:457-471) and are not rows in the table.
+ *
+ * @param {number|string} gencodeid
+ * @returns {string}
+ */
+export function formatGeneticCode(gencodeid) {
+	const id = Number(gencodeid);
+	if (!Number.isFinite(id)) return 'Unknown';
+	if (id === -1) return 'Nucleotide';
+	if (id < 0) return 'Amino acid';
+
+	const entry = GENETIC_CODES.find((c) => c.id === id);
+	return entry ? entry.label : `Code ${id}`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,11 @@
 		alignmentFileStore,
 		fileMetricsStore,
 		persistentFileStore,
-		currentFile
+		currentFile,
+		revalidatingFileId
 	} from '../stores/fileInfo';
+	import { uniqueFilename, resetFileInput } from '../lib/utils/fileIdentity.js';
+	import { applyAlignmentEdits } from '../lib/utils/alignmentEdits.js';
 	import {
 		analysisStore,
 		currentAnalysis,
@@ -25,6 +28,7 @@
 	import Aioli from '@biowasm/aioli';
 	import TreeSelector from '../lib/TreeSelector.svelte';
 	import ErrorHandler from '../lib/ErrorHandler.svelte';
+	import FileConflictPrompt from '../lib/FileConflictPrompt.svelte';
 	import DemoFileSelector from '../lib/DemoFileSelector.svelte';
 	import { X, FlaskConical, ExternalLink } from 'lucide-svelte';
 
@@ -688,6 +692,35 @@
 	let file;
 	let isStdOutVisible = false; // State for toggling stdout visibility
 	let validationError = null;
+	// Actions offered on the validation-error card. Currently only the alignment-edit restore.
+	let validationErrorActions = [];
+
+	// Same-name upload conflict, resolved by FileConflictPrompt.
+	let fileConflict = null;
+	let resolveFileConflict = null;
+
+	/**
+	 * The onConflict hook handed to persistentFileStore.uploadFile for genuine uploads.
+	 * Resolves to 'replace' or 'keep-both' once the user answers the modal.
+	 */
+	function promptForFileConflict({ existing, incoming }) {
+		const takenNames = ($persistentFileStore.files ?? []).map((f) => f.filename);
+		const analysisCount = ($analysisStore.analyses ?? []).filter(
+			(a) => a.fileId === existing?.id && a.method !== 'datareader'
+		).length;
+		fileConflict = {
+			filename: incoming.name,
+			keepBothName: uniqueFilename(incoming.name, takenNames),
+			analysisCount
+		};
+		return new Promise((resolve) => {
+			resolveFileConflict = (choice) => {
+				fileConflict = null;
+				resolveFileConflict = null;
+				resolve(choice);
+			};
+		});
+	}
 
 	async function handleFileUpload(event) {
 		// Track which entry point fired this call and which awaited step we're on,
@@ -698,7 +731,12 @@
 				? 'demo'
 				: event.isRepaired
 					? 'repair'
-					: 'upload';
+					: event.isEdited
+						? 'edit'
+						: 'upload';
+		// Captured before the first await: the reset in `finally` needs the element even on the
+		// failure path, and by then `event` may be long gone from the caller's scope.
+		const inputEvent = event;
 		let currentStage = 'init';
 		try {
 			// CLEAR THE PREVIOUS FILE'S ERROR FIRST, before any branch that can return early.
@@ -709,6 +747,7 @@
 			// screen beside the newly selected one. Same shape as the descriptorSync bug (#168): a
 			// reset placed after something that can exit early is not a reset. Issue #205.
 			validationError = null;
+			validationErrorActions = [];
 			// Errors no longer auto-dismiss (#187), which is right for someone who stepped away --
 			// but it means a stale error toast would otherwise outlive the file it describes.
 			// Successes are left alone: they link to a result that still exists.
@@ -801,7 +840,19 @@
 				// Pass any metadata from demo files
 				const metadata = event.isDemo ? event.metadata : {};
 				currentStage = 'storage';
-				fileId = await persistentFileStore.uploadFile(file, metadata);
+				// The conflict prompt is for GENUINE uploads only. A demo file, a repaired file and an
+				// edited alignment are all deliberate in-place replacements of a file the user just
+				// acted on — prompting there is noise, and for the edit case it would ask the user to
+				// confirm the replace they explicitly requested one click earlier.
+				const hooks = source === 'upload' ? { onConflict: promptForFileConflict } : {};
+				fileId = await persistentFileStore.uploadFile(file, metadata, hooks);
+
+				// 'Keep both' files the bytes under a new name. Keep the in-memory File in step so the
+				// alignment viewer and the export panel show the name it is actually stored under.
+				const storedRecord = ($persistentFileStore.files ?? []).find((f) => f.id === fileId);
+				if (storedRecord && storedRecord.filename !== file.name) {
+					file = new File([file], storedRecord.filename, { type: file.type });
+				}
 			} else {
 				fileId = event.fileId;
 			}
@@ -1132,7 +1183,51 @@
 					message: isTreeError ? 'Tree parsing issue' : 'File processing error'
 				}
 			};
+
+			// An edit that the reader rejects is a dead end otherwise: the edited bytes are already in
+			// IndexedDB under the same id, so there is nothing left on screen holding the pre-edit
+			// alignment. Offer to put it back — as an action, never automatically. Auto-restoring
+			// would silently discard work the user just did.
+			if (event.isEdited && event.previous instanceof File) {
+				const previous = event.previous;
+				validationErrorActions = [
+					{
+						id: 'restore-pre-edit',
+						label: 'Restore the alignment from before these edits',
+						run: () => handleFileUpload({ target: { files: [previous] }, isEdited: true, previous })
+					}
+				];
+			}
+		} finally {
+			// MUST be in finally. Re-selecting the same path fires no change event, so a file that
+			// failed could not be retried after the user corrected it outside the browser — and the
+			// failure loop is exactly the case this exists for.
+			resetFileInput(inputEvent);
+			// The Run gate is cleared however the re-read ended: success, rejection or throw.
+			revalidatingFileId.set(null);
 		}
+	}
+
+	/**
+	 * "Save edits" in the alignment viewer. The viewer now hands the edited alignment back rather
+	 * than writing the stores itself, because writing them left `fileMetricsStore.canonicalFasta`
+	 * — the exact bytes every runner submits — describing the PRE-edit alignment. Re-entering the
+	 * normal upload path is the whole fix: it clears the descriptor stores, re-runs datareader,
+	 * regenerates canonicalFasta and files a fresh datareader analysis.
+	 */
+	function handleAlignmentEdited(event) {
+		const { file: editedFile, previous } = event.detail ?? {};
+		if (!editedFile) return;
+
+		validationErrorActions = [];
+		file = editedFile;
+		return applyAlignmentEdits(editedFile, {
+			// uploadFile replaces the same-name record in place, so the id does not change and the
+			// analysis history stays attached.
+			fileId: $currentFile?.id ?? null,
+			setRevalidating: (id) => revalidatingFileId.set(id),
+			revalidate: (f) => handleFileUpload({ target: { files: [f] }, isEdited: true, previous })
+		});
 	}
 
 	// Toggle the stdout visibility
@@ -1430,9 +1525,11 @@
 					{handleFileUpload}
 					{handleDemoFileSelect}
 					{validationError}
+					{validationErrorActions}
 					{fileMetricsJSON}
 					{handleValidated}
 					{handleUseRepaired}
+					{handleAlignmentEdited}
 					{activeTab}
 					onChange={changeTab}
 				/>
@@ -1465,6 +1562,9 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Rendered at the page root so it overlays whichever tab is open. -->
+<FileConflictPrompt conflict={fileConflict} on:choose={(e) => resolveFileConflict?.(e.detail)} />
 
 <style>
 	.loader {

--- a/src/stores/fileInfo.js
+++ b/src/stores/fileInfo.js
@@ -2,10 +2,22 @@ import { writable, derived } from 'svelte/store';
 import { fileStorage } from '../lib/utils/indexedDBStorage';
 import { browser } from '$app/environment';
 import { trackEvent } from '../lib/utils/analytics.js';
+import { uniqueFilename } from '../lib/utils/fileIdentity.js';
 
 // Basic stores for immediate usage
 export const alignmentFileStore = writable(null);
 export const fileMetricsStore = writable(null);
+
+/**
+ * The id of the file currently being re-read after an in-place edit, or null.
+ *
+ * In-memory on purpose. The obvious alternative — gate the Run button on a 'pending' datareader
+ * record — wedges the button forever if that record is orphaned: cleanupInterruptedAnalyses
+ * (stores/analyses.js) only reconciles records whose metadata.executionMode is 'wasm', and
+ * datareader records carry no metadata at all. A flag that dies with the tab cannot outlive the
+ * work it describes.
+ */
+export const revalidatingFileId = writable(null);
 
 // Persistent file store
 function createPersistentFileStore() {
@@ -34,8 +46,19 @@ function createPersistentFileStore() {
 			}
 		},
 
-		// Upload a file to browser storage
-		async uploadFile(file) {
+		/**
+		 * Upload a file to browser storage.
+		 *
+		 * @param {File} file
+		 * @param {Object} metadata - persisted alongside the record (demo provenance, etc). This used
+		 *   to be dropped on the floor: +page.svelte has always passed it, uploadFile has always
+		 *   taken one parameter, so demo files were indistinguishable from user uploads on disk.
+		 * @param {{onConflict?: (ctx: {existing: Object, incoming: File}) => Promise<'replace'|'keep-both'>}} hooks
+		 *   Optional. When a same-name record exists AND a hook is supplied, the caller decides.
+		 *   With no hook the behaviour is exactly what it was (silent in-place replace), which is
+		 *   what FileManager, the demo loader and the alignment-edit save all want.
+		 */
+		async uploadFile(file, metadata = {}, { onConflict } = {}) {
 			if (!browser) return; // Only run in browser
 
 			update((state) => ({ ...state, isLoading: true, error: null }));
@@ -43,15 +66,35 @@ function createPersistentFileStore() {
 			try {
 				// Check if a file with the same name already exists
 				let existingFileId = null;
+				let existingRecord = null;
+				let takenNames = [];
 
 				update((state) => {
 					// Check current state for a file with the same name
 					const existing = state.files.find((f) => f.filename === file.name);
 					if (existing) {
 						existingFileId = existing.id;
+						existingRecord = existing;
 					}
+					takenNames = state.files.map((f) => f.filename);
 					return state;
 				});
+
+				let fileToSave = file;
+				let effectiveMetadata = metadata;
+
+				if (existingFileId && typeof onConflict === 'function') {
+					const choice = await onConflict({ existing: existingRecord, incoming: file });
+					if (choice === 'keep-both') {
+						// Uniquify BEFORE forceNew reaches saveFile — see uniqueFilename's note. A new
+						// name means a new id, which means the new file starts with no analyses. That is
+						// the point: the old runs describe the old contents.
+						const uniqueName = uniqueFilename(file.name, takenNames);
+						fileToSave = new File([file], uniqueName, { type: file.type });
+						effectiveMetadata = { ...metadata, forceNew: true };
+						existingFileId = null;
+					}
+				}
 
 				let fileId;
 
@@ -73,7 +116,8 @@ function createPersistentFileStore() {
 						content: arrayBuffer,
 						size: file.size,
 						type: file.type,
-						updatedAt: new Date().getTime()
+						updatedAt: new Date().getTime(),
+						...effectiveMetadata
 					};
 
 					// Save updated file
@@ -81,7 +125,7 @@ function createPersistentFileStore() {
 					fileId = existingFileId;
 				} else {
 					// Save as new file
-					fileId = await fileStorage.saveFile(file);
+					fileId = await fileStorage.saveFile(fileToSave, effectiveMetadata);
 				}
 
 				// Get the file metadata (without content)

--- a/src/test/alignment-edit-revalidation.test.js
+++ b/src/test/alignment-edit-revalidation.test.js
@@ -1,0 +1,186 @@
+/**
+ * "Save edits" in the alignment viewer used to write the edited FASTA to IndexedDB and to
+ * alignmentFileStore, say "Saved", and stop.
+ *
+ * Nothing re-ran datareader. `fileMetricsStore.canonicalFasta` — the exact string AnalyzeTab hands
+ * to every runner, local and remote — kept describing the alignment BEFORE the edit. So deleting a
+ * contaminated sequence and pressing Run produced a result computed with that sequence still in
+ * the alignment, while the viewer showed it gone.
+ *
+ * The two assertions that matter here are (a) the edit reaches revalidation at all, and (b) the
+ * pre-edit canonicalFasta is gone before revalidation resolves — a runner that fires mid-re-read
+ * must find nothing rather than the old bytes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('alivibe', async () => ({
+	AliVibe: (await import('./stubs/AliVibeStub.svelte')).default
+}));
+vi.mock('../lib/utils/indexedDBStorage', () => ({
+	fileStorage: {
+		saveFile: vi.fn(async () => 'id'),
+		updateFile: vi.fn(async () => 'id'),
+		getFile: vi.fn(async () => ({ id: 'id' })),
+		getFileMetadata: vi.fn(async () => ({ id: 'id' })),
+		getAllFiles: vi.fn(async () => []),
+		deleteFile: vi.fn(async () => {}),
+		fileRecordToFile: vi.fn(async () => null)
+	}
+}));
+vi.mock('../lib/utils/analytics.js', () => ({ trackEvent: vi.fn() }));
+
+const { buildEditedAlignmentFile, applyAlignmentEdits } = await import(
+	'../lib/utils/alignmentEdits.js'
+);
+const { fileMetricsStore, revalidatingFileId, alignmentFileStore } = await import(
+	'../stores/fileInfo.js'
+);
+const { fileStorage } = await import('../lib/utils/indexedDBStorage');
+const AlignmentViewerHarness = (await import('./stubs/AlignmentViewerHarness.svelte')).default;
+
+// jsdom's Blob implements neither text() nor arrayBuffer().
+if (typeof Blob.prototype.text !== 'function') {
+	Blob.prototype.text = function text() {
+		return Promise.resolve('>a\nACGACG\n>b\nACGTTT\n');
+	};
+}
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+	Blob.prototype.arrayBuffer = function arrayBuffer() {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
+}
+
+const editedFile = () =>
+	new File(['>a\nACGACG\n>b\nACGTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+
+describe('buildEditedAlignmentFile', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	it('keeps the original filename so the record is replaced in place', () => {
+		const f = buildEditedAlignmentFile([{ name: 'a', seq: 'ACG' }], 'CD2-slim.fna');
+		expect(f.name).toBe('CD2-slim.fna');
+	});
+
+	it('refuses to build an empty alignment', () => {
+		expect(() => buildEditedAlignmentFile([], 'x.fasta')).toThrow(/No alignment data/i);
+	});
+});
+
+describe('applyAlignmentEdits', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	it('sends the edited file through revalidation exactly once', async () => {
+		const revalidate = vi.fn(async () => 'ok');
+		const file = editedFile();
+
+		await applyAlignmentEdits(file, { revalidate });
+
+		expect(revalidate).toHaveBeenCalledTimes(1);
+		expect(revalidate).toHaveBeenCalledWith(file);
+	});
+
+	it('drops the pre-edit descriptor BEFORE revalidation resolves', async () => {
+		fileMetricsStore.set({ FILE_INFO: { sequences: 23 }, canonicalFasta: 'OLD' });
+
+		let seenDuringRevalidate = 'not-called';
+		const revalidate = vi.fn(async () => {
+			// This is the window a Run click would land in.
+			seenDuringRevalidate = get(fileMetricsStore);
+			return 'ok';
+		});
+
+		await applyAlignmentEdits(editedFile(), { revalidate });
+
+		expect(seenDuringRevalidate).toBeNull();
+	});
+
+	it('flags the file as revalidating for the whole re-read, then clears it', async () => {
+		const seen = [];
+		const revalidate = vi.fn(async () => {
+			seen.push(get(revalidatingFileId));
+			return 'ok';
+		});
+
+		await applyAlignmentEdits(editedFile(), {
+			revalidate,
+			fileId: 'file-1',
+			setRevalidating: (id) => revalidatingFileId.set(id)
+		});
+
+		expect(seen).toEqual(['file-1']);
+		expect(get(revalidatingFileId)).toBeNull();
+	});
+
+	it('clears the flag when revalidation REJECTS, so the Run button cannot wedge', async () => {
+		const revalidate = vi.fn(async () => {
+			throw new Error('datareader rejected the edited alignment');
+		});
+
+		await expect(
+			applyAlignmentEdits(editedFile(), {
+				revalidate,
+				fileId: 'file-1',
+				setRevalidating: (id) => revalidatingFileId.set(id)
+			})
+		).rejects.toThrow(/datareader rejected/);
+
+		expect(get(revalidatingFileId)).toBeNull();
+	});
+
+	it('fails loudly rather than silently doing nothing when no revalidator is wired', async () => {
+		await expect(applyAlignmentEdits(editedFile(), {})).rejects.toThrow(/revalidate/);
+	});
+});
+
+describe('the viewer hands the edit to its parent instead of filing it itself', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fileMetricsStore.set(null);
+		alignmentFileStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	afterEach(() => cleanup());
+
+	it('dispatches editsSaved with the new file and the pre-edit one', async () => {
+		const onSaved = vi.fn();
+		const original = new File(['>a\nACGACG\n'], 'CD2-slim.fna', { type: 'text/plain' });
+		render(AlignmentViewerHarness, { props: { alignmentFile: original, onSaved } });
+
+		await fireEvent.click(screen.getByTitle('Save alignment edits back to file'));
+
+		expect(onSaved).toHaveBeenCalledTimes(1);
+		const detail = onSaved.mock.calls[0][0];
+		expect(detail.file).toBeInstanceOf(File);
+		expect(detail.file.name).toBe('CD2-slim.fna');
+		// The pre-edit blob, kept so the error card can offer to put it back if datareader rejects
+		// the edit. IndexedDB already holds the edited bytes by then.
+		expect(detail.previous).toBe(original);
+	});
+
+	it('writes nothing to storage or to alignmentFileStore on its own', async () => {
+		// This is the actual defect: those two writes made the edit look applied while the metrics
+		// the runners read still described the old alignment.
+		const original = new File(['>a\nACGACG\n'], 'CD2-slim.fna', { type: 'text/plain' });
+		render(AlignmentViewerHarness, { props: { alignmentFile: original, onSaved: () => {} } });
+
+		await fireEvent.click(screen.getByTitle('Save alignment edits back to file'));
+
+		expect(fileStorage.saveFile).not.toHaveBeenCalled();
+		expect(fileStorage.updateFile).not.toHaveBeenCalled();
+		expect(get(alignmentFileStore)).toBeNull();
+	});
+});
+// NOTE: there is deliberately no "does not show Saved" case here. Written as an assertion on the
+// button label it passes with the fix reverted too — the old code set saveMessage only after an
+// await, so nothing has rendered yet at the point a click handler returns. A test that passes
+// either way is worse than no test.

--- a/src/test/datareader-warnings.test.js
+++ b/src/test/datareader-warnings.test.js
@@ -1,0 +1,116 @@
+/**
+ * What the Data tab tells the user about the changes datareader made to their alignment.
+ *
+ * datareader collapses duplicates, renames sequences, pads short ones and strips a terminal stop
+ * codon column. It has always written a sentence about each of those to ./datareader.log — a file
+ * nothing in the JS layer reads. Only counts reached results.json, and one of them was mislabelled:
+ * `ambiguous_sites` is the boolean padWarning, and the UI rendered it as "Found 1 ambiguous
+ * character in your alignment" — wrong count, wrong cause, wrong advice.
+ *
+ * The describe-don't-modify assertion at the bottom is the maintainer's rule, mirrored from
+ * stop-codon-diagnosis.test.js: this UI states what is in the file and stops there.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWarnings } from '../lib/utils/datareaderWarnings.js';
+
+const textOf = (w) => [w.title, w.message, w.details, ...(w.items ?? [])].join(' ');
+
+describe('padding warning', () => {
+	it('explains padding rather than reporting an ambiguous-character count', () => {
+		// The legacy boolean, which is all a cached record has.
+		const [w] = buildWarnings({ ambiguous_sites: 1 });
+		expect(w.message).toContain('padded');
+		expect(w.message).not.toContain('ambiguous character');
+		expect(textOf(w)).not.toContain('ambiguous character');
+	});
+
+	it('names how many sequences were padded, and which gap characters count', () => {
+		const [w] = buildWarnings({ padded_sequences: 3 });
+		expect(w.message).toContain('3 sequences');
+		expect(w.details).toContain('~');
+		expect(w.details).toContain('-');
+	});
+});
+
+describe('stop codons', () => {
+	it('leaves the dead `stop_codons` key dead', () => {
+		// datareader has never emitted this key; the branch that read it could not fire, and
+		// reviving it would fire on a key that means something else.
+		expect(buildWarnings({ stop_codons: 5 })).toHaveLength(0);
+	});
+
+	it('reports the key datareader does emit, as the boolean it is', () => {
+		const warnings = buildWarnings({ stop_codons_stripped: 1 });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].message).toMatch(/stop codon/i);
+	});
+});
+
+describe('names of the sequences that changed', () => {
+	it('lists renames', () => {
+		const [w] = buildWarnings({ renamed_names: ['seq|1 -> seq_1'] });
+		expect(w.items).toContain('seq|1 -> seq_1');
+		expect(textOf(w)).toContain('seq_1');
+	});
+
+	it('lists duplicate pairs', () => {
+		const [w] = buildWarnings({ duplicate_names: ['a = b'] });
+		expect(w.items).toContain('a = b');
+	});
+
+	it("accepts HyPhy's numerically-keyed objects as well as arrays", () => {
+		const [w] = buildWarnings({ renamed_names: { 0: 'x|1 -> x_1', 1: 'y|2 -> y_2' } });
+		expect(w.items).toEqual(['x|1 -> x_1', 'y|2 -> y_2']);
+	});
+
+	it('carries a name containing a double quote through without breaking', () => {
+		const [w] = buildWarnings({ duplicate_names: ['say "hi" = other'] });
+		expect(w.items).toContain('say "hi" = other');
+		expect(textOf(w)).toContain('say "hi"');
+	});
+
+	it('fires on the names alone, without a separate count field', () => {
+		expect(buildWarnings({ duplicate_names: ['a = b'] })).toHaveLength(1);
+		expect(buildWarnings({ renamed_names: ['a -> b'] })).toHaveLength(1);
+	});
+});
+
+describe('the copy describes, and never offers to modify the alignment', () => {
+	it('recommends nothing across every warning it can produce', () => {
+		const everything = buildWarnings({
+			duplicate_sequences: 2,
+			duplicate_names: ['a = b', 'c = a'],
+			sequences_renamed: 1,
+			renamed_names: ['seq|1 -> seq_1'],
+			padded_sequences: 2,
+			ambiguous_sites: 1,
+			stop_codons_stripped: 1,
+			sites: 12,
+			sequences: 4
+		});
+		expect(everything.length).toBeGreaterThan(4);
+		for (const w of everything) {
+			expect(textOf(w)).not.toMatch(/remove|fix|trim|we can|repair/i);
+		}
+	});
+});
+
+describe('a clean file produces no warnings', () => {
+	it('says nothing about an alignment with nothing to report', () => {
+		expect(
+			buildWarnings({
+				duplicate_sequences: 0,
+				sequences_renamed: 0,
+				ambiguous_sites: 0,
+				padded_sequences: 0,
+				stop_codons_stripped: 0,
+				sites: 187,
+				sequences: 10
+			})
+		).toEqual([]);
+	});
+
+	it('tolerates a missing FILE_INFO', () => {
+		expect(buildWarnings(undefined)).toEqual([]);
+	});
+});

--- a/src/test/datatab-metrics.test.js
+++ b/src/test/datatab-metrics.test.js
@@ -1,0 +1,80 @@
+/**
+ * The Data tab's numbers.
+ *
+ * Two separate bugs, both of which read as "the app is telling me something about my file" and
+ * were not true:
+ *
+ *  - "561 raw -> 187 processed" is the SAME alignment measured twice. datareader.bf takes `sites`
+ *    from a codon filter and `rawsites` from a nucleotide filter over identical data, so rawsites
+ *    is exactly 3x sites. The arrow said 374 sites had been discarded.
+ *  - The file-limits copy claimed 5,000 sequences and a tree above 500. The real gates are
+ *    maxUploadSize = 25000 and maxSLACSize = 10000 (HyPhyGlobals.ibf:33,15).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatAlignmentLength, formatGeneticCode } from '../lib/utils/fileMetricsDisplay.js';
+import { uploadLimits, uploadLimitsCopy } from '../lib/config/uploadLimits.js';
+
+describe('formatAlignmentLength', () => {
+	it('states one length in two units instead of implying a loss', () => {
+		expect(formatAlignmentLength({ rawsites: 561, sites: 187 })).toBe(
+			'561 nucleotides (187 codons)'
+		);
+	});
+
+	it('does not render the old arrow or the word "processed"', () => {
+		const out = formatAlignmentLength({ rawsites: 561, sites: 187 });
+		expect(out).not.toContain('→');
+		expect(out).not.toContain('processed');
+	});
+
+	it('falls back to codons alone for a cached record with no rawsites', () => {
+		// descriptorSync replays whatever IndexedDB holds, with no migration step.
+		const out = formatAlignmentLength({ sites: 187 });
+		expect(out).toBe('187 codons');
+		expect(out).not.toMatch(/NaN|undefined/);
+	});
+
+	it('does not invent a codon count for non-codon data', () => {
+		expect(formatAlignmentLength({ rawsites: 561, sites: 561, gencodeid: -1 })).toBe('561 sites');
+	});
+
+	it('says Unknown rather than NaN when there is no length at all', () => {
+		expect(formatAlignmentLength({})).toBe('Unknown');
+	});
+});
+
+describe('formatGeneticCode', () => {
+	it('names the code instead of printing its id', () => {
+		expect(formatGeneticCode(0)).toBe('Universal code');
+		expect(formatGeneticCode(0)).not.toBe('0');
+	});
+
+	it('resolves other table entries', () => {
+		expect(formatGeneticCode(4)).toContain('Invertebrate');
+	});
+
+	it('handles the non-codon sentinels, which are not rows in the table', () => {
+		expect(formatGeneticCode(-1)).toBe('Nucleotide');
+		expect(formatGeneticCode(-2)).toBe('Amino acid');
+	});
+
+	it('degrades to the id for a code it does not know', () => {
+		expect(formatGeneticCode(99)).toBe('Code 99');
+	});
+});
+
+describe('upload limits copy', () => {
+	it('carries the limits datareader actually enforces', () => {
+		expect(uploadLimits.maxSequences).toBe(25000);
+		expect(uploadLimits.treeRequiredAbove).toBe(10000);
+	});
+
+	it('no longer claims 5,000 sequences or a tree above 500', () => {
+		const copy = uploadLimitsCopy();
+		expect(copy).toContain('25,000 sequences');
+		// Lookbehind, not toContain: '25,000 sequences' contains '5,000 sequences' as a substring,
+		// which would make the naive assertion pass on the FIXED copy and fail on nothing.
+		expect(copy).not.toMatch(/(?<![\d,])5,000 sequences/);
+		expect(copy).not.toMatch(/(?<![\d,])500 sequences/);
+	});
+});

--- a/src/test/file-upload-identity.test.js
+++ b/src/test/file-upload-identity.test.js
@@ -1,0 +1,157 @@
+/**
+ * A file is identified by its NAME here, and that had three consequences nobody chose:
+ *
+ *  1. persistentFileStore.uploadFile took ONE parameter while +page.svelte has always called it
+ *     with two, so the demo/repair provenance in that second argument was silently dropped.
+ *  2. A same-name upload replaced the record's bytes in place and kept the id, so every FEL/MEME
+ *     run against the OLD contents stayed attached to the new ones with nothing marking them.
+ *  3. The file input was never reset, so re-selecting the same path after a rejection fired no
+ *     change event at all — the failure loop is the one case where the retry matters most.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uniqueFilename, isStaleRun, resetFileInput } from '../lib/utils/fileIdentity.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('../lib/utils/indexedDBStorage', () => {
+	const fileStorage = {
+		saveFile: vi.fn(async () => 'new-id'),
+		updateFile: vi.fn(async () => 'existing-id'),
+		getFile: vi.fn(async (id) => ({
+			id,
+			filename: 'alignment.fasta',
+			content: new ArrayBuffer(0)
+		})),
+		getFileMetadata: vi.fn(async (id) => ({ id, filename: 'alignment.fasta', createdAt: 1 })),
+		getAllFiles: vi.fn(async () => []),
+		deleteFile: vi.fn(async () => {}),
+		fileRecordToFile: vi.fn(async () => null)
+	};
+	return { fileStorage };
+});
+
+vi.mock('../lib/utils/analytics.js', () => ({ trackEvent: vi.fn() }));
+
+const { fileStorage } = await import('../lib/utils/indexedDBStorage');
+const { persistentFileStore } = await import('../stores/fileInfo.js');
+
+// jsdom's Blob has no arrayBuffer(); the store calls it on the in-place replace path.
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+	Blob.prototype.arrayBuffer = function arrayBuffer() {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
+}
+
+describe('uniqueFilename', () => {
+	it('numbers a colliding name', () => {
+		expect(uniqueFilename('alignment.fasta', ['alignment.fasta'])).toBe('alignment (2).fasta');
+	});
+
+	it('keeps counting past an existing numbered copy', () => {
+		expect(uniqueFilename('alignment.fasta', ['alignment.fasta', 'alignment (2).fasta'])).toBe(
+			'alignment (3).fasta'
+		);
+	});
+
+	it('does not stack suffixes when the colliding name is itself numbered', () => {
+		expect(uniqueFilename('alignment (2).fasta', ['alignment (2).fasta'])).toBe(
+			'alignment (3).fasta'
+		);
+	});
+
+	it('leaves a free name alone', () => {
+		expect(uniqueFilename('alignment.fasta', ['other.fasta'])).toBe('alignment.fasta');
+	});
+
+	it('handles extensionless and multi-dot names', () => {
+		expect(uniqueFilename('alignment', ['alignment'])).toBe('alignment (2)');
+		expect(uniqueFilename('a.b.fasta', ['a.b.fasta'])).toBe('a.b (2).fasta');
+	});
+});
+
+describe('isStaleRun', () => {
+	it('marks a run that predates the file being replaced', () => {
+		expect(isStaleRun({ createdAt: 100 }, { createdAt: 50, updatedAt: 200 })).toBe(true);
+	});
+
+	it('does not mark a run made after the replacement', () => {
+		expect(isStaleRun({ createdAt: 300 }, { createdAt: 50, updatedAt: 200 })).toBe(false);
+	});
+
+	it('never marks anything on a file that was never re-uploaded', () => {
+		expect(isStaleRun({ createdAt: 100 }, { createdAt: 50 })).toBe(false);
+	});
+});
+
+describe('persistentFileStore.uploadFile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes metadata through to storage as the second argument', async () => {
+		const file = new File(['>a\nACG\n'], 'demo.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(file, { source: 'demo', demoId: 'CD2' });
+
+		expect(fileStorage.saveFile).toHaveBeenCalledTimes(1);
+		expect(fileStorage.saveFile.mock.calls[0][1]).toEqual({ source: 'demo', demoId: 'CD2' });
+	});
+
+	it("saves a separate record under a free name when the user picks 'keep both'", async () => {
+		// Seed the store with an existing same-name record.
+		await persistentFileStore.loadFiles();
+		fileStorage.getAllFiles.mockResolvedValueOnce([
+			{ id: 'existing-id', filename: 'alignment.fasta', createdAt: 1 }
+		]);
+		await persistentFileStore.loadFiles();
+
+		const incoming = new File(['>b\nTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(incoming, {}, { onConflict: () => 'keep-both' });
+
+		expect(fileStorage.updateFile).not.toHaveBeenCalled();
+		expect(fileStorage.saveFile).toHaveBeenCalledTimes(1);
+		const [savedFile, savedMetadata] = fileStorage.saveFile.mock.calls[0];
+		expect(savedFile.name).toBe('alignment (2).fasta');
+		expect(savedMetadata).toMatchObject({ forceNew: true });
+	});
+
+	it('still replaces in place when no conflict hook is supplied', async () => {
+		fileStorage.getAllFiles.mockResolvedValueOnce([
+			{ id: 'existing-id', filename: 'alignment.fasta', createdAt: 1 }
+		]);
+		await persistentFileStore.loadFiles();
+
+		const incoming = new File(['>b\nTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(incoming);
+
+		expect(fileStorage.updateFile).toHaveBeenCalledTimes(1);
+		expect(fileStorage.saveFile).not.toHaveBeenCalled();
+	});
+});
+
+describe('resetFileInput', () => {
+	it('clears the input on the REJECTED path, not only the successful one', () => {
+		const input = document.createElement('input');
+		input.type = 'file';
+		// jsdom will not let a test assign arbitrary text to a file input's value, but it does allow
+		// clearing it — which is the only assignment this helper ever makes.
+		let ran = false;
+
+		// The shape handleFileUpload uses: reset in `finally`, after the catch has swallowed.
+		try {
+			throw new Error('File processing error');
+		} catch {
+			/* swallowed, as the page does */
+		} finally {
+			resetFileInput({ target: input });
+			ran = true;
+		}
+
+		expect(ran).toBe(true);
+		expect(input.value).toBe('');
+	});
+
+	it('ignores the synthetic { target: { files } } objects demo/repair/edit callers pass', () => {
+		expect(() => resetFileInput({ target: { files: [] } })).not.toThrow();
+		expect(() => resetFileInput(undefined)).not.toThrow();
+	});
+});

--- a/src/test/stubs/AliVibeStub.svelte
+++ b/src/test/stubs/AliVibeStub.svelte
@@ -1,0 +1,18 @@
+<script>
+	// Stand-in for the AliVibe widget. AlignmentViewer only ever calls these three methods on it,
+	// and getAlignment() is the one that matters: it is the edited alignment leaving the viewer.
+	export let height = null;
+	export let features = null;
+	export let rows = [
+		{ name: 'a', seq: 'ACGACG' },
+		{ name: 'b', seq: 'ACGTTT' }
+	];
+
+	export function getAlignment() {
+		return rows;
+	}
+	export function loadFasta() {}
+	export function loadTree() {}
+</script>
+
+<div data-testid="alivibe-stub" data-height={height} data-features={features ? 'yes' : 'no'}></div>

--- a/src/test/stubs/AlignmentViewerHarness.svelte
+++ b/src/test/stubs/AlignmentViewerHarness.svelte
@@ -1,0 +1,10 @@
+<script>
+	// Thin harness so a test can observe the editsSaved event without depending on how the
+	// testing-library version of the day exposes component events.
+	import AlignmentViewer from '../../lib/AlignmentViewer.svelte';
+
+	export let alignmentFile = null;
+	export let onSaved = () => {};
+</script>
+
+<AlignmentViewer {alignmentFile} on:editsSaved={(e) => onSaved(e.detail)} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
 	plugins: [sveltekit()],
 
 	resolve: {
-		dedupe: ['svelte']
+		dedupe: ['svelte'],
+		// Under Vitest, resolve packages to their BROWSER build. Without this, `svelte` resolves to
+		// its server entry and mount() throws "not available on the server", so no test can render a
+		// component — only reason it went unnoticed is that the one component test in the suite never
+		// actually called render(). Scoped to VITEST so dev and build are untouched.
+		...(process.env.VITEST ? { conditions: ['browser'] } : {})
 	},
 
 	test: {


### PR DESCRIPTION
Implements UX audit items **1.1, 1.3, 1.4, 1.5**, per the maintainer verdicts in `UX-QUALITY-OF-LIFE.md`.

Alignment-viewer edits now reach the analyses (they previously did not — FEL ran on the pre-edit alignment while the page said "Saved"); upload-time rewriting of the user's data is surfaced instead of filed in a log nobody reads; the Data tab's numbers are correct and legible; re-uploading a corrected file no longer mixes two alignments under one name.

**Contains a fix worth knowing about independently**: `vite.config.ts` needed `resolve.conditions: ['browser']` under VITEST, because `svelte` otherwise resolves to its server entry and `mount()` throws. No component test in this repo could render anything — masked because the one existing component test never called `render()`.

Also note 1.1 has **no e2e**, deliberately. There is no deterministic post-condition on the Data tab that discriminates fixed from unfixed, so the mechanism is pinned by a component test instead; the reasoning is recorded in the test file.

## Verification

Independently re-verified on the branch after the agents finished, not taken on trust:

- `npx vitest run` — 647 passed
- `npm run build` — clean

Every test was checked to fail with its own fix reverted; the actual failing output is in the commit message. Note the suite reports 16 skipped when run from a worktree — that is `meme-hit-likelihood`'s calibration corpus not resolving from that path, not a regression. It runs on `main`.

## Review notes

All six UX branches were cut from `dcf641e` in parallel and several touch `+page.svelte` and `MethodSelector.svelte`, so **merge order matters** and later ones will need a rebase. Suggested order is smallest-surface first: results → config → genetic-code → a11y → run-lifecycle → data-tab.
