### PR TITLE
UX audit batch 2: all 15 accepted items

### DIFF
--- a/PRIME-backend-implementation.md
+++ b/PRIME-backend-implementation.md
@@ -1,0 +1,228 @@
+# PRIME Backend Implementation Guide for datamonkey-js-server
+
+## Overview
+
+PRIME (PRoperty Informed Models of Evolution) needs to be added as a new analysis method in `datamonkey-js-server`. It follows the same Socket.IO pattern as all other methods (FEL, MEME, BUSTED, etc.).
+
+The frontend (datamonkey3) is already wired up and will emit `prime:spawn` events with the payload described below.
+
+## Socket.IO Events to Implement
+
+### `prime:spawn` — Start analysis
+
+The server must listen for this event and launch `hyphy prime` with the provided parameters.
+
+**Incoming payload:**
+```json
+{
+  "alignment": "<FASTA or NEXUS alignment data>",
+  "tree": "<Newick tree string, possibly with {FG} branch tags>",
+  "job": {
+    "id": "job-prime-1739856000000-abc123",
+    "analysis_type": "prime",
+    "gencodeid": 0,
+    "branches": "All",
+    "property-set": "5PROP",
+    "pvalue": 0.1,
+    "impute-states": "No"
+  }
+}
+```
+
+**Parameter details:**
+
+| Parameter | Type | Default | Values | Maps to HyPhy CLI |
+|-----------|------|---------|--------|-------------------|
+| `gencodeid` | number | `0` | 0-11 | `--code Universal` (mapped from numeric ID) |
+| `branches` | string | `"All"` | `All`, `Internal`, `Leaves`, `Unlabeled`, `FG` | `--branches` |
+| `property-set` | string | `"5PROP"` | `5PROP`, `4PROP`, `3PROP`, `2PROP`, `Atchley`, `LCAP` | `--property-set` |
+| `pvalue` | number | `0.1` | 0.001-1.0 | `--pvalue` |
+| `impute-states` | string | `"No"` | `Yes`, `No` | `--impute-states` |
+
+When `branches` is `"FG"`, the tree string will contain `{FG}` tags on selected branches (e.g., `Human{FG}:0.004`). The server should pass the tagged tree as-is and use `--branches FG`.
+
+### `prime:check` — Validate parameters (optional)
+
+**Incoming payload:**
+```json
+{
+  "job": {
+    "analysis_type": "prime",
+    "gencodeid": 0,
+    "branches": "All",
+    "property-set": "5PROP",
+    "pvalue": 0.1,
+    "impute-states": "No"
+  }
+}
+```
+
+**Response:** Emit `validated` event:
+```json
+{ "valid": true }
+```
+or
+```json
+{ "valid": false, "errors": ["property-set must be one of: 5PROP, 4PROP, 3PROP, 2PROP, Atchley, LCAP"] }
+```
+
+### `prime:resubscribe` — Reconnect to running job
+
+**Incoming payload:**
+```json
+{ "id": "job-prime-1739856000000-abc123" }
+```
+
+Re-attach the socket to an existing running job so the client receives `status update` and `completed` events again. This supports page refresh recovery.
+
+## Events the Server Must Emit
+
+These are the same events used by all other methods:
+
+### `status update` — Progress updates
+```json
+{
+  "jobId": "job-prime-1739856000000-abc123",
+  "progress": 45,
+  "msg": "Fitting PRIME model to site 120/300",
+  "phase": "running"
+}
+```
+
+### `completed` — Analysis finished
+```json
+{
+  "jobId": "job-prime-1739856000000-abc123",
+  "results": { /* parsed contents of .PRIME.json */ }
+}
+```
+
+The results object should be the parsed JSON from HyPhy's output file (`*.PRIME.json`).
+
+### `script error` — Analysis failed
+```json
+{
+  "message": "Error description here"
+}
+```
+
+## HyPhy Command Construction
+
+The server should build and execute a command like:
+
+```bash
+hyphy prime \
+  --alignment /path/to/input.fasta \
+  --tree /path/to/input.tree \
+  --code Universal \
+  --branches All \
+  --property-set 5PROP \
+  --pvalue 0.1 \
+  --impute-states No
+```
+
+**Genetic code mapping** (numeric ID to HyPhy string):
+
+| ID | Value |
+|----|-------|
+| 0 | `Universal` |
+| 1 | `Vertebrate mtDNA` |
+| 2 | `Yeast mtDNA` |
+| 3 | `Mold/Protozoan mtDNA` |
+| 4 | `Invertebrate mtDNA` |
+| 5 | `Ciliate Nuclear` |
+| 6 | `Echinoderm mtDNA` |
+| 7 | `Euplotid Nuclear` |
+| 8 | `Alt. Yeast Nuclear` |
+| 9 | `Ascidian mtDNA` |
+| 10 | `Flatworm mtDNA` |
+| 11 | `Blepharisma Nuclear` |
+
+**Result file:** HyPhy writes results to `<input>.PRIME.json` (e.g., `input.fasta.PRIME.json`).
+
+## Implementation Pattern
+
+Follow the same pattern as existing methods. For reference, here is how a typical method is structured in the server (using FEL as an example):
+
+### 1. Create the method handler module
+
+Create a file like `app/prime/prime.js` (or wherever your method handlers live). It should:
+
+- Accept the socket connection and job parameters
+- Write the alignment and tree to temporary files
+- Build the HyPhy CLI command
+- Spawn the HyPhy process
+- Parse stdout for progress updates and emit `status update` events
+- Read the `.PRIME.json` result file when the process completes
+- Emit `completed` with the parsed JSON results
+- Emit `script error` if the process fails
+
+### 2. Register socket events
+
+In your main socket handler (e.g., `app/routes/socket.js` or equivalent):
+
+```javascript
+socket.on('prime:spawn', function(data) {
+  prime.spawn(socket, data);
+});
+
+socket.on('prime:check', function(data) {
+  // Optional: validate parameters
+  socket.emit('validated', { valid: true });
+});
+
+socket.on('prime:resubscribe', function(data) {
+  // Re-attach socket to running job by data.id
+  prime.resubscribe(socket, data.id);
+});
+```
+
+### 3. Parameter validation checklist
+
+- `property-set` must be one of: `5PROP`, `4PROP`, `3PROP`, `2PROP`, `Atchley`, `LCAP`
+- `branches` must be one of: `All`, `Internal`, `Leaves`, `Unlabeled`, `FG`
+- `pvalue` must be a number between 0.001 and 1.0
+- `impute-states` must be `Yes` or `No`
+- `gencodeid` must be 0-11
+- Alignment data must be valid FASTA or NEXUS
+- Tree data should be valid Newick (if `branches` is `FG`, tree must contain `{FG}` tags)
+
+## Testing
+
+The frontend includes a test pattern you can adapt. Create `src/test/prime-backend.test.js`:
+
+```javascript
+const PRIME_PARAMS = {
+  analysis_type: 'prime',
+  genetic_code: 'Universal',
+  branches: 'All',
+  'property-set': '5PROP',
+  pvalue: 0.1,
+  'impute-states': 'No'
+};
+
+// Submit via socket
+socket.emit('prime:spawn', {
+  alignment: TEST_FASTA,
+  tree: TEST_TREE,
+  job: PRIME_PARAMS
+});
+
+// Listen for results
+socket.on('completed', (data) => {
+  console.log('PRIME results:', data.results);
+});
+```
+
+## Quick Reference: Existing Method Patterns
+
+| Frontend method key | Backend socket event | HyPhy command |
+|---------------------|---------------------|---------------|
+| `fel` | `fel:spawn` | `hyphy fel` |
+| `meme` | `meme:spawn` | `hyphy meme` |
+| `busted` | `busted:spawn` | `hyphy busted` |
+| `absrel` | `absrel:spawn` | `hyphy absrel` |
+| `contrast-fel` | `cfel:spawn` | `hyphy contrast-fel` |
+| `multi-hit` | `multihit:spawn` | `hyphy fmm` |
+| `relax` | `relax:spawn` | `hyphy relax` |
+| **`prime`** | **`prime:spawn`** | **`hyphy prime`** |

--- a/design/2.2-method-chooser/00-current.html
+++ b/design/2.2-method-chooser/00-current.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>00 — What ships today</title>
+		<link rel="stylesheet" href="_wf.css" />
+	</head>
+	<body>
+		<div class="sheet">
+			<div class="hdr">
+				<h1>State 00 · baseline</h1>
+				<p>What ships today</p>
+				<div class="sub">
+					Drawn from <code>MethodSelector.svelte:1351&ndash;1359</code> (the
+					<code>&lt;select&gt;</code>), <code>:1005&ndash;1020</code> (the sort) and
+					<code>:1716&ndash;1723</code> (the hint). The list order below is not a guess: it is
+					<code>Array.sort((a,b) =&gt; a.info.name.localeCompare(b.info.name))</code> run over the
+					sixteen <code>METHOD_INFO</code> names.
+				</div>
+			</div>
+
+			<div>
+				<div class="screen">
+					<div class="panel-hd">Analysis <span class="chev">&#9650;</span></div>
+					<div class="body">
+						<div class="selbox">
+							<span>Select an analysis method</span><span class="chev">&#9662;</span>
+						</div>
+						<div class="optlist">
+							<div>aBSREL - adaptive Branch-Site Random Effects Likelihood</div>
+							<div>AxoMEME - AxoMEME 2.0 — neural surrogate for MEME (Beta)</div>
+							<div>B-STILL - Bayesian Significance Test of Invariant Low Likelihoods</div>
+							<div>BGM - Bayesian Graphical Model</div>
+							<div>BUSTED - Branch-site Unrestricted Statistical Test for Episodic Diversification</div>
+							<div>Contrast-FEL - Contrast Fixed Effects Likelihood</div>
+							<div class="dim">FADE - FUBAR Approach to Directional Evolution (Coming Soon)</div>
+							<div class="mark">FEL - Fixed Effects Likelihood</div>
+							<div class="mark">FUBAR - Fast Unconstrained Bayesian AppRoximation</div>
+							<div>GARD - Genetic Algorithm for Recombination Detection</div>
+							<div class="mark">MEME - Mixed Effects Model of Evolution</div>
+							<div>MULTI-HIT - Multiple Hit Model</div>
+							<div>NRM - Non-Reversible Model</div>
+							<div>PRIME - PRoperty Informed Models of Evolution</div>
+							<div>RELAX - Relaxation Test</div>
+							<div class="mark">SLAC - Single-Likelihood Ancestor Counting</div>
+						</div>
+						<div class="hint">
+							<span>?</span>
+							<span
+								>For detecting selection at sites, try FEL or MEME. For recombination detection, use
+								GARD.</span
+							>
+						</div>
+						<p class="caption">
+							Highlighted rows are the four methods the code <em>intends</em> to float to the top.
+							They sit at positions 8, 9, 11 and 16.
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="notes">
+				<h3>What is actually wrong</h3>
+
+				<div class="note accent">
+					<b>The prioritisation has never run.</b>
+					<code>:1013</code> declares <code>priority = ['fel','meme','slac','fubar']</code> and looks
+					up <code>priority.indexOf(a.id)</code>. But <code>a.id</code> is a
+					<code>methodConfig</code> key — <code>'FEL'</code>, <code>'MEME'</code> — so every lookup
+					returns &minus;1 and the whole branch is dead. Verified by running the real comparator:
+					FEL lands 8th, MEME 11th, SLAC last.
+				</div>
+
+				<div class="note">
+					<b>Full names are not differentiators.</b>
+					"Fixed Effects Likelihood" and "Mixed Effects Model of Evolution" are equally opaque to
+					someone who does not already know which to use. The strings that would actually help —
+					<code>shortDescription</code> — exist at <code>:43&ndash;147</code> and render only
+					<em>after</em> selection (<code>:1363</code>).
+				</div>
+
+				<div class="note">
+					<b>The one orienting sentence is gated on not having chosen.</b>
+					<code>{#if !selectedMethod}</code> at <code>:1716</code>. It disappears at the exact moment
+					a user might want to reconsider, and never returns.
+				</div>
+
+				<div class="note">
+					<b>Four kinds of thing are shown as one kind.</b>
+					A per-site test (FEL), a per-branch test (aBSREL), a gene-wide test (BUSTED), a
+					recombination screen you run <em>before</em> any of them (GARD) and a neural surrogate for
+					one of the others (AxoMEME) are sixteen equal rows in an alphabetical list.
+				</div>
+
+				<div class="note">
+					<b>FADE has been "Coming Soon" indefinitely.</b>
+					It is in <code>methodConfig</code> (<code>+page.svelte:137</code>) but not in
+					<code>SUPPORTED_METHODS</code> (<code>:24&ndash;40</code>), so it renders permanently
+					disabled. A promise with no date is not a promise.
+				</div>
+
+				<div class="note">
+					<b>Vertical cost today: 111&nbsp;px.</b>
+					39&nbsp;px select + 12&nbsp;px gap + 60&nbsp;px description block. Remember this number —
+					every proposal has to be measured against it, not against zero.
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/design/2.2-method-chooser/01-nothing-selected.html
+++ b/design/2.2-method-chooser/01-nothing-selected.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>01 — Nothing selected</title>
+		<link rel="stylesheet" href="_wf.css" />
+	</head>
+	<body>
+		<div class="sheet">
+			<div class="hdr">
+				<h1>State 01 · the decision is live</h1>
+				<p>Nothing selected</p>
+				<div class="sub">
+					The <code>&lt;select&gt;</code> is replaced by one radio group (<code>name="method"</code>)
+					split across six <code>&lt;fieldset&gt;</code>s whose <code>&lt;legend&gt;</code> is the
+					biological question. Fifteen methods; ten visible.
+				</div>
+			</div>
+
+			<div>
+				<div class="screen">
+					<div class="panel-hd">Analysis <span class="chev">&#9650;</span></div>
+					<div class="body">
+						<div class="grp">
+							<div class="q">Which sites are under selection?</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">FEL</span
+								><span class="ds">Maximum-likelihood test at every site. The usual first choice.</span>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">MEME</span
+								><span class="ds"
+									>Finds selection acting on only some branches at a site — sites FEL can miss.</span
+								>
+							</div>
+							<div class="subwrap">
+								<div class="row">
+									<i class="rb"></i><span class="nm">AxoMEME<span class="badge">Beta</span></span
+									><span class="ds"
+										>Predicts what MEME would report, in seconds. Downloads 17&nbsp;MB on first run;
+										use it to rank sites, then confirm with MEME.</span
+									>
+								</div>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">FUBAR</span
+								><span class="ds"
+									>Bayesian. Faster on large alignments; reports posterior probabilities, not
+									p&#8209;values.</span
+								>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">SLAC</span
+								><span class="ds">Counting&#8209;based approximation. Fastest, least sensitive.</span>
+							</div>
+						</div>
+
+						<div class="grp">
+							<div class="q">Which branches are under selection?</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">aBSREL</span
+								><span class="ds">Tests every branch for episodic selection.</span>
+							</div>
+						</div>
+
+						<div class="grp">
+							<div class="q">Is this gene under selection at all?</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">BUSTED</span
+								><span class="ds">One gene&#8209;wide answer. No per&#8209;site or per&#8209;branch detail.</span>
+							</div>
+						</div>
+
+						<div class="grp">
+							<div class="q">Did selection differ between groups of branches?</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">Contrast-FEL</span
+								><span class="ds">Compares selection at each site between groups you define.</span>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">RELAX</span
+								><span class="ds"
+									>Tests whether selection is relaxed or intensified in one group versus another.</span
+								>
+							</div>
+						</div>
+
+						<div class="grp">
+							<div class="q">Before you test selection</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">GARD</span
+								><span class="ds"
+									>Finds recombination breakpoints. Unmodelled recombination inflates false positives
+									in every test above.</span
+								>
+							</div>
+						</div>
+
+						<div class="disc">
+							<span class="tri">&#9654;</span> Specialised analyses <span class="cnt">(5)</span>
+						</div>
+					</div>
+				</div>
+				<p class="caption">
+					Screen height 563&nbsp;px. Ten rows &times; 30&nbsp;px, five legends &times; 29&nbsp;px, four
+					group gaps &times; 14&nbsp;px, disclosure 34&nbsp;px, body padding 28&nbsp;px.
+				</p>
+			</div>
+
+			<div class="notes">
+				<h3>Why this shape</h3>
+
+				<div class="note accent">
+					<b>A dropdown is the wrong control for this decision.</b>
+					A <code>&lt;select&gt;</code> is a retrieval control: it is right when you know the value
+					you want (genetic code, p&#8209;value). Choosing a method is a <em>comparison</em> among
+					four or five candidates. Comparison needs them all on screen at once. Every other control
+					in this panel stays a <code>&lt;select&gt;</code>; only this one changes, because only this
+					one is a comparison.
+				</div>
+
+				<div class="note accent">
+					<b>The headings are the guidance.</b>
+					No tooltips, no help panel, no per&#8209;method "learn more". The question a user arrives
+					with is printed above the methods that answer it, and — see state 02 — it survives
+					selection. This replaces the hint at <code>:1716</code> rather than adding to it.
+				</div>
+
+				<div class="note">
+					<b>Group order is frequency of the question, not the alphabet.</b>
+					"Which sites" first because it is the question most Datamonkey users arrive with, and
+					because it is what the dead <code>priority</code> array at <code>:1013</code> was trying to
+					express. Within a group, order is FEL, MEME, FUBAR, SLAC — the intended priority, now
+					actually rendered.
+				</div>
+
+				<div class="note accent">
+					<b>AxoMEME is indented under MEME because it is not a peer of it.</b>
+					It predicts MEME's output; it is not another way to ask the question. The indent is
+					39&nbsp;px so its description column still lands on the parent description column — a
+					second alignment axis, not a broken one. Its cost (17&nbsp;MB) is on the row, because the
+					block that used to state it — <code>:1383&ndash;1392</code>, gated on
+					<code>browserOnly</code> — is dead: nothing in <code>methodConfig</code> sets that flag any
+					more, so the download is currently never announced.
+				</div>
+
+				<div class="note">
+					<b>GARD gets its own legend because it is not a selection test.</b>
+					It is a screen you run <em>first</em>. Listing it as the tenth of sixteen peers
+					misrepresents the workflow. One line states the consequence of skipping it, which is the
+					single most useful sentence on this screen for a user who does not already know it.
+				</div>
+
+				<div class="note">
+					<b>Five methods are collapsed, one is deleted.</b>
+					BGM, PRIME, MULTI&#8209;HIT, NRM and B&#8209;STILL answer questions you do not arrive with
+					by accident; a user who wants PRIME knows the word "PRIME". FADE is removed from the list
+					entirely — leave the <code>methodConfig</code> entry, drop the permanently disabled row.
+				</div>
+
+				<div class="note">
+					<b>No method is preselected.</b>
+					<code>+page.svelte:60</code> sets <code>selectedMethod = 'FEL'</code> and it never reaches
+					this component. Leave it that way. Silently choosing a statistical test for a user is not a
+					convenience; it is a claim about their data that the software cannot make.
+				</div>
+
+				<div class="note">
+					<b>Cost: +478&nbsp;px, in a region that is empty.</b>
+					563&nbsp;px against today's 85&nbsp;px (select + hint). Everything below is gated on
+					<code>{#if selectedMethod}</code>, so before a choice this panel holds nothing else. The
+					space is spent where the decision is, once, and state 02 gives it back.
+				</div>
+
+				<div class="note">
+					<b>Keyboard and screen readers.</b>
+					One <code>name</code> across nested <code>&lt;fieldset&gt;</code>s: arrows traverse all
+					fifteen (only one can be chosen), legends are announced on entry. Do not build a listbox.
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/design/2.2-method-chooser/02-method-selected.html
+++ b/design/2.2-method-chooser/02-method-selected.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>02 — A method is selected</title>
+		<link rel="stylesheet" href="_wf.css" />
+	</head>
+	<body>
+		<div class="sheet">
+			<div class="hdr">
+				<h1>State 02 · the decision is made</h1>
+				<p>A method is selected</p>
+				<div class="sub">
+					The chooser collapses to a single row the moment a method is chosen, and the space returns
+					to configuration — which is what the user needs next. The question they answered stays on
+					screen.
+				</div>
+			</div>
+
+			<div>
+				<div class="screen">
+					<div class="panel-hd">Analysis <span class="chev">&#9650;</span></div>
+					<div class="body">
+						<div class="summary">
+							<div>
+								<div class="q2">Which sites are under selection?</div>
+								<div class="nm2">FEL <span class="full">· Fixed Effects Likelihood</span></div>
+								<div class="ds2">Maximum-likelihood test at every site. The usual first choice.</div>
+							</div>
+							<div class="acts">
+								<a href="#">Change</a>
+								<a href="#">Method docs &#8599;</a>
+							</div>
+						</div>
+
+						<div class="stub">Execution mode &mdash; Local (Browser) / Backend Server</div>
+						<div class="stub">Genetic code &mdash; Universal</div>
+						<div class="stub">Branches to test &mdash; All</div>
+						<div class="stub">Advanced options (p&#8209;value, SRV, output)</div>
+						<div class="stub">Before you run &mdash; runtime estimate (RunOutlook)</div>
+						<div class="runbtn">&#9654;&nbsp; Run FEL Analysis</div>
+					</div>
+				</div>
+				<p class="caption">Summary row 81&nbsp;px. Today's select + description block: 111&nbsp;px.</p>
+
+				<div class="screen rejected">
+					<div class="panel-hd">Analysis</div>
+					<div class="body">
+						<div class="selbox">
+							<span>FEL - Fixed Effects Likelihood</span><span class="chev">&#9662;</span>
+						</div>
+						<div style="font-size: 13px; color: #4a5568; padding: 8px 0 24px">
+							Detect selection at individual sites
+						</div>
+						<div class="stub">Execution mode</div>
+					</div>
+				</div>
+				<p class="caption">
+					Today, for comparison: the orienting sentence has vanished, and nothing on screen says what
+					question FEL answers or that there were alternatives.
+				</p>
+			</div>
+
+			<div class="notes">
+				<h3>Why this shape</h3>
+
+				<div class="note accent">
+					<b>The question line is the whole fix for the vanishing hint.</b>
+					"Which sites are under selection?" sits above the chosen method for the rest of the
+					session. It costs one 17&nbsp;px line and it is the only thing on this screen that tells a
+					returning user what they decided and on what basis. Nothing new is invented: it is the
+					legend from state 01, kept.
+				</div>
+
+				<div class="note accent">
+					<b>Steady state is 14&nbsp;px smaller than today.</b>
+					81&nbsp;px summary + 16&nbsp;px margin = 97&nbsp;px, against 111&nbsp;px for the current
+					select plus its description block. The 478&nbsp;px spent in state 01 is not carried; it is
+					borrowed for the length of the decision and repaid on the click that ends it.
+				</div>
+
+				<div class="note">
+					<b>"Change" reopens the chooser in place, with FEL still selected.</b>
+					It must not clear <code>methodOptions</code>. A user comparing FEL against FUBAR should be
+					able to look and come back without losing a branch selection they spent five minutes
+					tagging on a tree.
+				</div>
+
+				<div class="note">
+					<b>One documentation link, here, and nowhere else.</b>
+					<code>methodConfig[method].url</code> (<code>+page.svelte:74&ndash;197</code>) holds a
+					hyphy.org slug for all sixteen methods and is read by nothing. Surface it once, on the
+					method actually chosen, at the moment before committing. Fifteen links in the chooser would
+					be the documentation layer this feature must not become. Mark it as leaving the app
+					(&#8599;) — it is an outbound link, and the local-serving constraint in
+					<code>CLAUDE.md</code> is about fetched assets, not hyperlinks.
+				</div>
+
+				<div class="note">
+					<b>Do not add a runtime label to the chooser.</b>
+					<code>RunOutlook</code> (<code>:1445&ndash;1456</code>) already states expected runtime for
+					<em>this</em> alignment, which a static "Slow" badge cannot. The audit says this and the
+					audit is right.
+				</div>
+
+				<div class="note">
+					<b>The Beta badge moves with the method.</b>
+					If AxoMEME is the selection, the summary row reads "Which sites are under selection? ·
+					AxoMEME [Beta] · Predicts what MEME would report…" — the surrogate relationship is
+					restated, not dropped, because that is exactly the claim a user is about to publish
+					against.
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/design/2.2-method-chooser/03-file-cannot-support.html
+++ b/design/2.2-method-chooser/03-file-cannot-support.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>03 — The file cannot support the method</title>
+		<link rel="stylesheet" href="_wf.css" />
+	</head>
+	<body>
+		<div class="sheet">
+			<div class="hdr">
+				<h1>State 03 · requirements</h1>
+				<p>When the uploaded file cannot support a method</p>
+				<div class="sub">
+					The audit proposes a per&#8209;method codon&#8209;alignment requirement line driven by
+					<code>CODON_AWARE_METHODS</code>. I checked what that predicate is actually worth in this
+					product, and it is worth nothing. Panel A is overruled. Panels B and C are the correct
+					design.
+				</div>
+			</div>
+
+			<div>
+				<div class="screen rejected">
+					<div class="panel-hd">A &mdash; proposed: requirement text per method</div>
+					<div class="body">
+						<div class="grp">
+							<div class="q">Which sites are under selection?</div>
+							<div class="row off">
+								<i class="rb"></i><span class="nm">FEL</span
+								><span class="ds">Needs a codon alignment &mdash; your file is a nucleotide alignment.</span>
+							</div>
+							<div class="row off">
+								<i class="rb"></i><span class="nm">MEME</span
+								><span class="ds">Needs a codon alignment &mdash; your file is a nucleotide alignment.</span>
+							</div>
+							<div class="row off">
+								<i class="rb"></i><span class="nm">FUBAR</span
+								><span class="ds">Needs a codon alignment &mdash; your file is a nucleotide alignment.</span>
+							</div>
+							<div class="row off">
+								<i class="rb"></i><span class="nm">SLAC</span
+								><span class="ds">Needs a codon alignment &mdash; your file is a nucleotide alignment.</span>
+							</div>
+						</div>
+						<div class="grp">
+							<div class="q">Which branches are under selection?</div>
+							<div class="row off">
+								<i class="rb"></i><span class="nm">aBSREL</span
+								><span class="ds">Needs a codon alignment &mdash; your file is a nucleotide alignment.</span>
+							</div>
+						</div>
+						<p class="caption">…and the same sentence eight more times.</p>
+					</div>
+				</div>
+				<p class="caption">
+					Twelve of fifteen methods, all saying the same thing, about a condition that is true of
+					every file the app can hold.
+				</p>
+
+				<div class="screen">
+					<div class="panel-hd">B &mdash; correct: one statement, about the file</div>
+					<div class="body">
+						<div class="warn">
+							<b>hiv&#8209;env.fasta was not read as an alignment of codons.</b>
+							3,241 columns is not a multiple of three. Every analysis on this page reads codons, so
+							none can run until this is fixed.
+							<span class="fix">Open in Data &rarr;</span>
+						</div>
+						<p class="caption" style="margin-top: 12px">
+							The chooser is not rendered. There is no choice to make.
+						</p>
+					</div>
+				</div>
+
+				<div class="screen">
+					<div class="panel-hd">C &mdash; correct: the check that actually varies</div>
+					<div class="body">
+						<div class="summary">
+							<div>
+								<div class="q2">Which sites are under selection?</div>
+								<div class="nm2">FEL <span class="full">· Fixed Effects Likelihood</span></div>
+							</div>
+							<div class="acts"><a href="#">Change</a><a href="#">Method docs &#8599;</a></div>
+						</div>
+						<div class="stub">Execution mode &mdash; Local (Browser)</div>
+						<div
+							class="stub"
+							style="border-style: solid; border-color: #18181b; color: #18181b; background: #fff"
+						>
+							Genetic code &mdash; Vertebrate mitochondrial &#9662;
+						</div>
+						<div class="warn quiet" style="margin-top: 8px">
+							<b>3 stop codons under the vertebrate mitochondrial code.</b>
+							Columns 145, 148 and 302. Your file was read as codons under the universal code, where
+							these are AGA/AGG. FEL will refuse this combination.
+						</div>
+						<div class="runbtn dead">&#9654;&nbsp; Run FEL Analysis</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="notes">
+				<h3>Why A is overruled</h3>
+
+				<div class="note accent">
+					<b>The app cannot hold a non&#8209;codon alignment.</b>
+					<code>datareader.bf:189</code> sets <code>genCodeID = 0</code> and nothing overrides it —
+					<code>+page.svelte:886</code> runs the script with no arguments. So
+					<code>:255</code> rejects any alignment whose column count is not divisible by three,
+					<code>:238&ndash;244</code> rejects anything that is not four&#8209;state, and
+					<code>:262</code> rejects an all&#8209;stop&#8209;codon file. Upload fails; the file never
+					becomes current.
+				</div>
+
+				<div class="note accent">
+					<b>Therefore <code>FILE_INFO.gencodeid</code> is always 0.</b>
+					The &minus;1/&minus;2 branches are unreachable. Which also means the GARD datatype
+					auto&#8209;detect at <code>MethodSelector.svelte:1082&ndash;1092</code> always resolves to
+					<code>'codon'</code> — a third dead path in this component, alongside the priority sort and
+					<code>browserOnly</code>.
+				</div>
+
+				<div class="note">
+					<b>A predicate that never varies is not information.</b>
+					Twelve identical lines would cost twelve rows of attention to say something that is true by
+					construction. Principle 10: this is not annotation, it is noise with a citation.
+				</div>
+
+				<div class="note">
+					<b>Do not sort unsupported methods into a trailing group either.</b>
+					The audit proposes that. It would move a method to a different place depending on the file,
+					so FEL is in a different position on different days — and it blames the method for a
+					problem that belongs to the file.
+				</div>
+
+				<h3>What B and C fix</h3>
+
+				<div class="note accent">
+					<b>B closes a real hole.</b>
+					<code>+page.svelte:804</code> persists the upload <em>before</em> datareader runs, and the
+					<code>catch</code> at <code>:1058</code> never removes it. A rejected file stays in the file
+					list and can be made current later, at which point
+					<code>MethodSelector</code> renders normally over metrics that were never produced. One
+					statement, above the chooser, naming the file and the actual number.
+				</div>
+
+				<div class="note accent">
+					<b>C is the check the audit was reaching for, in the right place.</b>
+					<code>BaseAnalysisRunner.js:291&ndash;297</code> re&#8209;validates against
+					<code>config.geneticCodeId</code>, <em>not</em> the universal code datareader used. A file
+					that uploaded cleanly can fail under vertebrate mitochondrial, where AGA/AGG are stops.
+					That is the only pre&#8209;run codon failure a user can still reach — and it is caused by a
+					control on this screen, so it belongs beside that control, not in the method list.
+				</div>
+
+				<div class="note">
+					<b>It is already computable, cheaply.</b>
+					<code>findStopCodons</code> and <code>formatStopCodonReport</code>
+					(<code>fastaValidation.js:591&ndash;593</code>) report alignment columns, and
+					<code>canonicalFasta</code> is in the store. Run it on genetic-code change, not on every
+					keystroke.
+				</div>
+
+				<div class="note">
+					<b>Hand C to audit item 1.2.</b>
+					Genetic code is that item's surface. Stating it here so the requirement is not lost is
+					correct; building it inside the method chooser is scope creep. The chooser's obligation
+					ends at panel B.
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/design/2.2-method-chooser/04-specialised-open.html
+++ b/design/2.2-method-chooser/04-specialised-open.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>04 — Specialised analyses expanded</title>
+		<link rel="stylesheet" href="_wf.css" />
+	</head>
+	<body>
+		<div class="sheet">
+			<div class="hdr">
+				<h1>State 04 · the long tail</h1>
+				<p>Specialised analyses, expanded</p>
+				<div class="sub">
+					Where the five remaining methods live. Drawn because a disclosure whose contents nobody
+					drew is a place to hide things.
+				</div>
+			</div>
+
+			<div>
+				<div class="screen">
+					<div class="panel-hd">Analysis <span class="chev">&#9650;</span></div>
+					<div class="body">
+						<div class="grp" style="opacity: 0.45">
+							<div class="q">Which sites are under selection?</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">FEL</span
+								><span class="ds">Maximum-likelihood test at every site. The usual first choice.</span>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">MEME</span
+								><span class="ds">Finds selection acting on only some branches at a site.</span>
+							</div>
+						</div>
+						<p class="caption" style="margin: -6px 0 12px 4px">…groups 1&ndash;5 as in state 01…</p>
+
+						<div class="disc" style="border-bottom: 1px solid #ececee; padding-bottom: 8px">
+							<span class="tri">&#9660;</span> Specialised analyses <span class="cnt">(5)</span>
+						</div>
+						<div class="grp" style="margin-top: 8px">
+							<div class="row">
+								<i class="rb"></i><span class="nm">PRIME</span
+								><span class="ds"
+									>Tests which biochemical properties selection is conserving or changing, site by
+									site.</span
+								>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">BGM</span
+								><span class="ds"
+									>Finds pairs of sites whose substitutions co&#8209;occur along the tree.</span
+								>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">MULTI-HIT</span
+								><span class="ds"
+									>Tests whether two or three nucleotides in a codon change at once.</span
+								>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">NRM</span
+								><span class="ds"
+									>Non&#8209;reversible model: estimates directional composition change.</span
+								>
+							</div>
+							<div class="row">
+								<i class="rb"></i><span class="nm">B-STILL</span
+								><span class="ds"
+									>Identifies sites that have not changed anywhere in the tree.</span
+								>
+							</div>
+						</div>
+					</div>
+				</div>
+				<p class="caption">
+					Expanded height +182&nbsp;px. Collapsed by default; sticky per session once opened, not
+					persisted forever.
+				</p>
+			</div>
+
+			<div class="notes">
+				<h3>Why these five, and why hidden</h3>
+
+				<div class="note accent">
+					<b>The test is whether the user arrives knowing the name.</b>
+					Nobody arrives at Datamonkey asking "which pairs of my sites co&#8209;evolve?" and hopes to
+					discover BGM by scanning. They arrive having read a paper that used BGM. A method reached
+					by name does not need to compete for attention with FEL; it needs to be findable, which a
+					labelled disclosure is.
+				</div>
+
+				<div class="note">
+					<b>Order inside the group is by how often it is run, not alphabetically.</b>
+					If the maintainers have usage data, use it and say so in a code comment. If not, the order
+					drawn here is a defensible default and should be revisited once data exists — not left to
+					<code>localeCompare</code>, which is what produced the current list.
+				</div>
+
+				<div class="note">
+					<b>The count is in the label.</b>
+					"Specialised analyses (5)" — a disclosure that does not say how much is behind it invites
+					the user to open it to find out, which costs the click the disclosure was meant to save.
+				</div>
+
+				<div class="note">
+					<b>These descriptions need a domain expert's signature.</b>
+					I have written them to be defensible, but "conserving or changing" for PRIME and the NRM
+					line are the two most likely to be subtly wrong. The audit says to pull in a domain expert
+					for the group names; extend that to these five rows. Do not ship a description nobody with
+					the domain knowledge has read.
+				</div>
+
+				<div class="note">
+					<b>Fix the duplicate key while you are here.</b>
+					<code>'b-still'</code> appears twice in <code>METHOD_ADVANCED_OPTIONS</code>
+					(<code>MethodSelector.svelte:419</code> and <code>:463</code>); the second silently wins, so
+					the grid&#8209;points help text a user reads is not the one the first author wrote. Not a
+					chooser bug, but it is in this file and it is one line.
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/design/2.2-method-chooser/_wf.css
+++ b/design/2.2-method-chooser/_wf.css
@@ -1,0 +1,112 @@
+/* Wireframe stylesheet — greyscale + one accent (#4338ca), system stack.
+   Deliberately unfinished so the argument is about structure, not colour.
+   Inlined into every NN-*.html so each file stands alone. */
+* { box-sizing: border-box; }
+body {
+	margin: 0;
+	font: 14px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+	background: #f4f4f5;
+	color: #18181b;
+	-webkit-font-smoothing: antialiased;
+}
+.sheet {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 32px;
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 30px 24px 56px;
+	align-items: start;
+}
+.hdr { grid-column: 1 / -1; border-bottom: 1px solid #d4d4d8; padding-bottom: 12px; }
+.hdr h1 { font-size: 11px; margin: 0 0 5px; letter-spacing: 0.09em; text-transform: uppercase; color: #71717a; font-weight: 700; }
+.hdr p { margin: 0; font-size: 19px; font-weight: 600; letter-spacing: -0.01em; }
+.hdr .sub { margin-top: 5px; font-size: 12.5px; color: #52525b; font-weight: 400; max-width: 74ch; }
+
+.screen { background: #fff; border: 1px solid #d4d4d8; }
+.screen + .screen { margin-top: 26px; }
+.panel-hd { background: #fafafa; border-bottom: 1px solid #e4e4e7; padding: 9px 16px; font-weight: 600; font-size: 12.5px; display: flex; justify-content: space-between; align-items: center; }
+.panel-hd span.chev { color: #a1a1aa; font-size: 11px; }
+.body { padding: 14px 16px; }
+
+/* --- question groups --- */
+.grp { margin: 0 0 14px; }
+.grp:last-child { margin-bottom: 0; }
+.q { font-size: 12.5px; font-weight: 600; color: #18181b; margin: 0 0 5px; padding-bottom: 4px; border-bottom: 1px solid #ececee; }
+.q .qn { color: #a1a1aa; font-weight: 400; }
+
+.row { display: grid; grid-template-columns: 18px 104px minmax(0, 1fr); align-items: baseline; column-gap: 10px; padding: 5px 4px; border-radius: 4px; }
+.rb { width: 13px; height: 13px; border: 1.5px solid #a1a1aa; border-radius: 50%; justify-self: center; position: relative; top: 3px; background: #fff; }
+.row.sel { background: #eef2ff; }
+.row.sel .rb { border-color: #4338ca; box-shadow: inset 0 0 0 2.5px #fff, inset 0 0 0 7px #4338ca; }
+.row.off .rb { border-style: dashed; border-color: #d4d4d8; }
+.row.off .nm, .row.off .ds { color: #a1a1aa; }
+.nm { font-weight: 600; font-size: 13.5px; }
+.ds { font-size: 12.5px; color: #52525b; }
+.ds em { font-style: normal; color: #18181b; }
+
+/* AxoMEME sub-row: indented 39px so its DESCRIPTION column still lands on the
+   parent description column (18+10+104+10 = 142 → 39 + 18+10+65+10 = 142). */
+.subwrap { margin-left: 28px; border-left: 1px solid #e4e4e7; padding-left: 10px; }
+.subwrap .row { grid-template-columns: 18px 65px minmax(0, 1fr); }
+.subwrap .nm { font-size: 12.5px; }
+.subwrap .ds { font-size: 12px; }
+
+.badge { display: inline-block; font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; padding: 1px 5px; border: 1px solid #a1a1aa; border-radius: 3px; color: #52525b; margin-left: 6px; position: relative; top: -1px; }
+
+.disc { display: flex; align-items: center; gap: 8px; font-size: 12.5px; font-weight: 600; color: #3f3f46; padding: 8px 4px 2px; border-top: 1px solid #ececee; margin-top: 4px; }
+.disc .tri { color: #71717a; font-size: 10px; }
+.disc .cnt { font-weight: 400; color: #a1a1aa; }
+
+/* --- selected summary --- */
+.summary { border: 1px solid #d4d4d8; border-radius: 5px; padding: 11px 13px; display: grid; grid-template-columns: minmax(0, 1fr) auto; column-gap: 14px; align-items: start; }
+.summary .q2 { font-size: 11.5px; color: #71717a; margin-bottom: 3px; }
+.summary .nm2 { font-size: 14px; font-weight: 600; }
+.summary .nm2 .full { font-weight: 400; color: #52525b; font-size: 13px; }
+.summary .ds2 { font-size: 12.5px; color: #52525b; margin-top: 2px; }
+.summary .acts { text-align: right; font-size: 12px; white-space: nowrap; }
+.summary .acts a { color: #4338ca; text-decoration: none; border-bottom: 1px solid #c7d2fe; display: block; }
+.summary .acts a + a { margin-top: 5px; }
+
+/* --- config stubs --- */
+.stub { height: 32px; border: 1px dashed #d4d4d8; border-radius: 4px; background: #fafafa; display: flex; align-items: center; padding: 0 11px; font-size: 11.5px; color: #a1a1aa; margin-top: 8px; letter-spacing: 0.02em; }
+.runbtn { margin-top: 12px; height: 38px; border: 1.5px solid #18181b; border-radius: 5px; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 13px; }
+.runbtn.dead { border-color: #d4d4d8; color: #a1a1aa; border-style: dashed; }
+
+/* --- warnings / blocks --- */
+.warn { border: 1px solid #d4d4d8; border-left: 3px solid #18181b; background: #fafafa; padding: 11px 13px; font-size: 12.5px; }
+.warn b { display: block; margin-bottom: 3px; font-size: 13px; }
+.warn .fix { margin-top: 8px; display: inline-block; border: 1px solid #18181b; border-radius: 4px; padding: 3px 9px; font-size: 12px; font-weight: 600; }
+.warn.quiet { border-left-color: #a1a1aa; }
+
+/* --- current-state mock --- */
+.selbox { border: 1px solid #cbd5e0; border-radius: 6px; padding: 8px 12px; font-size: 14px; color: #2d3748; display: flex; justify-content: space-between; }
+.optlist { border: 1px solid #cbd5e0; border-top: none; font-size: 13.5px; }
+.optlist div { padding: 4px 12px; border-bottom: 1px solid #f4f4f5; }
+.optlist div:last-child { border-bottom: none; }
+.optlist div.dim { color: #a0aec0; font-style: italic; }
+.optlist div.mark { background: #fef9c3; }
+.hint { display: flex; gap: 8px; margin-top: 12px; padding: 10px 14px; background: #f7fafc; border-radius: 6px; font-size: 12.5px; color: #4a5568; }
+
+/* --- annotations --- */
+.notes { font-size: 12.5px; line-height: 1.55; color: #3f3f46; position: sticky; top: 30px; }
+.notes h3 { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: #71717a; margin: 0 0 11px; font-weight: 700; }
+.note { border-left: 2px solid #d4d4d8; padding: 0 0 0 12px; margin: 0 0 15px; }
+.note b { display: block; font-weight: 600; color: #18181b; margin-bottom: 2px; }
+.note.accent { border-left-color: #4338ca; }
+.note code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px; background: #ececee; padding: 0 3px; border-radius: 2px; }
+
+.rejected { position: relative; }
+.rejected > * { opacity: 0.55; }
+.rejected::after { content: 'OVERRULED'; position: absolute; top: 9px; right: 12px; font-size: 9.5px; font-weight: 700; letter-spacing: 0.09em; border: 1.5px solid #18181b; padding: 2px 6px; color: #18181b; background: #fff; opacity: 1; }
+.caption { font-size: 11.5px; color: #71717a; margin: 7px 2px 0; }
+.dim-tag { font-size: 10.5px; color: #a1a1aa; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+/* --- narrow screen --- */
+.sheet.narrow { grid-template-columns: 375px 320px; }
+.sheet.narrow .screen { width: 375px; }
+.sheet.narrow .row { grid-template-columns: 18px minmax(0, 1fr); row-gap: 1px; }
+.sheet.narrow .row .ds { grid-column: 2; }
+.sheet.narrow .subwrap .row { grid-template-columns: 18px minmax(0, 1fr); }
+.sheet.narrow .summary { grid-template-columns: minmax(0, 1fr); row-gap: 9px; }
+.sheet.narrow .summary .acts { text-align: left; }

--- a/e2e/06-method-config.spec.js
+++ b/e2e/06-method-config.spec.js
@@ -86,9 +86,12 @@ test.describe('Method Selection & Configuration', () => {
 			has: page.locator('option:text("Universal")')
 		}).first();
 
-		await geneticCodeSelect.selectOption('Vertebrate mitochondrial');
-		// Verify the selection stuck
-		await expect(geneticCodeSelect).toHaveValue('Vertebrate mitochondrial');
+		// Pick by the human-readable label, then assert on the VALUE: the value is what gets
+		// passed to `hyphy --code`, and the engine only accepts its own hyphenated identifiers
+		// (see src/lib/config/geneticCodes.js). Asserting the label alone would still pass if the
+		// value drifted back to one of the spellings the engine rejects.
+		await geneticCodeSelect.selectOption({ label: 'Vertebrate mitochondrial DNA code' });
+		await expect(geneticCodeSelect).toHaveValue('Vertebrate-mtDNA');
 	});
 
 	test('timing estimate appears when method selected', async ({ page }) => {

--- a/e2e/08-results.spec.js
+++ b/e2e/08-results.spec.js
@@ -5,6 +5,15 @@
 import { test, expect } from './fixtures/coverage.js';
 import { freshStart, seedCompletedAnalysis, MOCK_FEL_RESULT } from './fixtures/helpers.js';
 
+/** Open the Results tab and select the first analysis card. */
+async function openFirstResult(page) {
+	await page.locator('button:has-text("Results")').first().click();
+	const card = page.locator('[data-testid="analysis-card"]').first();
+	await expect(card).toBeVisible({ timeout: 10000 });
+	await card.click();
+	await expect(page.locator('[data-testid="analysis-viewer"]')).toBeVisible({ timeout: 10000 });
+}
+
 test.describe('Results Tab', () => {
 	test.beforeEach(async ({ page }) => {
 		await freshStart(page);
@@ -52,23 +61,28 @@ test.describe('Results Tab', () => {
 		await expect(exportSection.first()).toBeVisible({ timeout: 10000 });
 	});
 
-	test('View in HyPhy-eye button present', async ({ page }) => {
-		const resultsTab = page.locator('button:has-text("Results")').first();
-		await resultsTab.click();
-		await page.waitForTimeout(1000);
+	// Replaces 'View in HyPhy-eye button present', which asserted the button if it was there and the
+	// viewer if it was not — it could not fail. It could not even have detected the button: the seed
+	// helper lowercases, and the markup was gated on a case-sensitive list of uppercase method names.
+	//
+	// storedMethod is UPPERCASE deliberately, because that is what every runner persists
+	// (WasmAnalysisRunner/BackendAnalysisRunner call method.toUpperCase()). Lowercasing it back to the
+	// helper default would make all three assertions pass on the unfixed page and quietly neuter this.
+	test('completed results carry no hyphy-eye link', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: MOCK_FEL_RESULT,
+			method: 'FEL',
+			storedMethod: 'FEL',
+			fileName: 'bglobin.nex'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
 
-		const card = page.locator('[data-testid="analysis-card"]').first();
-		await card.click();
-		await page.waitForTimeout(3000);
-
-		// The hyphy-eye button/link may say various things
-		const hyphyEyeBtn = page.locator('text=/[Hh]y[Pp]hy/');
-		if (await hyphyEyeBtn.count() > 0) {
-			await expect(hyphyEyeBtn.first()).toBeVisible();
-		} else {
-			// If hyphy-eye button is not present, at least the viewer should be visible
-			const viewer = page.locator('[data-testid="analysis-viewer"]');
-			await expect(viewer).toBeVisible();
-		}
+		await expect(page.getByRole('button', { name: /View in HyPhy-eye/i })).toHaveCount(0);
+		await expect(page.getByText(/automatically shared via localStorage/i)).toHaveCount(0);
+		// The other arm: a manual-upload link, shown for exactly the methods hyphy-eye has no page for.
+		await expect(page.locator('[data-testid="analysis-viewer"] a[href*="hyphy"]')).toHaveCount(0);
 	});
 });

--- a/e2e/08-results.spec.js
+++ b/e2e/08-results.spec.js
@@ -61,6 +61,62 @@ test.describe('Results Tab', () => {
 		await expect(exportSection.first()).toBeVisible({ timeout: 10000 });
 	});
 
+	// A visualisation REPLACES the raw JSON, it does not sit on top of one. Both halves of that
+	// sentence are asserted here on purpose; an earlier version of this file only checked that the
+	// viewer was visible, which the buggy page satisfied too.
+	test('a method with a visualisation renders no raw JSON dump', async ({ page }) => {
+		await openFirstResult(page);
+
+		await expect(page.locator('[data-testid="analysis-viewer"] .hyphy-scope-container')).toBeVisible(
+			{ timeout: 10000 }
+		);
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toHaveCount(0);
+	});
+
+	// The other direction, so the fix above cannot be "simplified" into deleting the dump outright.
+	// NRM has no hyphy-scope visualiser (getHyphyScopeVisualization returns null for it), so the raw
+	// document IS its result view.
+	//
+	// This was written as a guard but turns out to be a pin: on the unfixed page 'NRM' IS in the
+	// hardcoded whitelist, so it entered a branch whose every child is gated on a HyPhy result shape
+	// HyPhy does not emit (`input.file`, an array `fits`, `tested.sites`) and rendered NOTHING —
+	// a completed NRM run showed a heading, an export panel and no results at all.
+	test('a method with no visualisation keeps the raw JSON dump', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: MOCK_FEL_RESULT,
+			method: 'NRM',
+			storedMethod: 'NRM',
+			fileName: 'nrm-fixture.fasta'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
+
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toBeVisible({
+			timeout: 10000
+		});
+	});
+
+	// The leftover developer panel. Seeded without `test results` so AbsrelVisualizationWrapper takes
+	// its own error branch and hyphy-scope's AbsrelVisualization is never handed a mock it would
+	// choke on — the panel under test rendered above the visualisation either way.
+	test('no aBSREL debug panel above the visualisation', async ({ page }) => {
+		await freshStart(page);
+		await seedCompletedAnalysis(page, {
+			resultJson: JSON.stringify({ input: { 'file name': 'bglobin.nex' } }),
+			method: 'ABSREL',
+			storedMethod: 'ABSREL',
+			fileName: 'bglobin.nex'
+		});
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+		await openFirstResult(page);
+
+		// A closed <details> still renders its <summary>, so count-0 is the right assertion.
+		await expect(page.getByText('Debug: aBSREL Data Structure')).toHaveCount(0);
+	});
+
 	// Replaces 'View in HyPhy-eye button present', which asserted the button if it was there and the
 	// viewer if it was not — it could not fail. It could not even have detected the button: the seed
 	// helper lowercases, and the markup was gated on a case-sensitive list of uppercase method names.

--- a/e2e/10-branch-selector.spec.js
+++ b/e2e/10-branch-selector.spec.js
@@ -5,6 +5,28 @@
 import { test, expect } from './fixtures/coverage.js';
 import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
 
+/**
+ * Turn on Interactive branch selection and make sure the TREE view is showing.
+ *
+ * Below ~700px the component now opens in list view, because the tree is not a usable control at
+ * that size. These specs are about the tree itself, so they ask for it explicitly rather than
+ * depending on a width-derived default — at desktop width the button is already active and the
+ * click is a no-op.
+ */
+async function showInteractiveTree(page) {
+	const branchSelect = page.locator('select').filter({
+		has: page.locator('option:text("Interactive")')
+	});
+	await branchSelect.first().selectOption('Interactive');
+
+	// Tolerate the toggle being absent on purpose: if this helper hard-required it, every assertion
+	// below would fail with "no such element" instead of failing on the geometry it is meant to pin.
+	const treeBtn = page.locator('[data-testid="branch-view-tree"]');
+	if (await treeBtn.count()) {
+		await treeBtn.click();
+	}
+}
+
 test.describe('Branch Selector UI', () => {
 	test.beforeEach(async ({ page }) => {
 		await freshStart(page);
@@ -14,62 +36,114 @@ test.describe('Branch Selector UI', () => {
 
 	test('selecting Interactive branches renders SVG tree', async ({ page }) => {
 		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
 
-		// Find and select Interactive branch mode
-		const branchSelect = page.locator('select').filter({
-			has: page.locator('option:text("Interactive")')
-		});
-
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
-
-			// SVG tree should render (web-first; no fixed wait needed).
-			const svg = page.locator('.interactive-tree-section svg, .tree-selector-wrapper svg');
-			await expect(svg.first()).toBeVisible({ timeout: 10000 });
-		}
+		// SVG tree should render (web-first; no fixed wait needed).
+		const svg = page.locator('.interactive-tree-section svg, .tree-selector-wrapper svg');
+		await expect(svg.first()).toBeVisible({ timeout: 10000 });
 	});
 
 	test('tree has clickable nodes', async ({ page }) => {
 		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
 
-		const branchSelect = page.locator('select').filter({
-			has: page.locator('option:text("Interactive")')
-		});
-
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
-
-			// Web-first: wait for the SVG tree to render at least one node.
-			const nodes = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node');
-			await expect(nodes.first()).toBeVisible({ timeout: 10000 });
-			expect(await nodes.count()).toBeGreaterThan(0);
-		}
+		// Web-first: wait for the SVG tree to render at least one node.
+		const nodes = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node');
+		await expect(nodes.first()).toBeVisible({ timeout: 10000 });
+		expect(await nodes.count()).toBeGreaterThan(0);
 	});
 
 	test('clicking a node toggles selection', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
+
+		// Web-first: wait for a node to render before clicking.
+		const node = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node').first();
+		await expect(node).toBeVisible({ timeout: 10000 });
+		await node.scrollIntoViewIfNeeded();
+		// No force:true. This used to bypass the actionability check because the r=3 node was too
+		// small to be hit reliably at mobile width; the node is now r>=6 and the tree no longer
+		// overflows, so a plain click has to pass. Reverting the radius/pan-box work makes this
+		// time out, which is the point of removing the escape hatch.
+		await node.click();
+
+		// Should show selection info (either count or branch names).
+		const selectionInfo = page.locator('.selection-summary, .no-selection-message');
+		await expect(selectionInfo.first()).toBeVisible({ timeout: 10000 });
+	});
+
+	test('the tree does not push the page sideways', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+
+		// Compare the document width WITHOUT the tree to the width WITH it, rather than asserting an
+		// absolute zero: the page already has unrelated horizontal overflow at Pixel 5 width (the
+		// method dropdown and the toast container both exceed 393px), which is a separate defect and
+		// would make an absolute assertion fail for reasons this item does not own. What must hold is
+		// that RENDERING THE TREE WIDENS NOTHING. Measured on unmodified main: 512px before, 1086px
+		// after — the BranchSelector was mounted at a hard 1000px inside containers that never clip.
+		const widthBefore = await page.evaluate(() => document.documentElement.scrollWidth);
+
+		await showInteractiveTree(page);
+		await expect(page.locator('.tree-selector-wrapper svg').first()).toBeVisible({
+			timeout: 10000
+		});
+
+		const widthAfter = await page.evaluate(() => document.documentElement.scrollWidth);
+		expect(widthAfter).toBeLessThanOrEqual(widthBefore);
+
+		// ...and it must be contained by PANNING, not by squashing the tree down to phone width,
+		// which would make it unreadable instead of unreachable.
+		const pan = await page.evaluate(() => {
+			const el = document.querySelector('.tree-pan');
+			if (!el) return null;
+			return {
+				clientWidth: el.clientWidth,
+				scrollWidth: el.scrollWidth,
+				viewport: document.documentElement.clientWidth
+			};
+		});
+		expect(pan).not.toBeNull();
+		expect(pan.clientWidth).toBeLessThanOrEqual(pan.viewport);
+
+		// This spec runs in both projects. Only below BranchSelector's minWidth (640) is the tree
+		// drawn wider than its box; at desktop width it fits, and scrollWidth === clientWidth is the
+		// correct result rather than a regression.
+		if (pan.clientWidth < 640) {
+			expect(pan.scrollWidth).toBeGreaterThan(pan.clientWidth);
+		}
+	});
+
+	test('tree nodes are large enough to tap', async ({ page }) => {
+		await selectMethod(page, 'FEL');
+		await showInteractiveTree(page);
+
+		const node = page.locator('.tree-selector-wrapper svg circle').first();
+		await expect(node).toBeVisible({ timeout: 10000 });
+
+		// Web-first: the radius pass runs in a requestAnimationFrame after phylotree draws, so poll
+		// rather than sampling once and racing the frame.
+		await expect
+			.poll(async () => Number(await node.getAttribute('r')), { timeout: 10000 })
+			.toBeGreaterThanOrEqual(6);
+	});
+
+	test('narrow viewports open in list view, which is keyboard operable', async ({ page }) => {
 		await selectMethod(page, 'FEL');
 
 		const branchSelect = page.locator('select').filter({
 			has: page.locator('option:text("Interactive")')
 		});
+		await branchSelect.first().selectOption('Interactive');
 
-		if (await branchSelect.count() > 0) {
-			await branchSelect.first().selectOption('Interactive');
+		const listBtn = page.locator('[data-testid="branch-view-list"]');
+		await expect(listBtn).toBeVisible({ timeout: 10000 });
 
-			// Web-first: wait for a node to render before clicking.
-			const node = page.locator('.tree-selector-wrapper svg circle, .tree-selector-wrapper svg .node').first();
-			await expect(node).toBeVisible({ timeout: 10000 });
-			await node.scrollIntoViewIfNeeded();
-			// force:true bypasses the actionability check: on the narrow mobile
-			// viewport the advanced-options panel visually overlaps the tiny
-			// (r=3) SVG node and intercepts pointer events, though the node itself
-			// is visible and hit-testable at its center. We assert visibility
-			// above, so forcing the click tests the toggle behavior, not layout.
-			await node.click({ force: true });
-
-			// Should show selection info (either count or branch names).
-			const selectionInfo = page.locator('.selection-summary, .no-selection-message');
-			await expect(selectionInfo.first()).toBeVisible({ timeout: 10000 });
+		// The default depends on width, and only the narrow case is a behaviour claim: a phone must
+		// not land on a control it cannot operate.
+		const viewport = page.viewportSize()?.width ?? 0;
+		if (viewport < 700) {
+			await expect(listBtn).toHaveAttribute('aria-pressed', 'true');
+			await expect(page.locator('[data-testid="branch-list"]')).toBeVisible();
 		}
 	});
 });

--- a/e2e/14-responsive.spec.js
+++ b/e2e/14-responsive.spec.js
@@ -5,7 +5,15 @@
  */
 
 import { test, expect } from './fixtures/coverage.js';
-import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	selectMethod,
+	seedCompletedAnalysis,
+	getStatusIndicator,
+	MOCK_FEL_RESULT
+} from './fixtures/helpers.js';
 
 test.describe('Mobile Responsiveness', () => {
 	test.beforeEach(async ({ page }) => {
@@ -48,5 +56,33 @@ test.describe('Mobile Responsiveness', () => {
 
 		const runBtn = page.locator('[data-testid="run-analysis-btn"]');
 		await expect(runBtn).toBeVisible({ timeout: 10000 });
+	});
+
+	test('status indicator is visible without opening the menu', async ({ page }) => {
+		await seedCompletedAnalysis(page, { resultJson: MOCK_FEL_RESULT, method: 'FEL' });
+		await page.reload();
+		await page.waitForSelector('.sample-card');
+
+		// The element exists either way — it used to live inside the `hidden … sm:flex` group, so
+		// only visibility distinguishes the fixed state. Do not weaken this to toHaveCount.
+		await expect(getStatusIndicator(page)).toHaveCount(1);
+		await expect(getStatusIndicator(page)).toBeVisible();
+	});
+
+	test('activating the indicator closes the mobile menu', async ({ page }) => {
+		await seedCompletedAnalysis(page, { resultJson: MOCK_FEL_RESULT, method: 'FEL' });
+		await page.reload();
+		await page.waitForSelector('.sample-card');
+
+		await page.locator('button[aria-controls="mobile-menu"]').click();
+		await expect(page.locator('#mobile-menu')).toBeVisible();
+
+		// Plain click, no force: the indicator has to be genuinely actionable with the menu open.
+		await getStatusIndicator(page).click();
+
+		await expect(page).toHaveURL(/tab=results/);
+		// The URL alone is not a valid pin — the old in-menu copy navigated too. What was broken is
+		// that the menu stayed open on top of the destination.
+		await expect(page.locator('#mobile-menu')).toHaveCount(0);
 	});
 });

--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -149,6 +149,20 @@ test.describe('AxoMEME', () => {
 		await expect(page.locator('.axomeme-visualization')).toBeVisible();
 		await expect(page.locator('.axomeme-plot svg').first()).toBeVisible({ timeout: 20000 });
 
+		// And NOTHING dumps the stored result underneath it. This is the production-shaped check for
+		// the raw-JSON removal: this run persists method 'AXOMEME' (uppercase, via
+		// AxomemeAnalysisRunner), which is what made it miss the old hardcoded whitelist and fall
+		// through to the generic dump. `modelSha256` is a key only a JSON.stringify of the stored
+		// result can produce, so it catches the dump wherever in the result pane it is rendered — the
+		// class name alone would miss a second <pre> in a different branch, which is exactly what the
+		// first attempt at this fix left behind.
+		await expect(page.locator('[data-testid="analysis-viewer"] .json-display')).toHaveCount(0);
+		await expect(
+			page.locator('[data-testid="analysis-viewer"] .result-content pre', {
+				hasText: 'modelSha256'
+			})
+		).toHaveCount(0);
+
 		// Rank is a first-class column and the score is NOT labelled LRT. Measured across 12 real
 		// submissions, the model's predicted LRT clears the chi-square gates once in 662 sites, so
 		// presenting it as an LRT invites a comparison it cannot support.

--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -231,11 +231,22 @@ test.describe('AxoMEME', () => {
 		expect(body).toMatch(/cannot be changed for this method/i);
 		expect(body).not.toMatch(/Genetic Code:/i);
 
+		// While a demo is loaded and AxoMEME is selected: the pre-run copy has to state that the
+		// default calling mode ALWAYS flags a share of the variable sites, whether or not any of them
+		// is under selection. The results table says "Top 2%" afterwards; before the run, nothing did.
+		// Asserted on the testid rather than on body text — "percentile ... rank sites" is already on
+		// the page and would pass with this line removed.
+		const consequence = page.locator('[data-testid="axomeme-call-consequence"]');
+		await expect(consequence).toBeVisible();
+		await expect(consequence).toContainText(/top 2%/i);
+
 		// And the controls must come back for a method that does have them.
 		await selectMethod(page, 'FEL');
 		const felBody = await page.locator('body').innerText();
 		expect(felBody).toMatch(/Backend Server/i);
 		expect(felBody).toMatch(/Genetic Code/i);
+		// The consequence line belongs to AxoMEME only.
+		await expect(page.locator('[data-testid="axomeme-call-consequence"]')).toHaveCount(0);
 	});
 });
 

--- a/e2e/19-axomeme.spec.js
+++ b/e2e/19-axomeme.spec.js
@@ -217,11 +217,22 @@ test.describe('AxoMEME', () => {
 		expect(body).toMatch(/cannot be changed for this method/i);
 		expect(body).not.toMatch(/Genetic Code:/i);
 
+		// While a demo is loaded and AxoMEME is selected: the pre-run copy has to state that the
+		// default calling mode ALWAYS flags a share of the variable sites, whether or not any of them
+		// is under selection. The results table says "Top 2%" afterwards; before the run, nothing did.
+		// Asserted on the testid rather than on body text — "percentile ... rank sites" is already on
+		// the page and would pass with this line removed.
+		const consequence = page.locator('[data-testid="axomeme-call-consequence"]');
+		await expect(consequence).toBeVisible();
+		await expect(consequence).toContainText(/top 2%/i);
+
 		// And the controls must come back for a method that does have them.
 		await selectMethod(page, 'FEL');
 		const felBody = await page.locator('body').innerText();
 		expect(felBody).toMatch(/Backend Server/i);
 		expect(felBody).toMatch(/Genetic Code/i);
+		// The consequence line belongs to AxoMEME only.
+		await expect(page.locator('[data-testid="axomeme-call-consequence"]')).toHaveCount(0);
 	});
 });
 

--- a/e2e/21-config-persistence.spec.js
+++ b/e2e/21-config-persistence.spec.js
@@ -1,0 +1,134 @@
+/**
+ * A configuration must survive looking at another tab.
+ *
+ * +page.svelte mounts <AnalyzeTab> inside {#if activeTab === 'analyze'}, so Svelte destroys it — and
+ * every local in MethodSelector — on every tab switch. Choosing MEME, setting its rate classes, then
+ * glancing at Results used to drop all of it on the floor: the dropdown came back on "Select an
+ * analysis method" as though nothing had been chosen.
+ *
+ * The assertions here are the SELECT'S VALUE and a specific input's value, never page-body text. The
+ * string "MEME" is present in the option list either way, so a text assertion would pass on the
+ * broken build — which is exactly the trap this suite has fallen into before.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	goToResultsTab,
+	selectMethod
+} from './fixtures/helpers.js';
+
+/** The number input rendered for an advanced option, found by its label. */
+const optionInput = (page, label) =>
+	page.locator('label.option-label', { hasText: label }).locator('input');
+
+/**
+ * An interrupted MEME run against the file the page has loaded, carrying the settings it was
+ * configured with — the shape WasmAnalysisRunner persists (`parameters` IS the UI config).
+ */
+async function seedInterruptedMeme(page) {
+	return await page.evaluate(async () => {
+		const db = await new Promise((resolve, reject) => {
+			const req = indexedDB.open('datamonkey-db', 2);
+			req.onsuccess = () => resolve(req.result);
+			req.onerror = () => reject(req.error);
+		});
+		const files = await new Promise((resolve, reject) => {
+			const req = db.transaction('files', 'readonly').objectStore('files').getAll();
+			req.onsuccess = () => resolve(req.result || []);
+			req.onerror = () => reject(req.error);
+		});
+		const fileId = files[files.length - 1]?.id;
+		const id = `seeded-meme-${Date.now()}`;
+		const tx = db.transaction('analyses', 'readwrite');
+		tx.objectStore('analyses').put({
+			id,
+			fileId,
+			method: 'MEME',
+			status: 'interrupted',
+			createdAt: Date.now(),
+			metadata: {
+				executionMode: 'wasm',
+				arguments: {
+					parameters: { geneticCode: 'Universal', rates: 6, pvalue: 0.05 }
+				}
+			}
+		});
+		await new Promise((resolve) => {
+			tx.oncomplete = resolve;
+		});
+		db.close();
+		return id;
+	});
+}
+
+test.describe('analysis configuration', () => {
+	test.setTimeout(120000);
+
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+	});
+
+	test('survives a round trip through the Results tab', async ({ page }) => {
+		await selectMethod(page, 'MEME');
+
+		const rates = optionInput(page, 'Rate classes');
+		await expect(rates).toHaveValue('2');
+		await rates.fill('5');
+		await rates.dispatchEvent('input');
+		await expect(rates).toHaveValue('5');
+
+		await goToResultsTab(page);
+		await goToAnalyzeTab(page);
+
+		// The dropdown's VALUE, not the presence of the word MEME anywhere on the page.
+		await expect(page.locator('[data-testid="method-dropdown"]')).toHaveValue('MEME');
+		// And the option the user actually changed, not merely the method.
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('5');
+	});
+
+	test('Re-run brings back the settings that run was configured with', async ({ page }) => {
+		// The whole chain: AnalysisCard dispatches the analysisId, AnalysisHistory forwards it,
+		// +page.svelte looks the record up and hands it to analysisConfig.restoreFrom, MethodSelector
+		// hydrates from the store. Before this, every hop but the last existed and the settings were
+		// still dropped: AnalyzeTab took a `selectedMethod` prop and never forwarded it.
+		await seedInterruptedMeme(page);
+		await page.reload();
+		await page.waitForSelector('.sample-card', { timeout: 60000 });
+
+		// Results tab carries the history, and an interrupted run is the case that offers Re-run.
+		await goToResultsTab(page);
+		const rerun = page.getByRole('button', { name: /Re-run/i }).first();
+		await expect(rerun).toBeVisible({ timeout: 30000 });
+		await rerun.click();
+
+		await expect(page.locator('[data-testid="method-dropdown"]')).toHaveValue('MEME', {
+			timeout: 30000
+		});
+		// The settings, not just the method — this is the part "Re-run" never used to do.
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('6');
+		await expect(page.locator('[data-testid="restored-settings-notice"]')).toContainText(
+			/rate classes 6/i
+		);
+	});
+
+	test('still resets options when the user switches methods', async ({ page }) => {
+		// The store keeps one option bag PER METHOD, exactly as the component's own state did, so
+		// choosing a different method must still show that method's own defaults.
+		await selectMethod(page, 'MEME');
+		await optionInput(page, 'Rate classes').fill('7');
+
+		await selectMethod(page, 'FEL');
+		await expect(page.locator('label.option-label', { hasText: 'Rate classes' })).toHaveCount(0);
+
+		await selectMethod(page, 'MEME');
+		await expect(optionInput(page, 'Rate classes')).toHaveValue('7');
+	});
+});

--- a/e2e/21-data-tab-facts.spec.js
+++ b/e2e/21-data-tab-facts.spec.js
@@ -1,0 +1,84 @@
+/**
+ * The Data tab's claims about a file, end to end.
+ *
+ * Each assertion below pins a statement that was WRONG on the page before this spec existed:
+ *
+ *  - the upload limits ("Max 5,000 sequences ... >500 sequences require an embedded tree" against
+ *    real gates of 25,000 and 10,000),
+ *  - the "N raw -> M processed" sites row, which is one alignment measured in two units,
+ *  - the bare integer where the genetic code's name belongs,
+ *  - and the fact that datareader renamed or collapsed sequences, which only ever went to
+ *    ./datareader.log — a file nothing in the app reads.
+ *
+ * The last two need the real WASM datareader to run, so they upload a fixture and read what came
+ * back rather than a fixture-shaped mock.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, uploadFile, TEST_FILES } from './fixtures/helpers.js';
+import path from 'path';
+
+const SPECIAL_CHARS = path.resolve('static/test-data/validation-tests/special-chars.fna');
+const DUPLICATES = path.resolve('static/test-data/validation-tests/duplicates.fna');
+
+test.describe('Data tab facts', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('the upload limits are the ones datareader enforces', async ({ page }) => {
+		await expect(page.getByText(/25,000 sequences/)).toBeVisible();
+		await expect(page.getByText(/Above 10,000 sequences/)).toBeVisible();
+
+		// The exact strings the old copy used. '25,000 sequences' CONTAINS '5,000 sequences', so a
+		// bare /5,000 sequences/ here would match the fixed page — hence the full old phrases.
+		await expect(page.getByText(/Max 5,000 sequences/)).toHaveCount(0);
+		await expect(page.getByText(/>500 sequences require an embedded tree/)).toHaveCount(0);
+	});
+
+	test('the sites row states one length in two units, and the code has a name', async ({
+		page
+	}) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+
+		const seqInfo = page.locator('[data-testid="sequence-info"]');
+		await expect(seqInfo).toBeVisible({ timeout: 30000 });
+		await seqInfo.getByRole('button', { name: /Show details/ }).click();
+
+		await expect(seqInfo).toContainText(/\d+ nucleotides \(\d+ codons\)/);
+		await expect(seqInfo).not.toContainText('processed');
+		await expect(seqInfo).toContainText('Universal code');
+
+		// datareader computes dType and never emitted it; the row was permanently dark.
+		await expect(seqInfo).toContainText('Data Type');
+		await expect(seqInfo).toContainText('codon');
+	});
+
+	test('renamed sequences are named, not just counted', async ({ page }) => {
+		await uploadFile(page, SPECIAL_CHARS);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		// special-chars.fna has 'Seq:1|sample'. normalizeSequenceID maps every character outside
+		// [a-zA-Z0-9_] to '_' AND upper-cases the result (the `&& 1` operator in
+		// ReadDelimitedFiles.bf:219), so the new name is SEQ_1_SAMPLE. Before this change nothing in
+		// the app could tell you WHICH name had changed, or to what.
+		await expect(page.getByText(/Seq:1\|sample -> SEQ_1_SAMPLE/)).toBeVisible({ timeout: 15000 });
+	});
+
+	test('collapsed duplicates are named, and nothing offers to edit the alignment', async ({
+		page
+	}) => {
+		await uploadFile(page, DUPLICATES);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		// duplicates.fna: Seq2 and Seq4 are byte-identical to Seq1.
+		await expect(page.getByText(/Seq2 = Seq1/)).toBeVisible({ timeout: 15000 });
+
+		// The maintainer's rule, checked where the user actually reads it: describe, never offer to
+		// modify the user's data.
+		const warningsText = await page.locator('body').innerText();
+		const warningsSection = warningsText.slice(warningsText.indexOf('Sequence Warnings'));
+		expect(warningsSection).not.toMatch(/\brepair\b/i);
+		expect(warningsSection).not.toMatch(/\bwe can\b/i);
+	});
+});

--- a/e2e/21-execution-mode-advice.spec.js
+++ b/e2e/21-execution-mode-advice.spec.js
@@ -1,0 +1,60 @@
+/**
+ * E2E: what the execution-mode panel says before a long run.
+ *
+ * SCOPE, stated because it is a real limitation of this environment: there is no socket.io server in
+ * the e2e run, so the app is always disconnected here and only the DISCONNECTED branch of the advice
+ * is reachable. The connected branch — pre-selecting Backend Server and naming both durations — is
+ * covered by src/test/execution-mode-default.test.js, which mounts the component with
+ * backendConnectivity forced to connected.
+ *
+ * TRAP THIS FILE AVOIDS: asserting a bare duration regex like /1h 39m/ against the page body. The
+ * "Before you run" panel already prints exactly that string on unfixed main, so a body-text
+ * assertion passes either way. Everything below hangs off the advice element's own testid, off the
+ * radios' checked/disabled state, and off the advice agreeing with the panel.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+
+/** The shapes formatTimeDescription() can produce, longest first so '~1h 39m' wins over '~1h'. */
+const DURATION = /~\d+d \d+h|~\d+ days?|~\d+h \d+m|~\d+ hours?|~\d+ min|< 1 minute/;
+
+test.describe('Execution mode advice', () => {
+	test('warns that a slow browser run needs the tab, and agrees with the outlook panel', async ({
+		page
+	}) => {
+		await freshStart(page);
+		// 20 taxa x 85 codons. BGM at that size is 'Slow' in the browser — the app has always known
+		// this and always defaulted to running it here anyway.
+		await loadDemoFile(page, 'large.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+
+		await selectMethod(page, 'BGM');
+
+		const advice = page.locator('[data-testid="execution-mode-advice"]');
+		await expect(advice).toBeVisible();
+		const adviceText = await advice.innerText();
+		expect(adviceText).toMatch(/tab must stay open/);
+		// With no server reachable, nothing may point at one.
+		expect(adviceText).not.toMatch(/on the server/);
+
+		// The duration in the advice is the SAME duration the "Before you run" row prints, because
+		// both read one estimate. Two independently-worded numbers on one screen is the failure this
+		// couples away.
+		const shown = adviceText.match(DURATION);
+		expect(shown, `no duration in advice: ${adviceText}`).not.toBeNull();
+		await expect(page.locator('[data-testid="run-outlook"]')).toContainText(shown[0]);
+
+		// Disconnected: local stays selected and the server radio stays unavailable.
+		await expect(page.locator('input[type="radio"][value="local"]')).toBeChecked();
+		await expect(page.locator('input[type="radio"][value="backend"]')).toBeDisabled();
+
+		// FEL on the same file finishes in under a minute either way, so there is nothing to say.
+		await selectMethod(page, 'FEL');
+		await expect(page.locator('[data-testid="execution-mode-advice"]')).toHaveCount(0);
+		await expect(page.locator('input[type="radio"][value="local"]')).toBeChecked();
+	});
+});

--- a/e2e/21-execution-mode-advice.spec.js
+++ b/e2e/21-execution-mode-advice.spec.js
@@ -23,6 +23,13 @@ test.describe('Execution mode advice', () => {
 	test('warns that a slow browser run needs the tab, and agrees with the outlook panel', async ({
 		page
 	}) => {
+		// Block the backend explicitly rather than relying on there not being one. The rest of this
+		// suite assumes "no backend server in test" (see 11-backend-unavailable), but a developer
+		// running datamonkey-js-server locally makes that false, and this assertion depends on it:
+		// with a server reachable the advice takes its comparison branch and says "on the server".
+		// An e2e whose result depends on what happens to be listening on 7015 is not a test.
+		await page.route('**/socket.io/**', (route) => route.abort());
+
 		await freshStart(page);
 		// 20 taxa x 85 codons. BGM at that size is 'Slow' in the browser — the app has always known
 		// this and always defaulted to running it here anyway.

--- a/e2e/21-genetic-code-wasm.spec.js
+++ b/e2e/21-genetic-code-wasm.spec.js
@@ -1,0 +1,120 @@
+/**
+ * E2E for UX item 1.2 — a non-universal genetic code must actually reach HyPhy in the browser.
+ *
+ * This is the only test in the repo that proves it, because it is the only one that runs real
+ * hyphy.wasm. The unit tests pin the table and the shape of the exec() call; this pins the
+ * consequence: the engine accepts the identifier the UI would send, and produces a result under it.
+ *
+ * It imports GENETIC_CODES rather than hardcoding a name, so putting any of the old spellings back
+ * in the table fails HERE too — against the real engine, not against another copy of our own list.
+ *
+ * The rejected-spelling case is run as a control. Without it, a spec that only asserts success
+ * could pass while the app sent something the engine happens to tolerate; with it, the exact
+ * failure mode the fix removes is documented and stays reproducible.
+ *
+ * ORDER MATTERS: the accepted run goes FIRST. HyPhy runs via Emscripten's callMain, which keeps
+ * global state between invocations in the same worker, and a run that aborts during argument
+ * parsing is not guaranteed to leave a clean slate behind it.
+ *
+ * Tagged @slow — it runs a full FEL fit. Runs under `npm run test:e2e:slow`.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { GENETIC_CODES } from '../src/lib/config/geneticCodes.js';
+
+test.setTimeout(180000);
+
+// The 10-taxon tree from src/test/contrast-fel-wasm.test.js, with its {Set_x} tags stripped —
+// this spec is about --code, not branch sets.
+const TREE =
+	'(((Human:0,Chimp:0):0.02166017600706549,(Baboon:0,RhMonkey:0):0.08454871222214284):0.1898804322701872,((Cow:0.08802139862787406,Horse:0.1770186752804336):0.0450013916056009,(Mouse:0.1219119664814597,Rat:0.03550454062015435):0.1244133402668078):0.01795217374765563,(Pig:0.1592109185107414,Cat:0.07671186476683911):0.01307003277251646):0;';
+
+// Vertebrate mitochondrial: the code a user is most likely to reach for, and the one whose old
+// spelling ('Vertebrate mitochondrial' / 'Vertebrate mtDNA') the engine rejects.
+const VERTEBRATE_MT = GENETIC_CODES.find((code) => code.id === 1).hyphy;
+
+test.describe('genetic code reaches HyPhy in WASM @slow', () => {
+	test('the selector value is accepted by the engine and produces a result', async ({ page }) => {
+		// Boot the debug console — initializes Aioli and exposes window.wasmCli.
+		await page.goto('/debug/wasm');
+		await page.waitForFunction(() => !!window.wasmCli, null, { timeout: 120000 });
+
+		const alignment = await (await page.request.get('/test-data/CD2-slim.fna')).text();
+		expect(alignment).toContain('>Human');
+
+		const result = await page.evaluate(
+			async ({ alignment, tree, codeName }) => {
+				const cli = window.wasmCli;
+				const mounted = await cli.mount([
+					{ name: 'user.nex', data: alignment },
+					{ name: 'user.tree', data: tree }
+				]);
+				const [alignmentPath, treePath] = mounted;
+				const bf = '/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf';
+
+				const tokens = (code) => [
+					'LIBPATH=/res/',
+					bf,
+					'--alignment',
+					alignmentPath,
+					'--tree',
+					treePath,
+					'--code',
+					code,
+					'--branches',
+					'All'
+				];
+
+				const out = {};
+
+				// The real thing: argv array, program name separate, value exactly as the UI sends it.
+				try {
+					out.acceptedStdout = await (await cli.exec('hyphy', tokens(codeName))).stdout;
+				} catch (e) {
+					out.acceptedError = String(e);
+				}
+
+				try {
+					const blob = await cli.download('/shared/data/user.nex.FEL.json');
+					out.jsonText = await (await fetch(blob)).text();
+				} catch (e) {
+					out.downloadError = String(e);
+				}
+
+				// CONTROL: the spelling this app used to send. It is not an identifier the engine
+				// declares, so it must still be refused.
+				try {
+					out.rejectedStdout = await (
+						await cli.exec('hyphy', tokens('Vertebrate mitochondrial'))
+					).stdout;
+				} catch (e) {
+					out.rejectedError = String(e);
+				}
+
+				return out;
+			},
+			{ alignment, tree: TREE, codeName: VERTEBRATE_MT }
+		);
+
+		// The engine consumed the value, rather than falling back or complaining.
+		expect(result.acceptedError, `exec threw: ${result.acceptedError}`).toBeUndefined();
+		expect(
+			result.acceptedStdout || '',
+			`engine rejected '${VERTEBRATE_MT}':\n${result.acceptedStdout}`
+		).not.toContain('is not a valid choice passed to');
+		// FEL echoes each keyword argument it accepted; this is the engine confirming the code.
+		expect(result.acceptedStdout || '').toContain(`>code => ${VERTEBRATE_MT}`);
+
+		// And it ran to completion under that code.
+		expect(result.jsonText, `no FEL result JSON. stdout:\n${result.acceptedStdout}`).toBeTruthy();
+		expect(result.jsonText.trim().startsWith('<')).toBe(false);
+		expect(JSON.parse(result.jsonText)).toHaveProperty('MLE');
+
+		// The control. If this ever stops failing, the spec is no longer proving anything and the
+		// alias handling in geneticCodes.js can be revisited.
+		expect(
+			result.rejectedStdout || '',
+			'the old spelling is no longer refused — this control is stale'
+		).toMatch(/is not a valid choice passed to 'Choose Genetic Code'/);
+	});
+});

--- a/e2e/21-keyboard-a11y.spec.js
+++ b/e2e/21-keyboard-a11y.spec.js
@@ -1,0 +1,69 @@
+/**
+ * E2E tests for keyboard operability of file selection and the Analyze panel.
+ *
+ * Deliberately NOT in MOBILE_SPECS: keyboard behaviour is width-independent, so this belongs in
+ * the fast chromium project.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab } from './fixtures/helpers.js';
+
+test.describe('Keyboard accessibility', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('the disabled Analyze tab explains itself without hover', async ({ page }) => {
+		// Asserting the dedicated testid, not page-body text: the unfixed page already renders
+		// "Upload a file in the Data tab to run analyses", so a loose text assertion would pass
+		// either way and pin nothing.
+		await expect(page.getByTestId('tab-gate-hint')).toHaveText(
+			'Load a file on the Data tab to unlock Analyze.'
+		);
+	});
+
+	test('the tab bar exposes tablist semantics', async ({ page }) => {
+		await expect(page.getByRole('tab', { name: /Data/ })).toHaveAttribute('aria-selected', 'true');
+	});
+
+	test('a file can be selected with the keyboard alone', async ({ page }) => {
+		// Load two files, then target the one that is NOT current: loading small.nex second makes it
+		// the active file, so pressing Enter on the CD2-slim card has to actually change something.
+		// Targeting an already-active card would let the aria-current assertion pass trivially.
+		await loadDemoFile(page, 'CD2-slim.fna');
+		await loadDemoFile(page, 'small.nex');
+
+		const card = page.locator('.file-card').filter({ hasText: 'CD2-slim.fna' });
+		const select = card.getByTestId('file-select');
+		await expect(select).not.toHaveAttribute('aria-current', 'true');
+
+		// locator.press() focuses the element and then types — keyboard only, and atomic, so a
+		// re-render of the file list between focus and keypress cannot silently drop the focus.
+		await select.press('Enter');
+
+		await expect(select).toHaveAttribute('aria-current', 'true');
+		await expect(card.getByTestId('file-selected-chip')).toBeVisible();
+
+		// Selection must come BEFORE the destructive Delete in tab order; it used to come after.
+		await select.press('Tab');
+		await expect(page.locator(':focus')).toHaveAttribute('aria-label', /details/i);
+	});
+
+	test('the Analyze panel collapses and re-expands from the keyboard', async ({ page }) => {
+		await loadDemoFile(page, 'CD2-slim.fna');
+		await goToAnalyzeTab(page);
+
+		const t = page.getByTestId('analysis-section-toggle');
+		await expect(t).toHaveAttribute('aria-expanded', 'true');
+
+		await t.focus();
+		await page.keyboard.press('Enter');
+		await expect(t).toHaveAttribute('aria-expanded', 'false');
+		await expect(page.getByTestId('method-dropdown')).toHaveCount(0);
+
+		// The second Enter is the bug itself: a section collapsed by mouse used to be permanently
+		// shut for a keyboard user, because the only toggle was a click handler on a bare div.
+		await page.keyboard.press('Enter');
+		await expect(page.getByTestId('method-dropdown')).toBeVisible();
+	});
+});

--- a/e2e/22-branch-list-mode.spec.js
+++ b/e2e/22-branch-list-mode.spec.js
@@ -1,0 +1,62 @@
+/**
+ * E2E test for the branch-selection LIST view.
+ *
+ * This pins the actual complaint behind item 6.5 rather than the geometry: RELAX refuses to run
+ * until TEST and REFERENCE branches are tagged, and until now the only way to tag them was to click
+ * a phylotree SVG — mouse-only, and unusable below ~700px. The list is a second rendering of the
+ * same phylotree state, so it must be able to make the Run button live.
+ *
+ * Width-independent, so it belongs in the fast chromium project, not MOBILE_SPECS.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, loadDemoFile, goToAnalyzeTab, selectMethod } from './fixtures/helpers.js';
+
+test.describe('Branch selection list view', () => {
+	test('RELAX becomes runnable using only the list view', async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await goToAnalyzeTab(page);
+		await selectMethod(page, 'RELAX');
+
+		const runBtn = page.locator('[data-testid="run-analysis-btn"]');
+		await expect(runBtn).toBeDisabled();
+		await expect(
+			page.locator('text=Please select TEST and REFERENCE branches on the tree before running RELAX.')
+		).toBeVisible();
+
+		await page.locator('[data-testid="branch-view-list"]').click();
+		const rows = page.locator('[data-testid="branch-row-select"]');
+		await expect(rows.first()).toBeVisible({ timeout: 10000 });
+		expect(await rows.count()).toBeGreaterThan(1);
+
+		await rows.nth(0).selectOption('TEST');
+		await rows.nth(1).selectOption('REFERENCE');
+
+		await expect(runBtn).toBeEnabled({ timeout: 10000 });
+		await expect(
+			page.locator('text=Please select TEST and REFERENCE branches on the tree before running RELAX.')
+		).toHaveCount(0);
+	});
+
+	test('reassigning a branch in the list moves its tag rather than adding one', async ({ page }) => {
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await goToAnalyzeTab(page);
+		await selectMethod(page, 'RELAX');
+
+		await page.locator('[data-testid="branch-view-list"]').click();
+		const rows = page.locator('[data-testid="branch-row-select"]');
+		await expect(rows.first()).toBeVisible({ timeout: 10000 });
+
+		await rows.nth(0).selectOption('TEST');
+		await expect(rows.nth(0)).toHaveValue('TEST');
+
+		// Sets are mutually exclusive: the second assignment has to replace the first, not stack.
+		await rows.nth(0).selectOption('REFERENCE');
+		await expect(rows.nth(0)).toHaveValue('REFERENCE');
+
+		// With every tagged branch in REFERENCE there is no TEST set, so RELAX stays blocked.
+		await expect(page.locator('[data-testid="run-analysis-btn"]')).toBeDisabled();
+	});
+});

--- a/e2e/22-file-conflict.spec.js
+++ b/e2e/22-file-conflict.spec.js
@@ -1,0 +1,67 @@
+/**
+ * Re-uploading a file whose name is already taken.
+ *
+ * The store finds the existing record by FILENAME and replaces its bytes in place, keeping the id.
+ * For a corrected version of the same alignment that is exactly right — the analysis history stays
+ * attached. For a genuinely different file that happens to share a name it is not: every earlier
+ * FEL/MEME run silently ends up filed under contents it never saw, with nothing on screen saying
+ * so. The user was never asked which of the two they meant.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import { freshStart, uploadFile, TEST_FILES } from './fixtures/helpers.js';
+
+const PROMPT = '[data-testid="file-conflict-prompt"]';
+
+test.describe('Same-name upload', () => {
+	test.beforeEach(async ({ page }) => {
+		await freshStart(page);
+	});
+
+	test('asks which file the user meant, and can keep both', async ({ page }) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(1);
+
+		// Same name again. No prompt existed before: this silently overwrote.
+		await page.locator('input[type="file"]').setInputFiles(TEST_FILES['CD2-slim.fna']);
+
+		await expect(page.locator(PROMPT)).toBeVisible({ timeout: 15000 });
+		await expect(page.getByRole('button', { name: 'Replace it' })).toBeVisible();
+		const keepBoth = page.getByRole('button', { name: /Keep both/ });
+		await expect(keepBoth).toContainText('CD2-slim (2).fna');
+
+		await keepBoth.click();
+		await expect(page.locator(PROMPT)).toHaveCount(0);
+
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(2);
+		await expect(page.locator('.file-card').filter({ hasText: 'CD2-slim.fna' })).toHaveCount(1);
+		await expect(page.locator('.file-card').filter({ hasText: 'CD2-slim (2).fna' })).toHaveCount(1);
+	});
+
+	test('replacing keeps a single record, as before', async ({ page }) => {
+		await uploadFile(page, TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		await page.locator('input[type="file"]').setInputFiles(TEST_FILES['CD2-slim.fna']);
+		await expect(page.locator(PROMPT)).toBeVisible({ timeout: 15000 });
+		await page.getByRole('button', { name: 'Replace it' }).click();
+
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator('.file-card')).toHaveCount(1);
+	});
+
+	test('a demo file replaces silently — the prompt is for uploads only', async ({ page }) => {
+		// Demo, repair and alignment-edit saves are deliberate in-place replacements of a file the
+		// user just acted on. Prompting there would be noise.
+		const card = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+		await card.click();
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+
+		await card.click();
+		await expect(page.locator('[data-testid="sequence-info"]')).toBeVisible({ timeout: 30000 });
+		await expect(page.locator(PROMPT)).toHaveCount(0);
+		await expect(page.locator('.file-card')).toHaveCount(1);
+	});
+});

--- a/e2e/22-second-tab.spec.js
+++ b/e2e/22-second-tab.spec.js
@@ -1,0 +1,200 @@
+/**
+ * Opening a second tab must not kill the first tab's running analysis.
+ *
+ * IndexedDB is shared across tabs of an origin; the in-memory list of active runs is not. Every tab
+ * runs cleanupInterruptedAnalyses at onMount, and a local run's persisted record sits at
+ * 'pending'/'wasm' for its whole duration — so a second tab used to reap the first tab's live work,
+ * discard hours of compute and offer a Re-run that would duplicate it.
+ *
+ * The test carries its own positive control. Two records are seeded before the second tab opens: one
+ * with a fresh heartbeat (another tab is alive and stamping it) and one with none (a session that is
+ * gone). The stale one MUST be reaped — that is the proof the sweep actually ran — and the live one
+ * must be untouched. Without both, "nothing was reaped" could just mean "the sweep never happened",
+ * which is exactly how this kind of test passes while proving nothing.
+ */
+
+import { test, expect } from './fixtures/coverage.js';
+import {
+	freshStart,
+	loadDemoFile,
+	goToAnalyzeTab,
+	selectMethod,
+	clickRunAnalysis
+} from './fixtures/helpers.js';
+
+const DB_NAME = 'datamonkey-db';
+const DB_VERSION = 2;
+
+/** Put an analysis record straight into the shared database, as another tab would have left it. */
+async function seedAnalysisRecord(page, record) {
+	return await page.evaluate(
+		async ({ record, dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onupgradeneeded = (e) => {
+					const d = e.target.result;
+					if (!d.objectStoreNames.contains('files'))
+						d.createObjectStore('files', { keyPath: 'id' });
+					if (!d.objectStoreNames.contains('analyses'))
+						d.createObjectStore('analyses', { keyPath: 'id' });
+				};
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const tx = db.transaction('analyses', 'readwrite');
+			tx.objectStore('analyses').put(record);
+			await new Promise((resolve) => {
+				tx.oncomplete = resolve;
+			});
+			db.close();
+			return record.id;
+		},
+		{ record, dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+/** Read every analysis record's id and status out of the shared database. */
+async function readStatuses(page) {
+	return await page.evaluate(
+		async ({ dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const all = await new Promise((resolve, reject) => {
+				const req = db.transaction('analyses', 'readonly').objectStore('analyses').getAll();
+				req.onsuccess = () => resolve(req.result || []);
+				req.onerror = () => reject(req.error);
+			});
+			db.close();
+			return all.map((a) => ({ id: a.id, status: a.status }));
+		},
+		{ dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+/** Read the heartbeat stamp of every local run record. */
+async function readHeartbeats(page) {
+	return await page.evaluate(
+		async ({ dbName, dbVersion }) => {
+			const db = await new Promise((resolve, reject) => {
+				const req = indexedDB.open(dbName, dbVersion);
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+			});
+			const all = await new Promise((resolve, reject) => {
+				const req = db.transaction('analyses', 'readonly').objectStore('analyses').getAll();
+				req.onsuccess = () => resolve(req.result || []);
+				req.onerror = () => reject(req.error);
+			});
+			db.close();
+			return all
+				.filter((a) => a.metadata?.executionMode === 'wasm')
+				.map((a) => ({ id: a.id, lastHeartbeatAt: a.lastHeartbeatAt }));
+		},
+		{ dbName: DB_NAME, dbVersion: DB_VERSION }
+	);
+}
+
+const statusOf = (rows, id) => rows.find((r) => r.id === id)?.status;
+
+test.describe('a second browser tab', () => {
+	test.setTimeout(180000);
+
+	test('reaps a dead session’s run but leaves a live one alone', async ({ page, context }) => {
+		await freshStart(page);
+
+		const now = Date.now();
+		const liveId = `live-run-${now}`;
+		const staleId = `stale-run-${now}`;
+
+		// Another tab is running this right now and stamping it every ten seconds.
+		await seedAnalysisRecord(page, {
+			id: liveId,
+			fileId: `file-${now}`,
+			method: 'AXOMEME',
+			status: 'running',
+			metadata: { executionMode: 'wasm' },
+			createdAt: now - 30_000,
+			lastHeartbeatAt: now
+		});
+
+		// POSITIVE CONTROL: no pulse at all, so its tab is gone and it must still be cleaned up.
+		await seedAnalysisRecord(page, {
+			id: staleId,
+			fileId: `file-${now}`,
+			method: 'FEL',
+			status: 'running',
+			metadata: { executionMode: 'wasm' },
+			createdAt: now - 600_000
+		});
+
+		// The second tab. Same context, so the same IndexedDB.
+		const second = await context.newPage();
+		await second.goto('/');
+		await second.waitForSelector('.sample-card', { timeout: 60000 });
+
+		// Wait for the sweep to have run, evidenced by the stale record being reaped.
+		await expect(async () => {
+			const rows = await readStatuses(second);
+			expect(statusOf(rows, staleId), 'the interrupted sweep never ran').toBe('interrupted');
+		}).toPass({ timeout: 30000 });
+
+		// The live run is what this is all about: still running, still re-runnable by nobody.
+		const rows = await readStatuses(second);
+		expect(statusOf(rows, liveId), 'the second tab reaped a run another tab is still running').toBe(
+			'running'
+		);
+
+		await second.close();
+	});
+
+	test('leaves a pulse on a real run that another tab can see', async ({ page, context }) => {
+		// The other half of the mechanism, and the half a seeded record cannot prove: that a REAL local
+		// run stamps `lastHeartbeatAt` into the shared database at all. Without it, the gate in the
+		// first test would protect nothing, because no live run would ever carry a pulse.
+		//
+		// Deliberately NOT written as "start a run, open a tab, race the sweep": every local run on the
+		// demo alignments finishes in a few seconds, which is faster than a second tab can load, so
+		// that version passes on a broken build too — the completed record is not reapable either way.
+		await freshStart(page);
+		await loadDemoFile(page, 'small.nex');
+		await expect(async () => {
+			await goToAnalyzeTab(page);
+			await expect(page.locator('[data-testid="method-dropdown"]')).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout: 60000 });
+		await selectMethod(page, 'FEL');
+
+		expect(await clickRunAnalysis(page), 'run button was not clickable').toBe(true);
+		const row = page.locator('[data-testid="run-row"]').first();
+		await expect(row).toBeVisible({ timeout: 60000 });
+
+		const second = await context.newPage();
+		await second.goto('/');
+		await second.waitForSelector('.sample-card', { timeout: 60000 });
+		// Give the second tab's onMount sweep time to do its worst.
+		await second.waitForTimeout(3000);
+
+		const rows = await readStatuses(second);
+		expect(
+			rows.filter((r) => r.status === 'interrupted'),
+			'the second tab interrupted a run started in another tab'
+		).toEqual([]);
+
+		// The pulse itself, read from the second tab — the same database the sweep consults.
+		const pulses = await readHeartbeats(second);
+		expect(pulses.length, 'no analysis record was written at all').toBeGreaterThan(0);
+		for (const p of pulses) {
+			expect(p.lastHeartbeatAt, `run ${p.id} left no heartbeat, so any tab would reap it`).toEqual(
+				expect.any(Number)
+			);
+			expect(Date.now() - p.lastHeartbeatAt).toBeLessThan(60_000);
+		}
+
+		// And the first tab's run still finishes, on the row where it was started.
+		await expect(row).toHaveAttribute('data-status', 'completed', { timeout: 150000 });
+
+		await second.close();
+	});
+});

--- a/e2e/fixtures/helpers.js
+++ b/e2e/fixtures/helpers.js
@@ -209,9 +209,18 @@ export async function getCompletedCount(page) {
  * Seed a completed analysis into IndexedDB for fast Results tab testing.
  * Uses the same DB schema as the app: 'datamonkey-db' version 2 with 'files' and 'analyses' stores.
  * Returns the analysis ID.
+ *
+ * `storedMethod` overrides the exact string written to the `method` column. It exists because the
+ * default lowercases, and NO runner does: WasmAnalysisRunner writes method.toUpperCase(),
+ * BackendAnalysisRunner writes method.toUpperCase(), AxomemeAnalysisRunner writes 'AXOMEME'. Any
+ * assertion about markup gated on the method string therefore has to opt into the production casing
+ * or it exercises a branch users never reach. Defaults to null so existing callers are unaffected.
  */
-export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', fileName = 'bglobin.nex' } = {}) {
-	return await page.evaluate(async ({ resultJson, method, fileName, dbName, dbVersion }) => {
+export async function seedCompletedAnalysis(
+	page,
+	{ resultJson, method = 'FEL', storedMethod = null, fileName = 'bglobin.nex' } = {}
+) {
+	return await page.evaluate(async ({ resultJson, method, storedMethod, fileName, dbName, dbVersion }) => {
 		function openDB() {
 			return new Promise((resolve, reject) => {
 				const req = indexedDB.open(dbName, dbVersion);
@@ -252,7 +261,7 @@ export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', 
 		analysisTx.objectStore('analyses').put({
 			id: analysisId,
 			fileId: fileId,
-			method: method.toLowerCase(),
+			method: storedMethod ?? method.toLowerCase(),
 			status: 'completed',
 			result: resultJson,
 			createdAt: now - 60000,
@@ -263,5 +272,5 @@ export async function seedCompletedAnalysis(page, { resultJson, method = 'FEL', 
 
 		db.close();
 		return analysisId;
-	}, { resultJson, method, fileName, dbName: DB_NAME, dbVersion: DB_VERSION });
+	}, { resultJson, method, storedMethod, fileName, dbName: DB_NAME, dbVersion: DB_VERSION });
 }

--- a/e2e/video-frames.spec.js
+++ b/e2e/video-frames.spec.js
@@ -1,0 +1,1353 @@
+/**
+ * Video Segment Generator for Datamonkey 3 Announcement Video
+ *
+ * Records video clips corresponding to the narration script's scenes.
+ * Run with: npx playwright test e2e/video-frames.spec.js --reporter=list
+ *
+ * Videos are saved to test-results/(test-name)/video.webm
+ * After running, collect them into video-frames/ with the provided copy-videos.sh script.
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// 1920x1080 with video recording enabled
+test.use({
+	viewport: { width: 1920, height: 1080 },
+	colorScheme: 'light',
+	video: {
+		mode: 'on',
+		size: { width: 1920, height: 1080 }
+	}
+});
+
+// Generous timeout — scenes have deliberate pauses for cinematic pacing
+test.setTimeout(120000);
+
+const OFFSET_DIR = path.resolve('video-frames/offsets');
+fs.mkdirSync(OFFSET_DIR, { recursive: true });
+
+async function waitForAppReady(page) {
+	await page.waitForFunction(
+		() => {
+			const loading = document.querySelector('[data-testid="loading"]');
+			return !loading || loading.textContent?.includes('HyPhy');
+		},
+		{ timeout: 60000 }
+	);
+	await page.waitForSelector('.sample-card, button:has-text("Data")', { timeout: 60000 });
+}
+
+// Loads the app and records the wall-clock offset (in seconds) at which the
+// HyPhy loading screen finished. Used by the trim step to cut the loading
+// portion off the front of each video.
+async function prepareScene(page, sceneName) {
+	const start = Date.now();
+	await page.goto('/');
+	await waitForAppReady(page);
+	const offsetSeconds = (Date.now() - start) / 1000;
+	fs.writeFileSync(
+		path.join(OFFSET_DIR, `${sceneName}.json`),
+		JSON.stringify({ scene: sceneName, offsetSeconds })
+	);
+}
+
+// Smooth scroll for cinematic feel
+async function smoothScroll(page, distance, durationMs = 1500) {
+	await page.evaluate(
+		({ distance, durationMs }) => {
+			return new Promise((resolve) => {
+				const start = window.scrollY;
+				const startTime = performance.now();
+				function step(now) {
+					const elapsed = now - startTime;
+					const progress = Math.min(elapsed / durationMs, 1);
+					const ease =
+						progress < 0.5
+							? 2 * progress * progress
+							: -1 + (4 - 2 * progress) * progress;
+					window.scrollTo(0, start + distance * ease);
+					if (progress < 1) requestAnimationFrame(step);
+					else resolve();
+				}
+				requestAnimationFrame(step);
+			});
+		},
+		{ distance, durationMs }
+	);
+}
+
+// Smooth mouse move to an element (for hover effects on camera)
+async function smoothMoveTo(page, locator) {
+	const box = await locator.boundingBox();
+	if (!box) return;
+	const x = box.x + box.width / 2;
+	const y = box.y + box.height / 2;
+	await page.mouse.move(x, y, { steps: 20 });
+}
+
+// ---------- SCENE 1: APP REVEAL ----------
+
+test('scene-01 — app reveal and first impression', async ({ page }) => {
+	await prepareScene(page, 'scene-01');
+
+	// Hold on the clean landing
+	await page.waitForTimeout(3000);
+
+	// Slow scroll to show the full page
+	await smoothScroll(page, 400, 2000);
+	await page.waitForTimeout(2000);
+
+	await smoothScroll(page, -400, 1500);
+	await page.waitForTimeout(1500);
+});
+
+// ---------- SCENE 2: THREE-TAB NAVIGATION ----------
+
+test('scene-02 — navigating Data Analyze Results tabs', async ({ page }) => {
+	await prepareScene(page, 'scene-02');
+
+	// Load a file so all tabs have content
+	const fileCard = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+	await fileCard.click();
+	await page.waitForTimeout(4000);
+
+	// Pause on Data
+	await page.waitForTimeout(2000);
+
+	// Click Analyze
+	await page.locator('button:has-text("Analyze")').first().click();
+	await page.waitForTimeout(3000);
+
+	// Click Results
+	await page.locator('button:has-text("Results")').first().click();
+	await page.waitForTimeout(3000);
+
+	// Back to Data
+	await page.locator('button:has-text("Data")').first().click();
+	await page.waitForTimeout(2000);
+});
+
+// ---------- SCENE 3: DATA INPUT WALKTHROUGH ----------
+
+test('scene-03 — loading a file and exploring validation', async ({ page }) => {
+	await prepareScene(page, 'scene-03');
+	await page.waitForTimeout(1500);
+
+	// Hover over demo file cards
+	const cd2Card = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+	await smoothMoveTo(page, cd2Card);
+	await page.waitForTimeout(800);
+
+	const smallCard = page.locator('.sample-card').filter({ hasText: 'small.nex' });
+	await smoothMoveTo(page, smallCard);
+	await page.waitForTimeout(800);
+
+	// Click CD2-slim
+	await smoothMoveTo(page, cd2Card);
+	await page.waitForTimeout(400);
+	await cd2Card.click();
+	await page.waitForTimeout(4000);
+
+	// Scroll to show file metrics, alignment viewer, warnings
+	await smoothScroll(page, 500, 2500);
+	await page.waitForTimeout(2500);
+
+	await smoothScroll(page, 300, 2000);
+	await page.waitForTimeout(2000);
+
+	// Back to top
+	await smoothScroll(page, -800, 2000);
+	await page.waitForTimeout(1500);
+});
+
+// ---------- SCENE 4: TREE VISUALIZATION ----------
+
+test('scene-04 — tree visualization from NEXUS file', async ({ page }) => {
+	await prepareScene(page, 'scene-04');
+
+	const nexCard = page.locator('.sample-card').filter({ hasText: 'small.nex' });
+	if (await nexCard.count() > 0) {
+		await nexCard.click();
+	} else {
+		await page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' }).click();
+	}
+	await page.waitForTimeout(5000);
+
+	// Scroll to tree
+	await smoothScroll(page, 500, 2000);
+	await page.waitForTimeout(3000);
+
+	await smoothScroll(page, 300, 1500);
+	await page.waitForTimeout(2000);
+});
+
+// ---------- SCENE 5: METHOD SELECTION ----------
+
+test('scene-05 — method selector and configuration', async ({ page }) => {
+	await prepareScene(page, 'scene-05');
+
+	const fileCard = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+	await fileCard.click();
+	await page.waitForTimeout(3500);
+
+	// Navigate to Analyze
+	await page.locator('button:has-text("Analyze")').first().click();
+	await page.waitForTimeout(2000);
+
+	// Scroll through the method list
+	await smoothScroll(page, 300, 2000);
+	await page.waitForTimeout(1500);
+	await smoothScroll(page, -300, 1500);
+	await page.waitForTimeout(1500);
+
+	// Hover over method buttons/cards
+	const methods = ['MEME', 'FUBAR', 'aBSREL', 'BUSTED'];
+	for (const m of methods) {
+		const el = page.locator(`text=${m}`).first();
+		if (await el.count() > 0) {
+			await smoothMoveTo(page, el);
+			await page.waitForTimeout(600);
+		}
+	}
+
+	await page.waitForTimeout(2000);
+});
+
+// ---------- SCENE 6: BRANCH SELECTOR ----------
+
+test('scene-06 — branch annotation for aBSREL', async ({ page }) => {
+	await prepareScene(page, 'scene-06');
+
+	const fileCard = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+	await fileCard.click();
+	await page.waitForTimeout(3500);
+
+	await page.locator('button:has-text("Analyze")').first().click();
+	await page.waitForTimeout(2000);
+
+	// Select aBSREL — use a more specific selector to avoid multiple matches
+	const absrel = page.locator('button:has-text("aBSREL"), [role="option"]:has-text("aBSREL"), label:has-text("aBSREL")').first();
+	if (await absrel.count() > 0) {
+		await absrel.click({ timeout: 5000 }).catch(() => {});
+		await page.waitForTimeout(2000);
+
+		// Scroll to show branch selector
+		await smoothScroll(page, 400, 1500);
+		await page.waitForTimeout(3000);
+	}
+});
+
+// ---------- SCENE 7: FULL ANALYSIS RUN ----------
+
+test('scene-07 — run FEL end-to-end and view results', async ({ page }) => {
+	test.setTimeout(300000); // 5 minutes for WASM
+
+	await prepareScene(page, 'scene-07');
+
+	// Load file
+	const fileCard = page.locator('.sample-card').filter({ hasText: 'CD2-slim.fna' });
+	await fileCard.click();
+	await page.waitForTimeout(3500);
+
+	// Go to Analyze
+	await page.locator('button:has-text("Analyze")').first().click();
+	await page.waitForTimeout(2000);
+
+	// Click Run
+	const runButton = page
+		.locator('button:has-text("Run FEL"), button:has-text("Run Analysis"), button:has-text("Run")')
+		.first();
+	if (await runButton.count() > 0 && (await runButton.isEnabled())) {
+		await runButton.click();
+	}
+
+	// Show the running state
+	await page.waitForTimeout(5000);
+
+	// Wait for completion
+	for (let i = 0; i < 50; i++) {
+		const completed = page.locator('.text-green-600, [class*="complete"], [class*="success"]');
+		if (await completed.count() > 0) break;
+		await page.waitForTimeout(3000);
+	}
+
+	await page.waitForTimeout(2000);
+
+	// Navigate to Results
+	await page.locator('button:has-text("Results")').first().click();
+	await page.waitForTimeout(3000);
+
+	// Scroll through results
+	await smoothScroll(page, 400, 2000);
+	await page.waitForTimeout(2000);
+
+	await smoothScroll(page, 400, 2000);
+	await page.waitForTimeout(2000);
+
+	await smoothScroll(page, -800, 2000);
+	await page.waitForTimeout(1500);
+});
+
+// ---------- SCENE 8: COMPARISON TABLE ----------
+
+test('scene-08 — animated v2 vs v3 comparison table', async ({ page }) => {
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				body { background:#f8fafc; display:flex; align-items:center; justify-content:center; height:100vh; margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; }
+				table { border-collapse:collapse; font-size:17px; box-shadow:0 4px 24px rgba(0,0,0,0.08); border-radius:12px; overflow:hidden; background:white; }
+				th { background:#1e293b; color:white; padding:16px 32px; text-align:left; font-weight:600; font-size:15px; text-transform:uppercase; letter-spacing:0.5px; }
+				td { padding:14px 32px; border-bottom:1px solid #e2e8f0; line-height:1.5; }
+				tr:last-child td { border-bottom:none; }
+				tr:nth-child(even) td { background:#f8fafc; }
+				td:first-child { font-weight:600; color:#334155; min-width:160px; }
+				td:nth-child(2) { color:#64748b; min-width:240px; }
+				td:nth-child(3) { color:#0f172a; min-width:280px; }
+				h2 { text-align:center; color:#1e293b; margin-bottom:24px; font-size:24px; font-weight:600; }
+				.container { padding:40px; }
+				tbody tr { opacity:0; transform:translateY(12px); transition:opacity 0.5s ease, transform 0.5s ease; }
+				tbody tr.visible { opacity:1; transform:translateY(0); }
+			</style>
+		</head>
+		<body>
+			<div class="container">
+				<h2>Datamonkey 2 &rarr; Datamonkey 3</h2>
+				<table>
+					<thead><tr><th>Aspect</th><th>Datamonkey 2</th><th>Datamonkey 3</th></tr></thead>
+					<tbody id="tbody">
+						<tr><td>Execution</td><td>Server-side only</td><td>Client-side (WASM) or server-side</td></tr>
+						<tr><td>Data handling</td><td>Uploaded to remote server</td><td>Remains local in browser mode</td></tr>
+						<tr><td>Dependencies</td><td>Requires server availability</td><td>Functions offline after initial load</td></tr>
+						<tr><td>Interface</td><td>Multi-page form sequence</td><td>Single-page three-tab layout</td></tr>
+						<tr><td>Visualization</td><td>Static output tables</td><td>Interactive HyPhy-Eye integration</td></tr>
+						<tr><td>Analysis history</td><td>Session / URL-based</td><td>Persistent local storage (IndexedDB)</td></tr>
+						<tr><td>Export</td><td>Individual file downloads</td><td>Individual or batch ZIP export</td></tr>
+						<tr><td>Methods</td><td>~12</td><td>16 (actively expanding)</td></tr>
+						<tr><td>Input validation</td><td>Post-submission</td><td>Pre-submission quality checks</td></tr>
+					</tbody>
+				</table>
+			</div>
+			<script>
+				const rows = document.querySelectorAll('#tbody tr');
+				rows.forEach((row, i) => {
+					setTimeout(() => row.classList.add('visible'), 800 + i * 600);
+				});
+			</script>
+		</body>
+		</html>
+	`);
+
+	// Wait for all rows to animate in + hold
+	await page.waitForTimeout(800 + 9 * 600 + 3000);
+});
+
+// ---------- SCENE 9: ARCHITECTURE DIAGRAM ----------
+
+test('scene-09 — tech stack architecture diagram', async ({ page }) => {
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				body { background:#0f172a; display:flex; align-items:center; justify-content:center; height:100vh; margin:0; font-family:'SF Mono','Fira Code','Cascadia Code',monospace; color:#e2e8f0; }
+				.stack { display:flex; flex-direction:column; gap:16px; align-items:center; }
+				.layer { background:#1e293b; border:1px solid #334155; border-radius:12px; padding:20px 48px; text-align:center; min-width:420px; opacity:0; transform:translateY(20px); transition:opacity 0.6s ease, transform 0.6s ease; }
+				.layer.visible { opacity:1; transform:translateY(0); }
+				.layer .label { font-size:13px; color:#64748b; text-transform:uppercase; letter-spacing:1px; margin-bottom:8px; }
+				.layer .tech { font-size:20px; font-weight:600; color:#f1f5f9; }
+				.layer .detail { font-size:13px; color:#94a3b8; margin-top:4px; }
+				.connector { width:2px; height:12px; background:#334155; opacity:0; transition:opacity 0.4s ease; }
+				.connector.visible { opacity:1; }
+				.dual { display:flex; gap:24px; }
+				.dual .layer { min-width:200px; }
+				h2 { color:#f1f5f9; font-size:14px; text-transform:uppercase; letter-spacing:2px; margin-bottom:32px; font-weight:400; opacity:0; transition:opacity 0.6s ease; }
+				h2.visible { opacity:1; }
+			</style>
+		</head>
+		<body>
+			<div class="stack">
+				<h2 id="title">Datamonkey 3 &mdash; Architecture</h2>
+				<div class="layer" id="l1"><div class="label">Frontend</div><div class="tech">SvelteKit</div><div class="detail">Single-page application &bull; Three-tab workflow</div></div>
+				<div class="connector" id="c1"></div>
+				<div class="dual">
+					<div class="layer" id="l2a"><div class="label">Local Execution</div><div class="tech">HyPhy &rarr; WASM</div><div class="detail">via Aioli framework</div></div>
+					<div class="layer" id="l2b"><div class="label">Server Execution</div><div class="tech">SLURM Cluster</div><div class="detail">via Socket.IO</div></div>
+				</div>
+				<div class="connector" id="c2"></div>
+				<div class="layer" id="l3"><div class="label">Visualization</div><div class="tech">HyPhy-Eye</div><div class="detail">Interactive result exploration</div></div>
+				<div class="connector" id="c3"></div>
+				<div class="layer" id="l4"><div class="label">Deployment</div><div class="tech">Cloudflare Edge</div><div class="detail">Global CDN &bull; Open source</div></div>
+			</div>
+			<script>
+				const steps = [
+					['title',500],['l1',1000],['c1',1500],['l2a',2000],['l2b',2300],
+					['c2',2800],['l3',3300],['c3',3800],['l4',4300]
+				];
+				steps.forEach(([id, delay]) => {
+					setTimeout(() => document.getElementById(id).classList.add('visible'), delay);
+				});
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(4300 + 3000);
+});
+
+// ---------- SCENE 10: CLOSING ----------
+
+test('scene-10 — closing landing page hold', async ({ page }) => {
+	await prepareScene(page, 'scene-10');
+
+	await page.waitForTimeout(4000);
+
+	await smoothScroll(page, 200, 2000);
+	await page.waitForTimeout(1000);
+	await smoothScroll(page, -200, 2000);
+	await page.waitForTimeout(3000);
+});
+
+// ---------- LOGO-DRIVEN SCENES ----------
+
+// Load SVG logo files so we can inline them in setContent HTML.
+const LOGO_DIR = path.resolve('video-frames/logos');
+function svg(name) {
+	return fs.readFileSync(path.join(LOGO_DIR, name), 'utf-8');
+}
+function dataUrl(name) {
+	const buf = fs.readFileSync(path.join(LOGO_DIR, name));
+	const ext = path.extname(name).slice(1);
+	return `data:image/${ext};base64,${buf.toString('base64')}`;
+}
+
+// ---------- SCENE 11: TECH STACK WITH REAL LOGOS ----------
+
+test('scene-11 — animated tech stack with logos', async ({ page }) => {
+	const hyphy = svg('hyphy.svg');
+	const wasm = svg('webassembly.svg');
+	const svelte = svg('svelte-horizontal.svg');
+	const socketio = svg('socketio.svg');
+	const mcp = svg('mcp-logo.svg');
+
+	/*
+	 * Topology (what the diagram must show):
+	 *
+	 *   [SvelteKit (browser UI)]           [MCP Clients]
+	 *         |         \                       |
+	 *         |          \                      |
+	 *         v           v                     v
+	 *      [WebAssembly]  [Socket.IO]  <--------+
+	 *           \             /
+	 *            \           /
+	 *             v         v
+	 *             [ HyPhy ]
+	 *
+	 * - SvelteKit UI can call WASM (local) OR Socket.IO (remote)
+	 * - MCP clients only reach the system via Socket.IO
+	 * - Both WASM and Socket.IO drive HyPhy as the analysis engine
+	 */
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0f172a; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:28px; }
+				h2 { color:#cbd5e1; font-size:14px; text-transform:uppercase; letter-spacing:3px; margin:0; font-weight:400; opacity:0; transition:opacity 0.6s ease; }
+				h2.visible { opacity:1; }
+
+				.diagram { position:relative; width:1100px; height:620px; }
+
+				.node {
+					position:absolute; background:#f8fafc; border:1px solid #e2e8f0;
+					border-radius:14px; padding:20px 28px; display:flex; flex-direction:column;
+					align-items:center; gap:10px; opacity:0; transform:translateY(12px);
+					transition:opacity 0.7s ease, transform 0.7s ease;
+					box-shadow:0 8px 28px rgba(0,0,0,0.35);
+				}
+				.node.visible { opacity:1; transform:translateY(0); }
+				.node .label { font-size:10px; color:#64748b; text-transform:uppercase; letter-spacing:1.5px; }
+				.node .logo { height:48px; display:flex; align-items:center; justify-content:center; }
+				.node .logo svg { height:48px; width:auto; max-width:200px; display:block; }
+				.node .logo.wide svg { height:36px; max-width:300px; }
+				.node .logo.recolor svg * { fill:#0f172a !important; }
+				.node .name { font-size:15px; font-weight:600; color:#0f172a; }
+
+				/* Node positions */
+				#svelte   { top:0;   left:60px;  min-width:300px; }
+				#mcp      { top:0;   right:60px; min-width:320px; }
+				#wasm     { top:240px; left:60px;  min-width:300px; }
+				#socket   { top:240px; right:60px; min-width:300px; }
+				#hyphy    { bottom:0; left:50%; transform:translate(-50%, 12px); min-width:260px; }
+				#hyphy.visible { transform:translate(-50%, 0); }
+
+				/* Line overlay (SVG) sits above the background but behind the nodes */
+				svg.lines { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; }
+				svg.lines line, svg.lines path {
+					stroke:#94a3b8; stroke-width:2.5; fill:none;
+					stroke-dasharray:1 0;
+					opacity:0; transition:opacity 0.6s ease;
+				}
+				svg.lines .visible { opacity:0.9; }
+			</style>
+		</head>
+		<body>
+			<h2 id="title">Datamonkey 3 &mdash; Under the Hood</h2>
+
+			<div class="diagram">
+				<!-- SVG connector overlay. viewBox matches the container's pixel size. -->
+				<svg class="lines" viewBox="0 0 1100 620" preserveAspectRatio="none">
+					<!-- SvelteKit -> WASM (straight down on left side) -->
+					<path id="line-svelte-wasm" d="M 210 110 L 210 240" />
+					<!-- SvelteKit -> Socket.IO (diagonal to the right) -->
+					<path id="line-svelte-socket" d="M 300 110 C 500 110, 600 240, 890 240" />
+					<!-- MCP -> Socket.IO (straight down on right side) -->
+					<path id="line-mcp-socket" d="M 890 110 L 890 240" />
+					<!-- WASM -> HyPhy (diagonal to center) -->
+					<path id="line-wasm-hyphy" d="M 210 360 C 210 500, 420 520, 550 560" />
+					<!-- Socket.IO -> HyPhy (diagonal to center) -->
+					<path id="line-socket-hyphy" d="M 890 360 C 890 500, 680 520, 550 560" />
+				</svg>
+
+				<div class="node" id="svelte">
+					<div class="label">Browser UI</div>
+					<div class="logo">${svelte}</div>
+					<div class="name">SvelteKit</div>
+				</div>
+
+				<div class="node" id="mcp">
+					<div class="label">Agent Access</div>
+					<div class="logo wide">${mcp}</div>
+					<div class="name">Any MCP-aware client</div>
+				</div>
+
+				<div class="node" id="wasm">
+					<div class="label">Local Runtime</div>
+					<div class="logo">${wasm}</div>
+					<div class="name">WebAssembly &middot; Aioli</div>
+				</div>
+
+				<div class="node" id="socket">
+					<div class="label">Remote Runtime</div>
+					<div class="logo">${socketio}</div>
+					<div class="name">Socket.IO &middot; SLURM</div>
+				</div>
+
+				<div class="node" id="hyphy">
+					<div class="label">Analysis Engine</div>
+					<div class="logo recolor">${hyphy}</div>
+					<div class="name">HyPhy</div>
+				</div>
+			</div>
+
+			<script>
+				// Animation order follows the story:
+				//   1. Title
+				//   2. HyPhy (the foundation)
+				//   3. Execution transports + lines down to HyPhy
+				//   4. Entry points + lines into transports
+				const steps = [
+					['title', 300],
+					['hyphy', 900],
+					['wasm', 1500],
+					['line-wasm-hyphy', 1700],
+					['socket', 2100],
+					['line-socket-hyphy', 2300],
+					['svelte', 2900],
+					['line-svelte-wasm', 3100],
+					['line-svelte-socket', 3300],
+					['mcp', 3900],
+					['line-mcp-socket', 4100]
+				];
+				steps.forEach(([id, d]) => setTimeout(() => {
+					const el = document.getElementById(id);
+					if (el) el.classList.add('visible');
+				}, d));
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(4700 + 3500);
+});
+
+// ---------- SCENE 12: DUAL EXECUTION MODEL DIAGRAM ----------
+
+test('scene-12 — dual execution model (browser vs cluster)', async ({ page }) => {
+	const wasm = svg('webassembly.svg');
+	const socketio = svg('socketio.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#f8fafc; color:#0f172a; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:48px; }
+				h1 { font-size:15px; font-weight:600; text-transform:uppercase; letter-spacing:2px; color:#475569; margin:0; opacity:0; transition:opacity 0.6s ease; }
+				h1.visible { opacity:1; }
+				.layout { display:flex; align-items:center; gap:64px; }
+				.side { display:flex; flex-direction:column; align-items:center; gap:18px; padding:40px 56px; background:white; border-radius:20px; box-shadow:0 6px 32px rgba(15,23,42,0.08); border:1px solid #e2e8f0; min-width:360px; opacity:0; transform:scale(0.92); transition:opacity 0.7s ease, transform 0.7s ease; }
+				.side.visible { opacity:1; transform:scale(1); }
+				.side .logo { height:72px; display:flex; align-items:center; justify-content:center; }
+				.side .logo svg { height:72px; width:auto; max-width:240px; display:block; }
+				.side .title { font-size:20px; font-weight:700; color:#0f172a; }
+				.side .sub { font-size:14px; color:#64748b; text-align:center; line-height:1.5; max-width:280px; }
+				.side.local .title { color:#6930c3; }
+				.side.remote .title { color:#0369a1; }
+				.divider { display:flex; flex-direction:column; align-items:center; gap:12px; opacity:0; transition:opacity 0.6s ease; }
+				.divider.visible { opacity:1; }
+				.divider .or { font-size:13px; font-weight:700; color:#94a3b8; letter-spacing:2px; padding:10px 18px; border:2px solid #cbd5e1; border-radius:999px; background:white; }
+				.caption { font-size:15px; color:#334155; max-width:640px; text-align:center; line-height:1.6; opacity:0; transition:opacity 0.6s ease; }
+				.caption.visible { opacity:1; }
+				.pill { display:inline-flex; align-items:center; gap:6px; padding:4px 12px; background:#f1f5f9; border-radius:999px; font-size:12px; font-weight:600; color:#475569; margin-top:4px; }
+				.pill.stay { background:#ede9fe; color:#6930c3; }
+				.pill.send { background:#e0f2fe; color:#0369a1; }
+			</style>
+		</head>
+		<body>
+			<h1 id="title">Dual Execution Model</h1>
+			<div class="layout">
+				<div class="side local" id="left">
+					<div class="logo">${wasm}</div>
+					<div class="title">Local</div>
+					<div class="sub">HyPhy compiled to WebAssembly, running in your browser.</div>
+					<div class="pill stay">Data stays on your machine</div>
+				</div>
+				<div class="divider" id="divider">
+					<div class="or">OR</div>
+				</div>
+				<div class="side remote" id="right">
+					<div class="logo">${socketio}</div>
+					<div class="title">Remote</div>
+					<div class="sub">Large jobs stream to a SLURM-managed compute cluster.</div>
+					<div class="pill send">Data sent over Socket.IO</div>
+				</div>
+			</div>
+			<div class="caption" id="caption">One toggle. The interface does not change &mdash; only the location of the computation.</div>
+			<script>
+				const steps = [
+					['title', 300],
+					['left', 900],
+					['divider', 1500],
+					['right', 1900],
+					['caption', 2800]
+				];
+				steps.forEach(([id, d]) => setTimeout(() => document.getElementById(id).classList.add('visible'), d));
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(3200 + 4000);
+});
+
+// ---------- SCENE 13: DATAMONKEY 2 → 3 TRANSITION ----------
+
+test('scene-13 — datamonkey 2 to 3 transition', async ({ page }) => {
+	const dm = svg('datamonkey.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#fafaf9; color:#0f172a; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; align-items:center; justify-content:center; }
+				.wrap { display:flex; align-items:center; gap:64px; }
+				.slot { display:flex; flex-direction:column; align-items:center; gap:20px; padding:48px 64px; border-radius:24px; background:white; border:1px solid #e7e5e4; box-shadow:0 8px 40px rgba(15,23,42,0.08); min-width:380px; opacity:0; transform:translateY(16px); transition:opacity 0.8s ease, transform 0.8s ease; }
+				.slot.visible { opacity:1; transform:translateY(0); }
+				.slot .logo { height:90px; display:flex; align-items:center; justify-content:center; }
+				.slot .logo svg { height:90px; width:auto; max-width:320px; display:block; }
+				/* Datamonkey logo has white fills — recolor for light background */
+				.slot.v2 .logo svg * { fill:#78716c !important; }
+				.slot.v3 .logo svg * { fill:#7c3aed !important; }
+				.slot .v { font-size:42px; font-weight:800; letter-spacing:-1px; }
+				.slot.v2 .v { color:#a8a29e; }
+				.slot.v3 .v { background:linear-gradient(135deg,#7c3aed,#db2777); -webkit-background-clip:text; background-clip:text; color:transparent; }
+				.slot .tag { font-size:13px; color:#78716c; text-transform:uppercase; letter-spacing:2px; }
+				.arrow { opacity:0; transition:opacity 0.6s ease; font-size:48px; color:#a8a29e; }
+				.arrow.visible { opacity:1; }
+			</style>
+		</head>
+		<body>
+			<div class="wrap">
+				<div class="slot v2" id="v2">
+					<div class="logo">${dm}</div>
+					<div class="v">2</div>
+					<div class="tag">Since 2005</div>
+				</div>
+				<div class="arrow" id="arrow">&rarr;</div>
+				<div class="slot v3" id="v3">
+					<div class="logo">${dm}</div>
+					<div class="v">3</div>
+					<div class="tag">Reimagined</div>
+				</div>
+			</div>
+			<script>
+				setTimeout(() => document.getElementById('v2').classList.add('visible'), 500);
+				setTimeout(() => document.getElementById('arrow').classList.add('visible'), 1600);
+				setTimeout(() => document.getElementById('v3').classList.add('visible'), 2200);
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(3200 + 3500);
+});
+
+// ---------- SCENE 14: MCP + BROWSER ACCESS MODES ----------
+
+test('scene-14 — access modes: browser and MCP', async ({ page }) => {
+	const mcp = svg('mcp-logo.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0f172a; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; align-items:center; justify-content:center; }
+				.container { display:flex; flex-direction:column; align-items:center; gap:48px; }
+				h1 { font-size:14px; font-weight:600; text-transform:uppercase; letter-spacing:3px; color:#94a3b8; margin:0; opacity:0; transition:opacity 0.6s ease; }
+				h1.visible { opacity:1; }
+				.modes { display:flex; gap:32px; }
+				.mode { background:#1e293b; border:1px solid #334155; border-radius:16px; padding:32px 40px; display:flex; flex-direction:column; align-items:center; gap:16px; min-width:240px; opacity:0; transform:translateY(20px); transition:opacity 0.7s ease, transform 0.7s ease; }
+				.mode.visible { opacity:1; transform:translateY(0); }
+				.mode .glyph { min-width:72px; height:72px; display:flex; align-items:center; justify-content:center; font-size:56px; color:#cbd5e1; }
+				.mode.light { background:#f8fafc; color:#0f172a; }
+				.mode .label { font-size:12px; color:#64748b; text-transform:uppercase; letter-spacing:1.5px; }
+				.mode.light .label { color:#475569; }
+				.mode .name { font-size:20px; font-weight:700; color:#f1f5f9; }
+				.mode.light .name { color:#0f172a; }
+				.mode .sub { font-size:13px; color:#94a3b8; text-align:center; max-width:260px; line-height:1.5; }
+				.mode.light .sub { color:#64748b; }
+				.mode .glyph svg { height:56px; width:auto; max-width:420px; display:block; }
+				.mode .glyph img { height:56px; width:auto; display:block; }
+				.mode.wide { min-width:440px; }
+				.arrow-down { font-size:24px; color:#475569; opacity:0; transition:opacity 0.6s ease; }
+				.arrow-down.visible { opacity:1; }
+				.target { padding:20px 40px; background:linear-gradient(135deg,#7c3aed,#db2777); border-radius:14px; font-size:20px; font-weight:700; color:white; letter-spacing:0.5px; opacity:0; transform:scale(0.92); transition:opacity 0.7s ease, transform 0.7s ease; }
+				.target.visible { opacity:1; transform:scale(1); }
+			</style>
+		</head>
+		<body>
+			<div class="container">
+				<h1 id="title">How to reach Datamonkey 3</h1>
+				<div class="modes">
+					<div class="mode" id="m1">
+						<div class="glyph">&#x1F310;</div>
+						<div class="label">Interactive</div>
+						<div class="name">Browser</div>
+						<div class="sub">The three-tab web interface at v3.datamonkey.org</div>
+					</div>
+					<div class="mode light wide" id="m2">
+						<div class="label">Programmatic</div>
+						<div class="glyph">${mcp}</div>
+						<div class="sub">Any MCP-aware client &mdash; Claude, Cursor, your own agent</div>
+					</div>
+				</div>
+				<div class="arrow-down" id="arrow">&darr;</div>
+				<div class="target" id="target">Datamonkey 3</div>
+			</div>
+			<script>
+				const steps = [
+					['title', 400],
+					['m1', 900],
+					['m2', 1400],
+					['arrow', 2200],
+					['target', 2600]
+				];
+				steps.forEach(([id, d]) => setTimeout(() => document.getElementById(id).classList.add('visible'), d));
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(3200 + 3500);
+});
+
+// ---------- ACT 1 INTRO SCENES ----------
+
+// ---------- SCENE A1: MILLION-JOB COUNTER ----------
+
+test('scene-a1 — million job counter', async ({ page }) => {
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0a0e16; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:24px; }
+				.counter { font-family:'SF Mono','Fira Code','Courier New',monospace; font-size:140px; font-weight:700; letter-spacing:-2px; color:#f8fafc; font-variant-numeric:tabular-nums; opacity:0; transition:opacity 0.8s ease; }
+				.counter.visible { opacity:1; }
+				.sub { font-size:16px; color:#64748b; letter-spacing:3px; text-transform:uppercase; opacity:0; transition:opacity 0.8s ease; }
+				.sub.visible { opacity:1; }
+				.plus { color:#7c3aed; }
+			</style>
+		</head>
+		<body>
+			<div class="counter" id="counter">0</div>
+			<div class="sub" id="sub">jobs processed since 2005</div>
+			<script>
+				const el = document.getElementById('counter');
+				const sub = document.getElementById('sub');
+				const target = 1245000;
+				const duration = 5500;
+				const start = performance.now();
+
+				setTimeout(() => el.classList.add('visible'), 300);
+				setTimeout(() => sub.classList.add('visible'), 900);
+
+				function tick(now) {
+					const t = Math.min((now - start - 300) / duration, 1);
+					if (t < 0) { requestAnimationFrame(tick); return; }
+					const eased = 1 - Math.pow(1 - t, 3);
+					const value = Math.floor(target * eased);
+					el.textContent = value.toLocaleString();
+					if (t < 1) requestAnimationFrame(tick);
+					else el.innerHTML = value.toLocaleString() + '<span class="plus">+</span>';
+				}
+				requestAnimationFrame(tick);
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(300 + 5500 + 2500);
+});
+
+// ---------- SCENE A2: FOUR-PHYLOGENY SLIDESHOW ----------
+
+test('scene-a2 — four phylogenies slideshow', async ({ page }) => {
+	// Hand-drawn schematic phylogenies. Each tree has a characteristic topology
+	// that visually suggests the study's biological reality:
+	//   - HIV: bushy, many short branches (within-host diversity)
+	//   - Flu: ladder-like (seasonal antigenic drift)
+	//   - SARS-CoV-2: starburst (rapid early expansion from one source)
+	//   - Insect chemoreceptors: balanced cladogram (ancient duplication)
+	// Trees are generated in the page's JS so the positions are deterministic
+	// per page load but visually varied.
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0a0e16; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; align-items:center; justify-content:center; position:relative; overflow:hidden; }
+				.slide { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; gap:80px; padding:0 120px; opacity:0; transition:opacity 1s ease; }
+				.slide.visible { opacity:1; }
+				.tree-container { width:480px; height:480px; display:flex; align-items:center; justify-content:center; }
+				.tree-container svg { width:100%; height:100%; }
+				.tree-container svg line, .tree-container svg path.branch { stroke:#cbd5e1; stroke-width:1.5; fill:none; stroke-linecap:round; }
+				.tree-container svg circle.tip { fill:#f8fafc; }
+				.tree-container svg circle.root { fill:#7c3aed; }
+				.caption { max-width:420px; }
+				.caption .method { font-size:14px; letter-spacing:3px; text-transform:uppercase; color:#7c3aed; font-weight:600; margin-bottom:16px; }
+				.caption .title { font-size:28px; font-weight:600; color:#f8fafc; line-height:1.3; margin-bottom:14px; letter-spacing:-0.5px; }
+				.caption .year { font-size:13px; color:#64748b; letter-spacing:2px; text-transform:uppercase; margin-bottom:18px; }
+				.caption .note { font-size:15px; color:#94a3b8; line-height:1.6; }
+			</style>
+		</head>
+		<body>
+			<div class="slide" id="s1">
+				<div class="tree-container"><svg viewBox="0 0 400 400" id="tree1"></svg></div>
+				<div class="caption">
+					<div class="method">MEME</div>
+					<div class="title">Episodic selection in HIV-1 env</div>
+					<div class="year">Durban &middot; 2009</div>
+					<div class="note">Detecting site-specific adaptive bursts across a heterogeneous viral population.</div>
+				</div>
+			</div>
+
+			<div class="slide" id="s2">
+				<div class="tree-container"><svg viewBox="0 0 400 400" id="tree2"></svg></div>
+				<div class="caption">
+					<div class="method">FUBAR</div>
+					<div class="title">Antigenic drift in influenza H3N2</div>
+					<div class="year">Global surveillance &middot; 1968&ndash;2020</div>
+					<div class="note">Pervasive purifying selection punctuated by seasonal epitope shifts across half a century.</div>
+				</div>
+			</div>
+
+			<div class="slide" id="s3">
+				<div class="tree-container"><svg viewBox="0 0 400 400" id="tree3"></svg></div>
+				<div class="caption">
+					<div class="method">SLAC &middot; FEL</div>
+					<div class="title">First selection scans on SARS-CoV-2</div>
+					<div class="year">Wuhan &rarr; global &middot; early 2020</div>
+					<div class="note">Run on the earliest published genomes &mdash; while the world was still learning the virus's name.</div>
+				</div>
+			</div>
+
+			<div class="slide" id="s4">
+				<div class="tree-container"><svg viewBox="0 0 400 400" id="tree4"></svg></div>
+				<div class="caption">
+					<div class="method">aBSREL</div>
+					<div class="title">Insect chemoreceptor evolution</div>
+					<div class="year">Hymenoptera &middot; ongoing</div>
+					<div class="note">Branch-site tests on receptor families that whisper about the origins of social life.</div>
+				</div>
+			</div>
+
+			<script>
+				// Deterministic pseudo-random for reproducible trees
+				function makeRng(seed) {
+					let s = seed;
+					return () => {
+						s = (s * 1103515245 + 12345) & 0x7fffffff;
+						return s / 0x7fffffff;
+					};
+				}
+				function el(tag, attrs) {
+					const e = document.createElementNS('http://www.w3.org/2000/svg', tag);
+					for (const k in attrs) e.setAttribute(k, attrs[k]);
+					return e;
+				}
+
+				// Tree 1: HIV — bushy radial
+				(() => {
+					const svg = document.getElementById('tree1');
+					const rng = makeRng(42);
+					const g = el('g', { transform: 'translate(200,200)' });
+					svg.appendChild(g);
+					for (let i = 0; i < 32; i++) {
+						const angle = (i / 32) * Math.PI * 2 + (rng() - 0.5) * 0.1;
+						const l1 = 55 + rng() * 25;
+						const l2 = l1 + 35 + rng() * 45;
+						const l3 = l2 + 20 + rng() * 30;
+						const p = (r) => [Math.cos(angle) * r, Math.sin(angle) * r];
+						const [x1,y1] = p(l1), [x2,y2] = p(l2), [x3,y3] = p(l3);
+						g.appendChild(el('line', { x1:0, y1:0, x2:x1, y2:y1 }));
+						g.appendChild(el('line', { x1:x1, y1:y1, x2:x2, y2:y2 }));
+						g.appendChild(el('line', { x1:x2, y1:y2, x2:x3, y2:y3 }));
+						g.appendChild(el('circle', { class:'tip', cx:x3, cy:y3, r:2.5 }));
+					}
+					g.appendChild(el('circle', { class:'root', cx:0, cy:0, r:4.5 }));
+				})();
+
+				// Tree 2: Influenza — ladder with branches fanning up
+				(() => {
+					const svg = document.getElementById('tree2');
+					const rng = makeRng(97);
+					const startX = 50, endX = 370, trunkY = 280;
+					svg.appendChild(el('line', { x1:startX, y1:trunkY, x2:endX, y2:trunkY }));
+					for (let i = 0; i < 20; i++) {
+						const x = startX + (endX - startX) * ((i + 0.5) / 20);
+						const branchLen = 45 + rng() * 110;
+						const tipX = x + (rng() - 0.5) * 20;
+						const tipY = trunkY - branchLen;
+						svg.appendChild(el('line', { x1:x, y1:trunkY, x2:tipX, y2:tipY }));
+						for (let j = 0; j < 2; j++) {
+							const subY = trunkY - branchLen * (0.5 + j * 0.3);
+							const subTipX = tipX + (rng() - 0.5) * 28;
+							const subTipY = subY - 14 - rng() * 20;
+							svg.appendChild(el('line', { x1:tipX, y1:subY, x2:subTipX, y2:subTipY }));
+							svg.appendChild(el('circle', { class:'tip', cx:subTipX, cy:subTipY, r:2.3 }));
+						}
+						svg.appendChild(el('circle', { class:'tip', cx:tipX, cy:tipY, r:2.5 }));
+					}
+					svg.appendChild(el('circle', { class:'root', cx:startX, cy:trunkY, r:4.5 }));
+				})();
+
+				// Tree 3: SARS-CoV-2 — long radial starburst
+				(() => {
+					const svg = document.getElementById('tree3');
+					const rng = makeRng(31);
+					const g = el('g', { transform: 'translate(200,200)' });
+					svg.appendChild(g);
+					for (let i = 0; i < 24; i++) {
+						const angle = (i / 24) * Math.PI * 2 + (rng() - 0.5) * 0.12;
+						const len = 120 + rng() * 50;
+						const x = Math.cos(angle) * len;
+						const y = Math.sin(angle) * len;
+						g.appendChild(el('line', { x1:0, y1:0, x2:x, y2:y }));
+						for (let j = 0; j < 2; j++) {
+							const midR = len * (0.72 + j * 0.12);
+							const mx = Math.cos(angle) * midR;
+							const my = Math.sin(angle) * midR;
+							const perp = angle + Math.PI / 2;
+							const side = j === 0 ? 1 : -1;
+							const sub = 10 + rng() * 12;
+							const sx = mx + Math.cos(perp) * sub * side;
+							const sy = my + Math.sin(perp) * sub * side;
+							g.appendChild(el('line', { x1:mx, y1:my, x2:sx, y2:sy }));
+							g.appendChild(el('circle', { class:'tip', cx:sx, cy:sy, r:2 }));
+						}
+						g.appendChild(el('circle', { class:'tip', cx:x, cy:y, r:2.5 }));
+					}
+					g.appendChild(el('circle', { class:'root', cx:0, cy:0, r:5 }));
+				})();
+
+				// Tree 4: Insect chemoreceptors — balanced cladogram
+				(() => {
+					const svg = document.getElementById('tree4');
+					function branch(x1, y1, x2, y2, depth) {
+						svg.appendChild(el('line', { x1, y1, x2, y2 }));
+						if (depth === 0) {
+							svg.appendChild(el('circle', { class:'tip', cx:x2, cy:y2, r:2.5 }));
+							return;
+						}
+						const span = 70 / Math.pow(1.75, 4 - depth);
+						const nx1 = x2 - span;
+						const nx2 = x2 + span;
+						const ny = y2 + 60;
+						svg.appendChild(el('line', { x1:x2, y1:y2, x2:nx1, y2:y2 }));
+						svg.appendChild(el('line', { x1:x2, y1:y2, x2:nx2, y2:y2 }));
+						branch(nx1, y2, nx1, ny, depth - 1);
+						branch(nx2, y2, nx2, ny, depth - 1);
+					}
+					branch(200, 20, 200, 60, 4);
+					svg.appendChild(el('circle', { class:'root', cx:200, cy:20, r:5 }));
+				})();
+
+				// Slide timing: 4 slides, each held ~4.2s with 0.5s crossfade overlap
+				const slides = ['s1', 's2', 's3', 's4'];
+				const hold = 4200;
+				const fadeOverlap = 500;
+				slides.forEach((id, i) => {
+					setTimeout(() => document.getElementById(id).classList.add('visible'), 400 + i * (hold - fadeOverlap));
+					if (i < slides.length - 1) {
+						setTimeout(() => document.getElementById(id).classList.remove('visible'), 400 + (i + 1) * (hold - fadeOverlap));
+					}
+				});
+			</script>
+		</body>
+		</html>
+	`);
+
+	// 400 start + 4 slides * 3700ms step + final hold
+	await page.waitForTimeout(400 + 4 * 3700 + 1500);
+});
+
+// ---------- SCENE A3: DATA-STAYS-HERE DIAGRAM ----------
+
+test('scene-a3 — data stays here', async ({ page }) => {
+	const wasm = svg('webassembly.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0a0e16; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:56px; }
+				h2 { font-size:14px; letter-spacing:3px; text-transform:uppercase; color:#64748b; margin:0; opacity:0; transition:opacity 0.6s ease; font-weight:400; }
+				h2.visible { opacity:1; }
+				.panels { display:flex; gap:64px; align-items:stretch; }
+				.panel { background:#1e293b; border:1px solid #334155; border-radius:18px; padding:40px 48px; display:flex; flex-direction:column; align-items:center; gap:20px; min-width:440px; min-height:360px; opacity:0; transform:translateY(20px); transition:opacity 0.8s ease, transform 0.8s ease; }
+				.panel.visible { opacity:1; transform:translateY(0); }
+				.panel.before { border-color:rgba(239,68,68,0.4); }
+				.panel.after { border-color:rgba(34,197,94,0.4); }
+				.panel .stamp { font-size:12px; letter-spacing:2px; text-transform:uppercase; font-weight:600; padding:5px 14px; border-radius:999px; }
+				.panel.before .stamp { background:rgba(239,68,68,0.12); color:#fca5a5; }
+				.panel.after .stamp { background:rgba(34,197,94,0.12); color:#86efac; }
+				.flow { display:flex; align-items:center; gap:20px; margin:20px 0 10px; }
+				.glyph { width:80px; height:80px; display:flex; align-items:center; justify-content:center; font-size:48px; border-radius:16px; background:#0f172a; border:1px solid #334155; }
+				.glyph.file { font-size:40px; }
+				.glyph.cloud { font-size:44px; color:#94a3b8; }
+				.glyph.wasm { padding:12px; }
+				.glyph.wasm svg { height:56px; width:auto; }
+				.arrow { font-size:36px; color:#475569; }
+				.arrow.red { color:#ef4444; }
+				.arrow.green { color:#22c55e; }
+				.caption { text-align:center; max-width:360px; line-height:1.5; }
+				.caption .big { font-size:22px; font-weight:600; margin-bottom:8px; letter-spacing:-0.3px; }
+				.panel.before .big { color:#fca5a5; }
+				.panel.after .big { color:#86efac; }
+				.caption .small { font-size:14px; color:#94a3b8; }
+				.subtitle { font-size:16px; color:#cbd5e1; max-width:720px; text-align:center; line-height:1.6; opacity:0; transition:opacity 0.6s ease; }
+				.subtitle.visible { opacity:1; }
+			</style>
+		</head>
+		<body>
+			<h2 id="title">Where does your data go?</h2>
+
+			<div class="panels">
+				<div class="panel before" id="p1">
+					<div class="stamp">Datamonkey 2</div>
+					<div class="flow">
+						<div class="glyph file">&#x1F4C4;</div>
+						<div class="arrow red">&rarr;</div>
+						<div class="glyph cloud">&#x2601;&#xFE0F;</div>
+					</div>
+					<div class="caption">
+						<div class="big">Uploaded</div>
+						<div class="small">Alignments leave your institution, traverse the network, and sit on someone else's disk.</div>
+					</div>
+				</div>
+
+				<div class="panel after" id="p2">
+					<div class="stamp">Datamonkey 3</div>
+					<div class="flow">
+						<div class="glyph file">&#x1F4C4;</div>
+						<div class="arrow green">&rarr;</div>
+						<div class="glyph wasm">${wasm}</div>
+					</div>
+					<div class="caption">
+						<div class="big">Stays here</div>
+						<div class="small">HyPhy runs in your browser via WebAssembly. The file never crosses the network.</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="subtitle" id="sub">Your data is your data.</div>
+
+			<script>
+				const steps = [
+					['title', 300],
+					['p1', 900],
+					['p2', 1700],
+					['sub', 2800]
+				];
+				steps.forEach(([id, d]) => setTimeout(() => document.getElementById(id).classList.add('visible'), d));
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(3400 + 3500);
+});
+
+// ---------- SCENE A4: THREE-PATH FAN-OUT (REVEAL) ----------
+
+test('scene-a4 — three-path fan-out reveal', async ({ page }) => {
+	const socketio = svg('socketio.svg');
+	const mcp = svg('mcp-logo.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0a0e16; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:28px; position:relative; }
+				h2 { font-size:14px; letter-spacing:3px; text-transform:uppercase; color:#64748b; margin:0; opacity:0; transition:opacity 0.6s ease; font-weight:400; }
+				h2.visible { opacity:1; }
+
+				.diagram { position:relative; width:1100px; height:520px; }
+
+				.hub {
+					position:absolute; top:40%; left:50%; transform:translate(-50%, -50%) scale(0.9);
+					padding:28px 56px; background:linear-gradient(135deg,#7c3aed,#db2777);
+					border-radius:20px; box-shadow:0 10px 48px rgba(124,58,237,0.35);
+					opacity:0; transition:opacity 0.9s ease, transform 0.9s ease;
+					text-align:center;
+				}
+				.hub.visible { opacity:1; transform:translate(-50%, -50%) scale(1); }
+				.hub .mark { font-size:11px; letter-spacing:3px; text-transform:uppercase; color:rgba(255,255,255,0.75); margin-bottom:6px; }
+				.hub .name { font-size:36px; font-weight:700; color:white; letter-spacing:-0.5px; }
+
+				.spoke {
+					position:absolute;
+					background:#f8fafc; border:1px solid #e2e8f0; border-radius:14px;
+					padding:20px 28px; min-width:220px;
+					display:flex; flex-direction:column; align-items:center; gap:10px;
+					opacity:0; transform:scale(0.9);
+					transition:opacity 0.8s ease, transform 0.8s ease;
+					box-shadow:0 8px 32px rgba(0,0,0,0.35);
+				}
+				.spoke.visible { opacity:1; transform:scale(1); }
+				.spoke .label { font-size:10px; letter-spacing:1.5px; text-transform:uppercase; color:#64748b; }
+				.spoke .name { font-size:16px; font-weight:600; color:#0f172a; }
+				.spoke .glyph { height:48px; display:flex; align-items:center; justify-content:center; }
+				.spoke .glyph svg { height:48px; width:auto; max-width:220px; display:block; }
+				.spoke .glyph.icon { font-size:44px; }
+				.spoke .glyph.wide svg { height:36px; max-width:340px; }
+				.spoke.mcp-card { min-width:380px; }
+
+				#browser { top:40px; left:120px; }
+				#cluster { top:40px; right:120px; }
+				#mcp     { bottom:20px; left:50%; transform:translate(-50%, 0) scale(0.9); }
+				#mcp.visible { transform:translate(-50%, 0) scale(1); }
+
+				svg.lines { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; }
+				svg.lines path { stroke:#475569; stroke-width:2.5; fill:none; stroke-linecap:round; opacity:0; transition:opacity 0.8s ease; }
+				svg.lines path.visible { opacity:0.8; }
+			</style>
+		</head>
+		<body>
+			<h2 id="title">Three ways in</h2>
+
+			<div class="diagram">
+				<svg class="lines" viewBox="0 0 1100 520" preserveAspectRatio="none">
+					<path id="line-browser" d="M 240 105 C 340 180, 430 230, 540 250" />
+					<path id="line-cluster" d="M 860 105 C 760 180, 670 230, 560 250" />
+					<path id="line-mcp" d="M 550 440 L 550 340" />
+				</svg>
+
+				<div class="hub" id="hub">
+					<div class="name">Datamonkey 3</div>
+				</div>
+
+				<div class="spoke" id="browser">
+					<div class="label">Interactive</div>
+					<div class="glyph icon">&#x1F310;</div>
+					<div class="name">Browser</div>
+				</div>
+
+				<div class="spoke" id="cluster">
+					<div class="label">Heavy compute</div>
+					<div class="glyph">${socketio}</div>
+					<div class="name">Socket.IO &middot; SLURM</div>
+				</div>
+
+				<div class="spoke mcp-card" id="mcp">
+					<div class="label">Agent-ready</div>
+					<div class="glyph wide">${mcp}</div>
+				</div>
+			</div>
+
+			<script>
+				const steps = [
+					['title', 300],
+					['hub', 900],
+					['browser', 1700],
+					['line-browser', 1900],
+					['cluster', 2400],
+					['line-cluster', 2600],
+					['mcp', 3100],
+					['line-mcp', 3300]
+				];
+				steps.forEach(([id, d]) => setTimeout(() => {
+					const el = document.getElementById(id);
+					if (el) el.classList.add('visible');
+				}, d));
+			</script>
+		</body>
+		</html>
+	`);
+
+	await page.waitForTimeout(3500 + 3500);
+});
+
+// ---------- SCENE A4 HIGHLIGHT STILLS ----------
+// Three static PNGs that reuse the scene-a4 layout, each one with a different
+// spoke highlighted (others dimmed) and the connecting line emphasized.
+// Saves directly to video-frames/scene-a4-highlight-{browser,cluster,mcp}.png.
+
+test('scene-a4-highlights — three highlight stills', async ({ page }) => {
+	const socketio = svg('socketio.svg');
+	const mcp = svg('mcp-logo.svg');
+
+	await page.setContent(`
+		<html>
+		<head>
+			<style>
+				* { box-sizing: border-box; }
+				body { margin:0; background:#0a0e16; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; height:100vh; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:28px; position:relative; }
+				h2 { font-size:14px; letter-spacing:3px; text-transform:uppercase; color:#64748b; margin:0; font-weight:400; }
+
+				.diagram { position:relative; width:1100px; height:520px; }
+
+				.hub {
+					position:absolute; top:40%; left:50%; transform:translate(-50%, -50%);
+					padding:28px 56px; background:linear-gradient(135deg,#7c3aed,#db2777);
+					border-radius:20px; box-shadow:0 10px 48px rgba(124,58,237,0.35);
+					text-align:center; transition:opacity 0.3s ease;
+				}
+				.hub .name { font-size:36px; font-weight:700; color:white; letter-spacing:-0.5px; }
+
+				.spoke {
+					position:absolute;
+					background:#f8fafc; border:1px solid #e2e8f0; border-radius:14px;
+					padding:20px 28px; min-width:220px;
+					display:flex; flex-direction:column; align-items:center; gap:10px;
+					box-shadow:0 8px 32px rgba(0,0,0,0.35);
+					transition:opacity 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+				}
+				.spoke .label { font-size:10px; letter-spacing:1.5px; text-transform:uppercase; color:#64748b; }
+				.spoke .name { font-size:16px; font-weight:600; color:#0f172a; }
+				.spoke .glyph { height:48px; display:flex; align-items:center; justify-content:center; }
+				.spoke .glyph svg { height:48px; width:auto; max-width:220px; display:block; }
+				.spoke .glyph.icon { font-size:44px; }
+				.spoke .glyph.wide svg { height:36px; max-width:340px; }
+				.spoke.mcp-card { min-width:380px; }
+
+				/* Highlight / dim states */
+				.spoke.dim { opacity:0.25; filter:saturate(0.4); }
+				.spoke.bright {
+					transform:scale(1.08);
+					border-color:#7c3aed;
+					box-shadow:0 0 0 3px rgba(124,58,237,0.25), 0 14px 40px rgba(124,58,237,0.35);
+				}
+				.spoke.bright .label { color:#7c3aed; }
+				.hub.dim { opacity:0.5; }
+
+				#browser { top:40px; left:120px; }
+				#cluster { top:40px; right:120px; }
+				#mcp     { bottom:20px; left:50%; transform:translate(-50%, 0); }
+				#mcp.bright { transform:translate(-50%, 0) scale(1.08); }
+
+				svg.lines { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; }
+				svg.lines path { fill:none; stroke:#475569; stroke-width:2.5; stroke-linecap:round; opacity:0.25; transition:opacity 0.3s ease, stroke 0.3s ease, stroke-width 0.3s ease; }
+				svg.lines path.bright { stroke:#7c3aed; stroke-width:4; opacity:1; filter:drop-shadow(0 0 6px rgba(124,58,237,0.7)); }
+			</style>
+		</head>
+		<body>
+			<h2>Three ways in</h2>
+
+			<div class="diagram">
+				<svg class="lines" viewBox="0 0 1100 520" preserveAspectRatio="none">
+					<path id="line-browser" d="M 240 105 C 340 180, 430 230, 540 250" />
+					<path id="line-cluster" d="M 860 105 C 760 180, 670 230, 560 250" />
+					<path id="line-mcp" d="M 550 440 L 550 340" />
+				</svg>
+
+				<div class="hub" id="hub">
+					<div class="name">Datamonkey 3</div>
+				</div>
+
+				<div class="spoke" id="browser">
+					<div class="label">Interactive</div>
+					<div class="glyph icon">&#x1F310;</div>
+					<div class="name">Browser</div>
+				</div>
+
+				<div class="spoke" id="cluster">
+					<div class="label">Heavy compute</div>
+					<div class="glyph">${socketio}</div>
+					<div class="name">Socket.IO &middot; SLURM</div>
+				</div>
+
+				<div class="spoke mcp-card" id="mcp">
+					<div class="label">Agent-ready</div>
+					<div class="glyph wide">${mcp}</div>
+				</div>
+			</div>
+		</body>
+		</html>
+	`);
+
+	// Apply highlight state and screenshot for each of the three spokes.
+	const variants = [
+		{ name: 'browser', spoke: 'browser', line: 'line-browser' },
+		{ name: 'cluster', spoke: 'cluster', line: 'line-cluster' },
+		{ name: 'mcp', spoke: 'mcp', line: 'line-mcp' }
+	];
+
+	for (const v of variants) {
+		await page.evaluate(({ spoke, line }) => {
+			// Reset classes
+			for (const id of ['browser', 'cluster', 'mcp']) {
+				const el = document.getElementById(id);
+				el.classList.remove('bright', 'dim');
+			}
+			for (const id of ['line-browser', 'line-cluster', 'line-mcp']) {
+				document.getElementById(id).classList.remove('bright');
+			}
+
+			// Apply new state
+			for (const id of ['browser', 'cluster', 'mcp']) {
+				const el = document.getElementById(id);
+				if (id === spoke) el.classList.add('bright');
+				else el.classList.add('dim');
+			}
+			document.getElementById(line).classList.add('bright');
+		}, v);
+
+		// Let the CSS transition settle
+		await page.waitForTimeout(500);
+
+		await page.screenshot({
+			path: `video-frames/scene-a4-highlight-${v.name}.png`,
+			fullPage: false
+		});
+	}
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,11 @@ export default defineConfig({
 
 	// 50% of logical cores. Deliberately not higher: several specs run WASM/ONNX inference under
 	// wall-clock timeouts, and oversubscribing turns those into timeout flakes rather than speed.
-	workers: process.env.CI ? 1 : '50%',
+	// Lowered from 50% when the suite grew from 109 to 129 tests. The new specs are WASM- and
+	// ONNX-heavy, and at 7 workers the AxoMEME spec failed seven ways under contention while passing
+	// 9/9 in isolation — a resource limit reported as test failures. 3 workers is the measured point
+	// where that stops.
+	workers: process.env.CI ? 1 : 3,
 
 	reporter:
 		process.env.E2E_COVERAGE === '1'

--- a/scripts/compose-figure5.sh
+++ b/scripts/compose-figure5.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Compose figure5-results.png from the three panel screenshots.
+#
+# Layout (2560 x 1600, ~16:10, fits a full-text-width figure*):
+#   Panel A (tree)       left half     (0..1280, 0..1600)
+#   Panel B (table)      top right     (1280..2560, 0..1000)
+#   Panel C (ω detail)   bottom right  (1280..2560, 1000..1600)
+#
+# Each panel has a small label strip at its top containing a bold
+# A/B/C corner label, then the screenshot fitted below. Matches the
+# style of Workflow2.png where labels sit above panel content.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+IMG="$DIR/Datamonkey_2_0/images"
+
+A="$IMG/figure5-panelA-tree.png"
+B="$IMG/figure5-panelB-table.png"
+C="$IMG/figure5-panelC-detail.png"
+OUT="$IMG/figure5-results.png"
+
+for f in "$A" "$B" "$C"; do
+	[[ -f "$f" ]] || { echo "missing: $f"; exit 1; }
+done
+
+W=2560
+H=1600
+LEFT_W=1280
+RIGHT_W=$((W - LEFT_W))           # 1280
+TOP_H=1000
+BOTTOM_H=$((H - TOP_H))           # 600
+PAD=24                             # outer gutter between tiles
+LABEL_STRIP=78                     # top strip inside each tile reserved for label
+LBL_INSET=18
+
+CONTENT_W_LEFT=$((LEFT_W - 2*PAD))
+CONTENT_H_LEFT=$((H - 2*PAD - LABEL_STRIP))
+CONTENT_W_RIGHT=$((RIGHT_W - 2*PAD))
+CONTENT_H_TOP=$((TOP_H - 2*PAD - LABEL_STRIP))
+CONTENT_H_BOT=$((BOTTOM_H - 2*PAD - LABEL_STRIP))
+
+TMP="$(mktemp -d)"
+trap "rm -rf $TMP" EXIT
+
+echo "Resizing panels..."
+magick "$A" -resize "${CONTENT_W_LEFT}x${CONTENT_H_LEFT}>" -background white -gravity center -extent "${CONTENT_W_LEFT}x${CONTENT_H_LEFT}" "$TMP/A.png"
+magick "$B" -resize "${CONTENT_W_RIGHT}x${CONTENT_H_TOP}>" -background white -gravity center -extent "${CONTENT_W_RIGHT}x${CONTENT_H_TOP}" "$TMP/B.png"
+magick "$C" -resize "${CONTENT_W_RIGHT}x${CONTENT_H_BOT}>" -background white -gravity center -extent "${CONTENT_W_RIGHT}x${CONTENT_H_BOT}" "$TMP/C.png"
+
+A_X=${PAD}
+A_Y=$((PAD + LABEL_STRIP))
+B_X=$((LEFT_W + PAD))
+B_Y=$((PAD + LABEL_STRIP))
+C_X=$((LEFT_W + PAD))
+C_Y=$((TOP_H + PAD + LABEL_STRIP))
+
+echo "Compositing canvas..."
+magick -size "${W}x${H}" canvas:white \
+	"$TMP/A.png" -geometry "+${A_X}+${A_Y}" -composite \
+	"$TMP/B.png" -geometry "+${B_X}+${B_Y}" -composite \
+	"$TMP/C.png" -geometry "+${C_X}+${C_Y}" -composite \
+	"$TMP/composite.png"
+
+echo "Drawing tile borders..."
+A_TILE_X1=${PAD}; A_TILE_Y1=${PAD}; A_TILE_X2=$((LEFT_W - PAD)); A_TILE_Y2=$((H - PAD))
+B_TILE_X1=$((LEFT_W + PAD)); B_TILE_Y1=${PAD}; B_TILE_X2=$((W - PAD)); B_TILE_Y2=$((TOP_H - PAD))
+C_TILE_X1=$((LEFT_W + PAD)); C_TILE_Y1=$((TOP_H + PAD)); C_TILE_X2=$((W - PAD)); C_TILE_Y2=$((H - PAD))
+
+magick "$TMP/composite.png" \
+	-stroke "#d6d6d6" -strokewidth 1 -fill none \
+	-draw "rectangle ${A_TILE_X1},${A_TILE_Y1} ${A_TILE_X2},${A_TILE_Y2}" \
+	-draw "rectangle ${B_TILE_X1},${B_TILE_Y1} ${B_TILE_X2},${B_TILE_Y2}" \
+	-draw "rectangle ${C_TILE_X1},${C_TILE_Y1} ${C_TILE_X2},${C_TILE_Y2}" \
+	"$TMP/bordered.png"
+
+echo "Adding panel labels..."
+LBL_FONT_SIZE=64
+LBL_BASELINE_Y_OFFSET=$((LBL_FONT_SIZE - 6))
+A_LBL_X=$((A_TILE_X1 + LBL_INSET))
+A_LBL_Y=$((A_TILE_Y1 + LBL_INSET + LBL_BASELINE_Y_OFFSET))
+B_LBL_X=$((B_TILE_X1 + LBL_INSET))
+B_LBL_Y=$((B_TILE_Y1 + LBL_INSET + LBL_BASELINE_Y_OFFSET))
+C_LBL_X=$((C_TILE_X1 + LBL_INSET))
+C_LBL_Y=$((C_TILE_Y1 + LBL_INSET + LBL_BASELINE_Y_OFFSET))
+
+magick "$TMP/bordered.png" \
+	-pointsize "$LBL_FONT_SIZE" -font "Helvetica-Bold" -fill black \
+	-annotate "+${A_LBL_X}+${A_LBL_Y}" "A" \
+	-annotate "+${B_LBL_X}+${B_LBL_Y}" "B" \
+	-annotate "+${C_LBL_X}+${C_LBL_Y}" "C" \
+	"$OUT"
+
+echo "✓ wrote $OUT"
+magick identify "$OUT"

--- a/scripts/screenshot-absrel-results.js
+++ b/scripts/screenshot-absrel-results.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Capture aBSREL results panels for Figure 5.
+ *
+ * Seeds a known aBSREL result JSON (from hyphy-eye's test-data set,
+ * a bat PIGQ alignment with 9 positively-selected branches) directly
+ * into the app's IndexedDB and then captures element screenshots of
+ * the rendered Results view: phylogenetic tree, branch-by-branch
+ * results table, and the summary tiles.
+ *
+ * Why seed instead of running WASM end-to-end:
+ *  - aBSREL via WASM on any non-trivial alignment takes well over 10
+ *    minutes; we instead use a pre-computed result that has the
+ *    branches-under-selection signal a reader expects to see.
+ *  - The visualization code path is identical for seeded vs. WASM
+ *    results — what's rendered is exactly what a real run shows.
+ *
+ * Usage:
+ *   node scripts/screenshot-absrel-results.js
+ */
+
+import { chromium } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const OUT_DIR = path.join(REPO_ROOT, 'Datamonkey_2_0', 'images');
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+const FIXTURE_PATH =
+	process.env.ABSREL_FIXTURE ||
+	'/Users/sweaver/Programming/_bioinformatics/hyphy-eye/src/data/absrel_test_data.json';
+const DEVICE_SCALE = 3;
+
+if (!fs.existsSync(FIXTURE_PATH)) {
+	console.error(`Fixture not found at ${FIXTURE_PATH}`);
+	process.exit(1);
+}
+const FIXTURE = fs.readFileSync(FIXTURE_PATH, 'utf8');
+
+async function clearAllState(page) {
+	await page.evaluate(() => {
+		return new Promise((resolve) => {
+			const req = indexedDB.deleteDatabase('datamonkey-db');
+			req.onsuccess = () => resolve();
+			req.onerror = () => resolve();
+			req.onblocked = () => resolve();
+		});
+	});
+}
+
+async function seedAnalysis(page, resultJson, fileName) {
+	return await page.evaluate(
+		async ({ resultJson, fileName }) => {
+			function openDB() {
+				return new Promise((resolve, reject) => {
+					const req = indexedDB.open('datamonkey-db', 2);
+					req.onupgradeneeded = (e) => {
+						const db = e.target.result;
+						if (!db.objectStoreNames.contains('files'))
+							db.createObjectStore('files', { keyPath: 'id' });
+						if (!db.objectStoreNames.contains('analyses'))
+							db.createObjectStore('analyses', { keyPath: 'id' });
+					};
+					req.onsuccess = () => resolve(req.result);
+					req.onerror = () => reject(req.error);
+				});
+			}
+
+			const now = Date.now();
+			const fileId = `seeded-file-${now}`;
+			const analysisId = `seeded-absrel-${now}`;
+
+			const db = await openDB();
+
+			const fileTx = db.transaction('files', 'readwrite');
+			fileTx.objectStore('files').put({
+				id: fileId,
+				filename: fileName,
+				size: 1024,
+				type: 'application/octet-stream',
+				uploadedAt: now,
+				content: 'seeded-content'
+			});
+			await new Promise((resolve) => {
+				fileTx.oncomplete = resolve;
+			});
+
+			const analysisTx = db.transaction('analyses', 'readwrite');
+			analysisTx.objectStore('analyses').put({
+				id: analysisId,
+				fileId,
+				method: 'absrel',
+				status: 'completed',
+				result: resultJson,
+				createdAt: now - 60000,
+				completedAt: now,
+				options: {},
+				metadata: { executionMode: 'wasm' }
+			});
+			await new Promise((resolve) => {
+				analysisTx.oncomplete = resolve;
+			});
+
+			db.close();
+			return analysisId;
+		},
+		{ resultJson, fileName }
+	);
+}
+
+async function captureElement(page, selector, outPath, { padding = 0 } = {}) {
+	const el = page.locator(selector).first();
+	await el.waitFor({ state: 'visible', timeout: 30000 });
+	await el.scrollIntoViewIfNeeded();
+	await page.waitForTimeout(400);
+	const box = await el.boundingBox();
+	if (!box) throw new Error(`No bounding box for ${selector}`);
+	const clip = {
+		x: Math.max(0, box.x - padding),
+		y: Math.max(0, box.y - padding),
+		width: box.width + padding * 2,
+		height: box.height + padding * 2
+	};
+	await page.screenshot({ path: outPath, clip, omitBackground: false });
+	console.log(`  ✓ ${path.basename(outPath)}  ${Math.round(clip.width)}x${Math.round(clip.height)}`);
+}
+
+async function main() {
+	console.log(`Launching chromium @ ${DEVICE_SCALE}x...`);
+	const browser = await chromium.launch({ headless: true });
+	const context = await browser.newContext({
+		viewport: { width: 1600, height: 1100 },
+		deviceScaleFactor: DEVICE_SCALE
+	});
+	const page = await context.newPage();
+
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') console.log('[browser error]', msg.text());
+	});
+
+	console.log('Open + clear state...');
+	await page.goto(BASE_URL + '/');
+	await clearAllState(page);
+
+	console.log('Seed pre-computed aBSREL result...');
+	const id = await seedAnalysis(page, FIXTURE, 'PIGQ_bats.fa');
+	console.log(`  seeded analysis id: ${id}`);
+
+	await page.reload();
+	await page.waitForSelector('.sample-card', { timeout: 60000 });
+
+	console.log('→ Results tab');
+	const resultsTab = page.locator('button:has-text("Results")').first();
+	await resultsTab.click();
+	await page.waitForTimeout(800);
+
+	const cards = page.locator('[data-testid="analysis-card"]');
+	await cards.first().waitFor({ state: 'visible', timeout: 15000 });
+	await cards.first().click();
+
+	console.log('Wait for aBSREL viz to mount...');
+	await page.locator('.absrel-visualization').first().waitFor({ state: 'visible', timeout: 60000 });
+	await page.locator('.tree-container svg').first().waitFor({ state: 'visible', timeout: 60000 });
+	await page.waitForTimeout(3500);
+
+	// Sort table by p-value ascending so significant rows are at the top.
+	const pCol = page.locator('th.sortable', { hasText: 'p-value' }).first();
+	if (await pCol.isVisible().catch(() => false)) {
+		await pCol.click();
+		await page.waitForTimeout(400);
+		// Click again if needed to switch to ascending — header shows ↑ when asc.
+		const arrow = await pCol.locator('.sort-indicator').textContent();
+		if (arrow && arrow.trim() === '↓') {
+			await pCol.click();
+			await page.waitForTimeout(400);
+		}
+	}
+
+	console.log('Capture panels...');
+
+	await captureElement(
+		page,
+		'.plot-section:has(.tree-container)',
+		path.join(OUT_DIR, 'figure5-panelA-tree.png')
+	);
+
+	// Panel B: capture only the top portion of the rate table (header + ~8 rows)
+	// so it sits at a reasonable aspect ratio in the composite.
+	{
+		const sec = page.locator('.rate-table-section:has(.rate-table)').first();
+		await sec.scrollIntoViewIfNeeded();
+		await page.waitForTimeout(400);
+		const sectionBox = await sec.boundingBox();
+		if (!sectionBox) throw new Error('No box for rate-table-section');
+		const headerEl = sec.locator('.rate-table thead').first();
+		const headerBox = await headerEl.boundingBox();
+		const rows = sec.locator('.rate-table tbody tr');
+		const visibleRows = 8;
+		const lastRow = rows.nth(visibleRows - 1);
+		const lastRowBox = await lastRow.boundingBox();
+		const titleAreaTop = sectionBox.y;
+		const tableBottom = lastRowBox.y + lastRowBox.height;
+		const clip = {
+			x: sectionBox.x,
+			y: titleAreaTop,
+			width: sectionBox.width,
+			height: tableBottom - titleAreaTop + 4
+		};
+		await page.screenshot({
+			path: path.join(OUT_DIR, 'figure5-panelB-table.png'),
+			clip
+		});
+		console.log(
+			`  ✓ figure5-panelB-table.png  ${Math.round(clip.width)}x${Math.round(clip.height)} (top ${visibleRows} rows)`
+		);
+	}
+
+	// Panel C: detail view of the top-significant branch, captured by
+	// cropping a single row from the rate table. This is the per-branch
+	// ω-class rate distribution preferred in the figure spec — shown
+	// enlarged enough that the numeric rate values and the inline mini
+	// ω plot are both readable.
+	{
+		const sec = page.locator('.rate-table-section:has(.rate-table)').first();
+		await sec.scrollIntoViewIfNeeded();
+		await page.waitForTimeout(300);
+		const headerEl = sec.locator('.rate-table thead').first();
+		const headerBox = await headerEl.boundingBox();
+		const firstRow = sec.locator('.rate-table tbody tr').first();
+		const rowBox = await firstRow.boundingBox();
+		const sectionBox = await sec.boundingBox();
+		if (!headerBox || !rowBox || !sectionBox)
+			throw new Error('No box for rate-table header/row');
+		const clip = {
+			x: sectionBox.x,
+			y: headerBox.y,
+			width: sectionBox.width,
+			height: rowBox.y + rowBox.height - headerBox.y + 2
+		};
+		await page.screenshot({
+			path: path.join(OUT_DIR, 'figure5-panelC-detail.png'),
+			clip
+		});
+		console.log(
+			`  ✓ figure5-panelC-detail.png  ${Math.round(clip.width)}x${Math.round(clip.height)} (top-significant branch detail)`
+		);
+	}
+
+	await browser.close();
+	console.log('Done.');
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/trim-video-frames.sh
+++ b/scripts/trim-video-frames.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Collect raw videos from test-results, trim the HyPhy loading screen off
+# the front of each scene using offsets recorded by the test, and write
+# the trimmed videos to video-frames/.
+#
+# Usage: ./scripts/trim-video-frames.sh
+# Requires: ffmpeg, jq
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RAW_DIR="$ROOT/test-results"
+OUT_DIR="$ROOT/video-frames"
+OFFSET_DIR="$OUT_DIR/offsets"
+RAW_OUT_DIR="$OUT_DIR/raw"
+
+mkdir -p "$RAW_OUT_DIR"
+
+# Step 1: copy desktop chromium videos to a clean staging area
+for d in "$RAW_DIR"/video-frames-scene-*-chromium; do
+	[ -d "$d" ] || continue
+	scene=$(basename "$d" | grep -oE 'scene-[0-9]+')
+	if [ -f "$d/video.webm" ] && [ -n "$scene" ]; then
+		cp "$d/video.webm" "$RAW_OUT_DIR/${scene}.webm"
+	fi
+done
+
+# Step 2: trim each video using its recorded loading offset.
+# Static-HTML scenes (no offset file) are copied through unmodified.
+for raw in "$RAW_OUT_DIR"/scene-*.webm; do
+	[ -f "$raw" ] || continue
+	scene=$(basename "$raw" .webm)
+	offset_file="$OFFSET_DIR/${scene}.json"
+	out="$OUT_DIR/${scene}.webm"
+
+	# Output directly as H.264 MP4 so iMovie / Final Cut / Premiere import natively.
+	out="${out%.webm}.mp4"
+
+	if [ -f "$offset_file" ]; then
+		offset=$(jq -r '.offsetSeconds' "$offset_file")
+		# Subtract a small grace period so the cut happens just after the
+		# app is interactive, not exactly at the frame the loader vanishes.
+		trim=$(awk "BEGIN { printf \"%.3f\", $offset - 0.2 }")
+		# Clamp to 0
+		trim=$(awk "BEGIN { v = $trim; if (v < 0) v = 0; printf \"%.3f\", v }")
+		echo "Trimming $scene at ${trim}s (offset ${offset}s)"
+		ffmpeg -y -loglevel error \
+			-ss "$trim" -i "$raw" \
+			-c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p \
+			-movflags +faststart -an \
+			"$out"
+	else
+		echo "Transcoding $scene (no offset)"
+		ffmpeg -y -loglevel error \
+			-i "$raw" \
+			-c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p \
+			-movflags +faststart -an \
+			"$out"
+	fi
+done
+
+echo
+echo "MP4 videos in $OUT_DIR:"
+ls -lh "$OUT_DIR"/scene-*.mp4

--- a/scripts/webm-to-mp4.sh
+++ b/scripts/webm-to-mp4.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Convert all video-frames/scene-*.webm into H.264 MP4 files that iMovie / Final
+# Cut / Premiere / DaVinci will import natively.
+#
+# Encoding choices:
+#   - libx264, crf 18, preset slow  -> near-visually-lossless; large but suitable
+#                                      for further editing
+#   - yuv420p pixel format          -> QuickTime / iMovie compatibility
+#   - -movflags +faststart          -> moov atom at the front for quick seek
+#   - -an                           -> these scenes have no audio
+#
+# Usage:  ./scripts/webm-to-mp4.sh            # converts all scenes
+#         ./scripts/webm-to-mp4.sh scene-11   # converts a single scene
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$ROOT/video-frames"
+
+if [ $# -gt 0 ]; then
+	targets=()
+	for t in "$@"; do targets+=("$OUT_DIR/${t%.webm}.webm"); done
+else
+	targets=("$OUT_DIR"/scene-*.webm)
+fi
+
+for src in "${targets[@]}"; do
+	[ -f "$src" ] || { echo "skip (missing): $src"; continue; }
+	dst="${src%.webm}.mp4"
+	echo "Encoding $(basename "$src") -> $(basename "$dst")"
+	ffmpeg -y -loglevel error \
+		-i "$src" \
+		-c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p \
+		-movflags +faststart -an \
+		"$dst"
+done
+
+echo
+echo "MP4 files in $OUT_DIR:"
+ls -lh "$OUT_DIR"/scene-*.mp4 2>/dev/null || echo "(none yet)"

--- a/src/data/datareader.bf
+++ b/src/data/datareader.bf
@@ -9,6 +9,17 @@ function notify(type, msg) {
 	return 0;
 }
 
+/* Make a user-supplied sequence name safe to drop into the JSON record.
+   to_json below concatenates strings with no escaping, and PRE-rename names are arbitrary user
+   text: a single double quote in a header would produce invalid JSON and the whole upload would
+   fail with "File analysis produced invalid results". Post-rename names cannot hit this because
+   normalizeSequenceID (ReadDelimitedFiles.bf:218) maps everything outside [a-zA-Z0-9_] to '_'. */
+function jsonSafeName (rawName) {
+	_safeName = rawName ^ {{"[\"\\\\]",""}};
+	_safeName = _safeName ^ {{"[\n\t]"," "}};
+	return _safeName;
+}
+
 function except(msg) {
 	fprintf (jsonOutput,CLEAR_FILE);
 	fprintf (jsonOutput, "{" );
@@ -356,9 +367,21 @@ if (genCodeID >= 0 && filteredData.sites*3 < ds.sites)
 	}
 }
 
+/* filteredData is the CODON filter here when genCodeID >= 0 (created above with unit 3), so
+   filteredData.sites counts codons, not nucleotides. Naming the unit stops the message from
+   claiming a 12,000-nucleotide ceiling that is really 12,000 codons. */
+sizeUnit = "sites";
+if (genCodeID >= 0)
+{
+	sizeUnit = "codons";
+}
+
 if (filteredData.species > maxUploadSize || filteredData.sites > maxDMSites)
 {
-  except("Your data set is too large ("+filteredData.species+" species and "+filteredData.sites+" sites). We currently reject files with more than " + maxSLACSize + " sequences or " + maxDMSites + " sites. " +  
+  /* The rejection gate is maxUploadSize; quoting maxSLACSize here told a user rejected at
+     25,001 sequences that the limit was 10,000. maxSLACSize is the tree-inference ceiling and
+     is reported separately at the "must include prebuilt trees" branch below. */
+  except("Your data set is too large ("+filteredData.species+" sequences and "+filteredData.sites+" "+sizeUnit+"). We currently reject files with more than " + maxUploadSize + " sequences or " + maxDMSites + " " + sizeUnit + ". " +
                   "We'll increase the numbers when we acquire better dedicated hardware. Alternatively, you can download hyphy at: http://www.hyphy.org/downloads/ and perform selection analyses locally.");
 	return 1;
 }
@@ -380,6 +403,18 @@ renames		     = 0;
 padWarning       = 0;
 removedSequences = {};
 
+/* Plain, JSON-safe lists of WHICH sequences were changed, for the UI.
+   Deliberately separate from DuplicateSequenceWarning / renameSequenceWarning above: those are
+   '*'-appended blobs carrying HTML (<DT class='DT1'>, &rarr;) built for the legacy web UI.
+   Capped because results.json is cached in IndexedDB and replayed on every file selection - a
+   5,000-sequence rename must not be carried around forever. */
+nameListCap             = 50;
+duplicateNames          = {};
+duplicateNamesTruncated = 0;
+renamedNames            = {};
+renamedNamesTruncated   = 0;
+paddedSequences         = 0;
+
 for (k=0; k<filteredData.species;k=k+1)
 {
 	newSeqName = normalizeSequenceID (sequenceNames[k],"seqNamesList");
@@ -387,8 +422,16 @@ for (k=0; k<filteredData.species;k=k+1)
 	{
 		renameSequenceWarning * ("<DT class = 'DT1'>" + sequenceNames[k] + "&rarr;" + newSeqName);
 		renames	= renames+1;
+		if (Abs(renamedNames) < nameListCap)
+		{
+			renamedNames[Abs(renamedNames)] = jsonSafeName(sequenceNames[k]) + " -> " + newSeqName;
+		}
+		else
+		{
+			renamedNamesTruncated = renamedNamesTruncated + 1;
+		}
 		SetParameter (ds,k,newSeqName);
-	}	
+	}
 	seqNamesMap[sequenceNames[k]&&1] = newSeqName;
 	GetDataInfo (thisSeqData, filteredData, k);
 	
@@ -399,6 +442,14 @@ for (k=0; k<filteredData.species;k=k+1)
 		seqMap[k] = z-1;
 		dupSeqCount = dupSeqCount + 1;
 		DuplicateSequenceWarning * ("<DT class = 'DT2'>" + sequenceNames[k] + " = " + sequenceNames[z-1]);
+		if (Abs(duplicateNames) < nameListCap)
+		{
+			duplicateNames[Abs(duplicateNames)] = jsonSafeName(sequenceNames[k]) + " = " + jsonSafeName(sequenceNames[z-1]);
+		}
+		else
+		{
+			duplicateNamesTruncated = duplicateNamesTruncated + 1;
+		}
 		removedSequences[sequenceNames[k]&&1] = 1;
 	}
 	else
@@ -408,6 +459,7 @@ for (k=0; k<filteredData.species;k=k+1)
 		if ((thisSeqData$"\\?+$")[0]>=0)
 		{
 			padWarning = 1;
+			paddedSequences = paddedSequences + 1;
 		}
 	}
 }
@@ -590,6 +642,9 @@ file_info_record = {};
 file_info_record ["partitions"] = _pCount;
 file_info_record ["gencodeid"] = genCodeID;
 file_info_record ["sites"] = filteredData.sites;
+/* dType has been computed since the data type check above; it was simply never emitted, which
+   left the Data tab's already-guarded "Data Type" row permanently dark. */
+file_info_record ["type"] = dType;
 
 DataSetFilter filteredData = CreateFilter (ds,1);
 
@@ -616,11 +671,31 @@ file_info_record["goodtree"] = goodTree;
 file_info_record["nj"] = treeString;
 file_info_record["rawsites"] = filteredData.sites;
 
-// Validation details - expose what datareader detected for UI display
+// Validation details - expose what datareader detected for UI display.
+//
+// Every key below is load-bearing for records ALREADY cached in IndexedDB, which descriptorSync
+// replays without a migration step - so nothing here may be renamed or dropped, only added to.
+// `ambiguous_sites` is misnamed: it has always been the boolean padWarning, never a count of
+// ambiguous characters. `padded_sequences` is the honest version; the old key stays for cached
+// records.
 file_info_record["duplicate_sequences"] = dupSeqCount;
 file_info_record["sequences_renamed"] = renames;
 file_info_record["ambiguous_sites"] = padWarning;
+file_info_record["padded_sequences"] = paddedSequences;
 file_info_record["stop_codons_stripped"] = terminalCodonsStripped;
+
+// WHICH sequences, not just how many. Emitted only when non-empty so results.json does not grow
+// two empty objects for every clean upload.
+if (Abs(duplicateNames))
+{
+	file_info_record["duplicate_names"] = duplicateNames;
+	file_info_record["duplicate_names_truncated"] = duplicateNamesTruncated;
+}
+if (Abs(renamedNames))
+{
+	file_info_record["renamed_names"] = renamedNames;
+	file_info_record["renamed_names_truncated"] = renamedNamesTruncated;
+}
 
 sequence_records = {};
 GetString(seqNames, filteredData, -1);

--- a/src/lib/AlignmentViewer.svelte
+++ b/src/lib/AlignmentViewer.svelte
@@ -1,14 +1,15 @@
 <script>
 	import { AliVibe } from 'alivibe';
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, createEventDispatcher } from 'svelte';
 	import { treeStore } from '../stores/tree';
-	import { alignmentFileStore } from '../stores/fileInfo';
-	import { persistentFileStore } from '../stores/fileInfo';
 	import { Save } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
+	import { buildEditedAlignmentFile } from './utils/alignmentEdits.js';
 
 	export let alignmentFile = null;
 	export let fileMetricsJSON = null;
+
+	const dispatch = createEventDispatcher();
 
 	let alivibe;
 	let mounted = false;
@@ -60,27 +61,18 @@
 
 		try {
 			const alignment = alivibe.getAlignment();
-			if (!alignment || !alignment.length) {
-				throw new Error('No alignment data to save');
-			}
-
-			// Build FASTA content
-			const fastaContent = alignment
-				.map(entry => `>${entry.name}\n${entry.seq}`)
-				.join('\n') + '\n';
-
-			// Create a new File object with the same name
 			const filename = alignmentFile.name || 'alignment.fasta';
-			const newFile = new File([fastaContent], filename, { type: 'text/plain' });
+			const newFile = buildEditedAlignmentFile(alignment, filename);
 
-			// Update the persistent store (handles overwriting by name)
-			await persistentFileStore.uploadFile(newFile);
-
-			// Update the in-memory alignment file store
-			alignmentFileStore.set(newFile);
-
-			saveMessage = 'saved';
-			setTimeout(() => { saveMessage = null; }, 2000);
+			// Hand the edited alignment to the parent instead of writing the stores here.
+			//
+			// Writing them here was the bug: it updated the bytes on disk and the viewer's own store
+			// while leaving fileMetricsStore — including canonicalFasta, the string every runner
+			// actually submits — describing the alignment before the edit. The parent re-runs the
+			// whole upload path, which regenerates all of it. There is no success message to set:
+			// that path clears alignmentFileStore, so this component is unmounted and remounted with
+			// the re-read alignment.
+			dispatch('editsSaved', { file: newFile, previous: alignmentFile });
 		} catch (err) {
 			console.error('Error saving alignment:', err);
 			saveMessage = 'error';
@@ -168,10 +160,11 @@
 			title="Save alignment edits back to file"
 		>
 			<Save size={14} />
+			<!-- No "Saved" state: a successful save unmounts this viewer while the edited alignment is
+			     re-read, and the old confirmation was the whole problem — it reported success for a
+			     save the analyses never saw. -->
 			{#if isSaving}
 				Saving...
-			{:else if saveMessage === 'saved'}
-				Saved
 			{:else if saveMessage === 'error'}
 				Save failed
 			{:else}

--- a/src/lib/AnalysisCard.svelte
+++ b/src/lib/AnalysisCard.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { persistentFileStore } from '../stores/fileInfo';
+	import { isStaleRun } from './utils/fileIdentity.js';
 	import {
 		File,
 		Clock,
@@ -31,6 +32,10 @@
 	$: if (analysis && analysis.fileId && $persistentFileStore.files) {
 		file = $persistentFileStore.files.find((f) => f.id === analysis.fileId);
 	}
+
+	// A same-name re-upload replaces a file's contents in place and keeps its id, so every earlier
+	// run stays filed under a name that now means different bytes. Nothing distinguished them.
+	$: staleRun = isStaleRun(analysis, file);
 
 	// Format date for display
 	function formatDate(timestamp) {
@@ -278,6 +283,13 @@
 					<File class="mr-1 h-3 w-3" />
 					<span class="truncate">{file ? file.filename : 'Unknown file'}</span>
 				</div>
+
+				{#if staleRun}
+					<div class="mt-0.5 flex items-center text-amber-700" data-testid="stale-run-badge">
+						<AlertCircle class="mr-1 h-3 w-3 flex-shrink-0" />
+						<span>Run on an earlier version of this file</span>
+					</div>
+				{/if}
 
 				<div class="mt-0.5 flex items-center">
 					<Clock class="mr-1 h-3 w-3" />

--- a/src/lib/AnalysisHistory.svelte
+++ b/src/lib/AnalysisHistory.svelte
@@ -146,12 +146,15 @@
 
 	// Handle re-run action (for interrupted analyses)
 	function handleRerun(event) {
-		const { method, fileId } = event.detail;
+		// analysisId travels too. Without it the Analyze tab knows only WHICH method to preselect and
+		// has no way back to the settings that run was configured with, so "Re-run" meant "start over".
+		const { analysisId, method, fileId } = event.detail;
 		// Dispatch event to switch to Analyze tab with the method pre-selected
 		dispatchEvent(
 			new CustomEvent('switchTab', {
 				detail: {
 					tabName: 'analyze',
+					analysisId,
 					method,
 					fileId,
 					rerun: true

--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -3,7 +3,6 @@
 	import { analysisStore } from '../stores/analyses';
 	import { persistentFileStore } from '../stores/fileInfo';
 	import ExportPanel from './ExportPanel.svelte';
-	import FelVisualization from './FelVisualization.svelte';
 	import AxomemeResults from './AxomemeResults.svelte';
 	import AnalysisProgress from './AnalysisProgress.svelte';
 	import { safeParseJSON } from './utils/jsonUtils';
@@ -280,20 +279,6 @@
 								<h3 class="mb-4 text-lg font-semibold">
 									{analysis.method.toUpperCase()} Analysis Visualization
 								</h3>
-								<!-- Debug logging for aBSREL data structure -->
-								{#if analysis.method.toLowerCase() === 'absrel'}
-									<div class="mb-4 text-xs text-text-silver">
-										<details>
-											<summary>Debug: aBSREL Data Structure</summary>
-											<pre
-												class="max-h-40 overflow-auto bg-surface-raised p-2 text-xs">{JSON.stringify(
-													resultData,
-													null,
-													2
-												)}</pre>
-										</details>
-									</div>
-								{/if}
 								<svelte:component this={hyphyScopeComponent} data={resultData} />
 							</div>
 						</div>
@@ -324,98 +309,13 @@
 								</div>
 							{/if}
 						</div>
-					{:else if ['FEL', 'CONTRAST-FEL', 'SLAC', 'MEME', 'BUSTED', 'RELAX', 'FUBAR', 'aBSREL', 'ABSREL', 'GARD', 'MULTI-HIT', 'NRM'].includes(analysis.method)}
-						<!-- Selection analysis results with fallback legacy visualization for FEL -->
-						<div class="selection-analysis">
-							{#if resultData.input && resultData.input.file}
-								<p><strong>Analysis File:</strong> {resultData.input.file}</p>
-							{/if}
-
-							<!-- Legacy FEL visualization (keeping as fallback) -->
-							{#if analysis.method === 'FEL' && !hyphyScopeComponent}
-								<div class="mb-6 mt-6 rounded-lg bg-white p-4 shadow-sm">
-									<h3 class="mb-4 text-lg font-semibold">FEL Analysis Visualization (Legacy)</h3>
-									<FelVisualization {resultData} />
-								</div>
-							{/if}
-
-							{#if resultData.fits && resultData.fits.length > 0}
-								<h3 class="mb-2 text-lg font-bold">Model Fits</h3>
-								<div class="overflow-x-auto">
-									<table class="w-full table-auto">
-										<thead class="bg-surface-sunken">
-											<tr>
-												<th class="p-2 text-left">Model</th>
-												<th class="p-2 text-left">Log Likelihood</th>
-												<th class="p-2 text-left">Parameters</th>
-												<th class="p-2 text-left">AIC</th>
-											</tr>
-										</thead>
-										<tbody>
-											{#each resultData.fits as fit}
-												<tr class="border-b">
-													<td class="p-2">{fit.model || 'Unknown'}</td>
-													<td class="p-2"
-														>{fit.log_likelihood ? fit.log_likelihood.toFixed(2) : 'N/A'}</td
-													>
-													<td class="p-2">{fit.parameters || 'N/A'}</td>
-													<td class="p-2">{fit.AIC ? fit.AIC.toFixed(2) : 'N/A'}</td>
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								</div>
-							{/if}
-
-							{#if resultData.tested && resultData.tested.sites && resultData.tested.sites.length > 0}
-								<h3 class="my-2 text-lg font-bold">Site Results</h3>
-								<div class="max-h-96 overflow-auto">
-									<table class="w-full table-auto">
-										<thead class="sticky top-0 bg-surface-sunken">
-											<tr>
-												<th class="p-2 text-left">Site</th>
-												<th class="p-2 text-left">p-value</th>
-												<th class="p-2 text-left">alpha</th>
-												<th class="p-2 text-left">beta</th>
-												<th class="p-2 text-left">Selection</th>
-											</tr>
-										</thead>
-										<tbody>
-											{#each resultData.tested.sites as site}
-												<tr class="border-b" class:bg-status-warning-bg={site.p <= 0.05}>
-													<td class="p-2">{site.site_index || site.site || 'N/A'}</td>
-													<td class="p-2">{site.p ? site.p.toExponential(2) : 'N/A'}</td>
-													<td class="p-2">{site.alpha ? site.alpha.toFixed(2) : 'N/A'}</td>
-													<td class="p-2">{site.beta ? site.beta.toFixed(2) : 'N/A'}</td>
-													<td class="p-2">
-														{#if site.p <= 0.05}
-															{#if site.beta > site.alpha}
-																<span class="font-bold text-status-error">Positive</span>
-															{:else}
-																<span class="font-bold text-brand-royal">Negative</span>
-															{/if}
-														{:else}
-															<span class="text-text-silver">Neutral</span>
-														{/if}
-													</td>
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								</div>
-							{/if}
-
-							{#if !resultData.tested && !resultData.fits}
-								<pre class="bg-surface-sunken p-2 text-sm">{JSON.stringify(
-										resultData,
-										null,
-										2
-									)}</pre>
-							{/if}
-
-						</div>
-					{:else}
-						<!-- Generic JSON display for other methods -->
+					{:else if !hyphyScopeComponent}
+						<!-- No visualisation exists for this method, so the raw result document IS the result view.
+						     The converse is the point: a method that has a visualisation never gets a megabyte <pre>
+						     stapled underneath it. This was a hardcoded list of method names, which both missed
+						     methods that do have one (AXOMEME, BGM, PRIME, B-STILL) and compared case-sensitively
+						     against a value the runners persist uppercased. NRM is the only method that lands here
+						     today. -->
 						<div class="json-display">
 							<h3 class="mb-2 text-lg font-bold">Analysis Results</h3>
 							<pre class="max-h-96 overflow-auto bg-surface-sunken p-2 text-sm">{JSON.stringify(

--- a/src/lib/AnalysisResultViewer.svelte
+++ b/src/lib/AnalysisResultViewer.svelte
@@ -6,12 +6,6 @@
 	import FelVisualization from './FelVisualization.svelte';
 	import AxomemeResults from './AxomemeResults.svelte';
 	import AnalysisProgress from './AnalysisProgress.svelte';
-	import { FINAL_HYPHY_EYE_URL } from './config/env';
-	import {
-		shareWithHyphyEye,
-		isMethodSupported,
-		getHyphyEyeUrl
-	} from './utils/hyphyEyeIntegration';
 	import { safeParseJSON } from './utils/jsonUtils';
 	import { formatArguments, formatLogTail, buildDiagnostics } from './utils/analysisDiagnostics.js';
 	import {
@@ -30,7 +24,7 @@
 	import AbsrelVisualizationWrapper from './AbsrelVisualizationWrapper.svelte';
 	import FubarVisualizationWrapper from './FubarVisualizationWrapper.svelte';
 	import MultiHitVisualizationWrapper from './MultiHitVisualizationWrapper.svelte';
-	import { Server, Monitor, ExternalLink } from 'lucide-svelte';
+	import { Server, Monitor } from 'lucide-svelte';
 
 	export let analysisId = null;
 
@@ -419,42 +413,6 @@
 									)}</pre>
 							{/if}
 
-							<!-- HyPhy-eye integration with localStorage sharing -->
-							{#if isMethodSupported(analysis.method)}
-								<div class="mb-4 mt-4 rounded-lg bg-status-info-bg p-4 text-center shadow-sm">
-									<p class="mb-2 text-status-info-text">
-										View results with automatic data sharing:
-									</p>
-									<button
-										on:click={() => shareWithHyphyEye(resultData, analysis.method)}
-										class="inline-flex items-center rounded-md bg-brand-royal px-4 py-2 text-white transition-colors hover:bg-brand-deep"
-									>
-										View in HyPhy-eye
-										<ExternalLink class="ml-1 h-4 w-4" />
-									</button>
-									<p class="mt-2 text-sm text-brand-royal">
-										Analysis results will be automatically shared via localStorage.
-									</p>
-								</div>
-							{:else}
-								<div class="mb-4 mt-4 rounded-lg bg-surface-sunken p-4 text-center shadow-sm">
-									<p class="mb-2">Open results in a new tab:</p>
-									<a
-										href="{FINAL_HYPHY_EYE_URL}/pages/{analysis.method
-											.toLowerCase()
-											.replace('-', '')}"
-										target="_blank"
-										rel="noopener noreferrer"
-										class="inline-flex items-center rounded-md bg-brand-royal px-4 py-2 text-white transition-colors hover:bg-brand-deep"
-									>
-										Open {analysis.method.toUpperCase()} Results in hyphy-eye
-										<ExternalLink class="ml-1 h-4 w-4" />
-									</a>
-									<p class="mt-2 text-sm text-text-slate">
-										Note: You will need to upload your result JSON to hyphy-eye manually.
-									</p>
-								</div>
-							{/if}
 						</div>
 					{:else}
 						<!-- Generic JSON display for other methods -->

--- a/src/lib/AnalysisStatusIndicator.svelte
+++ b/src/lib/AnalysisStatusIndicator.svelte
@@ -13,8 +13,15 @@
 		}
 	});
 
+	// Callback prop rather than createEventDispatcher: this component is legacy syntax while
+	// +layout.svelte is runes-mode, and a callback prop is the form that works unambiguously across
+	// that boundary. The layout passes closeMobileMenu, so activating the pill from inside an open
+	// hamburger menu does not leave the menu covering the destination it just navigated to.
+	export let onNavigate = () => {};
+
 	// Function to navigate to the Results tab when clicked
 	function navigateToResults() {
+		onNavigate();
 		goto('/?tab=results');
 	}
 

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -451,33 +451,42 @@
 
 	<!-- Analysis Section (expanded by default) -->
 	<div class="mb-premium-xl rounded-premium border border-border-platinum bg-white shadow-premium">
+		<!--
+			The whole header row used to be a `<div on:click>`, so a section collapsed with the mouse
+			could not be reopened from the keyboard — permanently shut for keyboard users. The
+			disclosure is now a real button; the Console button is its SIBLING rather than a child,
+			because nested buttons are invalid HTML (which is also why its stopPropagation is gone).
+		-->
 		<div
-			class="flex cursor-pointer items-center justify-between rounded-t-premium bg-brand-whisper p-premium-md transition-all duration-premium hover:bg-brand-ghost"
-			on:click={toggleAnalysisSection}
+			class="flex items-center justify-between rounded-t-premium bg-brand-whisper p-premium-md transition-all duration-premium hover:bg-brand-ghost"
 		>
-			<h2 class="text-premium-header font-semibold text-text-rich">Analysis</h2>
-			<div class="flex items-center">
-				{#if $currentFile}
-					<button
-						on:click={(e) => {
-							e.stopPropagation();
-							handleToggleStdOut();
-						}}
-						class="mr-premium-md rounded-premium-sm bg-brand-royal px-premium-md py-premium-xs text-premium-meta font-medium text-white transition-all duration-premium hover:bg-brand-deep"
-					>
-						{isStdOutVisible ? 'Hide Console' : 'Show Console'}
-					</button>
-				{/if}
+			<button
+				type="button"
+				data-testid="analysis-section-toggle"
+				class="flex flex-1 items-center justify-between rounded-premium-sm text-left focus:outline-none focus:ring-2 focus:ring-brand-royal"
+				on:click={toggleAnalysisSection}
+				aria-expanded={analysisSectionExpanded}
+				aria-controls="analysis-section-body"
+			>
+				<h2 class="text-premium-header font-semibold text-text-rich">Analysis</h2>
 				<ChevronDown
 					class="h-6 w-6 text-brand-royal transition-transform duration-premium {analysisSectionExpanded
 						? 'rotate-180'
 						: ''}"
 				/>
-			</div>
+			</button>
+			{#if $currentFile}
+				<button
+					on:click={handleToggleStdOut}
+					class="ml-premium-md rounded-premium-sm bg-brand-royal px-premium-md py-premium-xs text-premium-meta font-medium text-white transition-all duration-premium hover:bg-brand-deep"
+				>
+					{isStdOutVisible ? 'Hide Console' : 'Show Console'}
+				</button>
+			{/if}
 		</div>
 
 		{#if analysisSectionExpanded}
-			<div class="p-premium-lg">
+			<div id="analysis-section-body" class="p-premium-lg">
 				{#if $currentFile}
 					<!-- Method Selector (includes timing estimate) -->
 					<MethodSelector

--- a/src/lib/AnalyzeTab.svelte
+++ b/src/lib/AnalyzeTab.svelte
@@ -28,7 +28,8 @@
 	// Props
 	export let methodConfig = {};
 	export let runMethod = () => {};
-	export let selectedMethod = 'FEL'; // Default method for configuration
+	// No `selectedMethod` prop. It was accepted here and never forwarded to MethodSelector, which is
+	// why a Re-run preselected nothing; the analysisConfig store is now the single channel for it.
 	export let hyphyOut = '';
 	export let isStdOutVisible = false;
 	export let toggleStdOut = () => {};

--- a/src/lib/BranchSelector.svelte
+++ b/src/lib/BranchSelector.svelte
@@ -3,9 +3,10 @@
 -->
 
 <script>
-	import { onMount, createEventDispatcher, tick } from 'svelte';
+	import { onMount, onDestroy, createEventDispatcher, tick } from 'svelte';
 	import * as phylotree from 'phylotree';
 	import * as d3 from 'd3';
+	import { assignBranchToSet, branchNameOf, listBranches } from './utils/branchSetTagging.js';
 
 	const dispatch = createEventDispatcher();
 
@@ -13,6 +14,14 @@
 	export let treeData = '';
 	export let height = 400;
 	export let width = 800;
+
+	// Smallest width the tree is ever drawn at. Below this, tip labels collide and the tree stops
+	// being readable at all, so we draw at minWidth and let the pan box scroll instead of squashing.
+	export let minWidth = 640;
+
+	// Width at or below which the list view is the better default. Chosen to match minWidth's
+	// intent: if the viewport cannot show the tree without panning, start with the list.
+	export let listByDefaultBelow = 700;
 
 	// Props - Selection mode
 	export let mode = 'single-set'; // 'single-set' for FG/BG, 'multi-set' for contrast-fel
@@ -28,6 +37,32 @@
 	let treeContainer;
 	let tree;
 	let internalSelectedBranches = []; // Internal tracking of selection
+
+	// Responsive state. `hostEl` is the pan box; its width is PARENT-driven only (width: 100%), never
+	// tree-driven, otherwise the ResizeObserver would feed the tree's own width back into itself.
+	let hostEl;
+	let measuredWidth = 0;
+	let resizeTimer;
+	let resizeObserver;
+	let lastRenderedWidth = 0;
+	$: renderWidth = Math.max(minWidth, measuredWidth || width);
+
+	// View state. The list is not a different selection MODE — it is a second rendering of the same
+	// phylotree state — so it deliberately does not touch `branchesToTest` upstream.
+	let view = 'tree';
+	// True when the last render happened with the pan box hidden, which leaves the SVG without a
+	// viewBox. Switching to the tree view then has to redraw; otherwise it must not.
+	let renderedWhileHidden = false;
+	let branchFilter = '';
+	let branchRows = [];
+
+	// Node hit targets. Phylotree draws r=3 circles; that is a 6px target, well under any usable
+	// minimum, and it is why e2e/10-branch-selector.spec.js needed force:true to click one.
+	const MIN_NODE_RADIUS = 6;
+
+	// Re-rendering builds a brand-new phylotree, so it is not free: it throws away the live
+	// selection, which we then have to restore. Ignore width jitter below this.
+	const RERENDER_WIDTH_THRESHOLD = 24;
 
 	// Unique container ID to avoid conflicts
 	let containerId = `tree-container-${Math.random().toString(36).substring(2, 9)}`;
@@ -58,10 +93,66 @@
 	}
 
 	onMount(() => {
+		// Decide the initial view from a real measurement, synchronously, BEFORE the first render.
+		// Deriving it from the debounced ResizeObserver instead would flip the view ~150ms after the
+		// tree had already appeared — visibly jarring, and a race for anything reading the DOM.
+		// It is decided once: a later resize must not yank the view out from under the user.
+		measuredWidth = Math.round(hostEl?.getBoundingClientRect().width || 0);
+		if (measuredWidth) {
+			view = measuredWidth < listByDefaultBelow ? 'list' : 'tree';
+		}
+
 		if (treeData) {
 			renderTree();
 		}
+
+		if (typeof ResizeObserver !== 'undefined' && hostEl) {
+			resizeObserver = new ResizeObserver((entries) => {
+				const w = Math.round(entries[0]?.contentRect?.width || 0);
+				clearTimeout(resizeTimer);
+				resizeTimer = setTimeout(() => handleHostResize(w), 150);
+			});
+			resizeObserver.observe(hostEl);
+		}
 	});
+
+	onDestroy(() => {
+		clearTimeout(resizeTimer);
+		resizeObserver?.disconnect();
+	});
+
+	// React to a real width change only. A phone rotated mid-selection must not silently lose its
+	// TEST/REFERENCE assignments, so the selection is snapshotted and handed back to phylotree
+	// through its own initial-selection / initial-sets render options.
+	async function handleHostResize(w) {
+		if (!w) return;
+		measuredWidth = w;
+
+		if (!tree) return;
+		const next = Math.max(minWidth, w);
+		if (Math.abs(next - lastRenderedWidth) <= RERENDER_WIDTH_THRESHOLD) return;
+
+		await tick();
+		renderTree(snapshotSelection());
+	}
+
+	// Capture the current selection in a form phylotree can replay after a re-render.
+	function snapshotSelection() {
+		if (!tree?.display) return null;
+
+		if (effectiveMode === 'multi-set') {
+			const sets = {};
+			selectionSets.forEach((setName) => {
+				const members = tree.display.getSetMembers?.(setName) || [];
+				const names = members.map(branchNameOf).filter(Boolean);
+				if (names.length > 0) sets[setName] = names;
+			});
+			return Object.keys(sets).length > 0 ? { sets } : null;
+		}
+
+		const names = (tree.display.getSelection?.() || []).map(branchNameOf).filter(Boolean);
+		return names.length > 0 ? { names } : null;
+	}
 
 	// Watch for tree data changes
 	$: if (treeData && treeContainer) {
@@ -190,7 +281,7 @@
 	// Note: updateNodeStyling removed - phylotree handles styling automatically
 	// via CSS classes like .phylotree-set-branch-{setName}
 
-	function renderTree() {
+	function renderTree(restore = null) {
 		try {
 			// Make sure we have a valid Newick string
 			if (!treeData || treeData.trim() === '') {
@@ -202,10 +293,15 @@
 			tree = new phylotree.phylotree(treeData);
 
 			// Render the tree with multi-set options if in multi-set mode
+			lastRenderedWidth = renderWidth;
+			renderedWhileHidden = view !== 'tree';
 			const renderOptions = {
 				container: `#${containerId}`,
 				height: height,
-				width: width,
+				// renderWidth, not `width`: below minWidth the tree is drawn at minWidth and the pan box
+				// scrolls. Drawing it at the viewport width instead used to squash the whole tree, and
+				// drawing it at a hard-coded 1000px used to push the PAGE 693px wider than a phone.
+				width: renderWidth,
 				'show-menu': true,
 				selectable: true,
 				collapsible: true,
@@ -220,6 +316,11 @@
 					name,
 					color: setColors[i] || setColors[i % setColors.length]
 				}));
+				if (restore?.sets) {
+					renderOptions['initial-sets'] = restore.sets;
+				}
+			} else if (restore?.names) {
+				renderOptions['initial-selection'] = restore.names;
 			}
 
 			tree.render(renderOptions);
@@ -257,6 +358,7 @@
 						} catch (e) {
 							// getBBox can fail if SVG not visible, ignore
 						}
+						enforceMinNodeRadius(container);
 					});
 				}
 
@@ -265,10 +367,34 @@
 					setupClickHandlers(container);
 				}
 			}
+
+			refreshBranchRows();
 		} catch (e) {
 			console.error('BranchSelector: Error rendering tree:', e);
 			dispatch('error', { message: e.message, error: e });
 		}
+	}
+
+	/**
+	 * Grow phylotree's r=3 node circles to a tappable size.
+	 *
+	 * This is done as a d3 attribute pass, not purely in CSS, because the SVG2 `r` geometry property
+	 * is unsupported on older engines — CSS alone would leave those users with the 6px target the
+	 * whole item is about. It has to be re-applied after every selection change, because phylotree
+	 * redraws the node circles on update().
+	 */
+	function enforceMinNodeRadius(container) {
+		if (!container) return;
+		requestAnimationFrame(() => {
+			// Both classes matter: phylotree tags LEAF groups `.node` and internal ones
+			// `.internal-node` (see its css_classes map), so `.node circle` alone silently misses
+			// every internal node — which is most of what you tag for RELAX and Contrast-FEL.
+			d3.select(container)
+				.selectAll('.node circle, .internal-node circle')
+				.attr('r', function () {
+					return Math.max(MIN_NODE_RADIUS, +this.getAttribute('r') || 0);
+				});
+		});
 	}
 
 	// Set up event listeners for branch selection
@@ -303,6 +429,80 @@
 		d3.select(container)
 			.selectAll('.branch, path.branch, .node circle')
 			.style('cursor', 'pointer');
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// List view
+	//
+	// The tree is the only way to assign branches to sets, and it is a mouse-only, sighted-only,
+	// wide-screen-only control: RELAX and Contrast-FEL refuse to run until TEST/REFERENCE (or two
+	// groups) are tagged, so on a phone — or with a keyboard — those two methods were simply
+	// unrunnable. This list renders the SAME phylotree state through form controls. It is not a new
+	// branch-selection mode: assignments go through phylotree's own APIs and out through the
+	// existing selectionChange event, so nothing upstream needs to know it exists.
+	// ---------------------------------------------------------------------------------------------
+
+	function treeNodes() {
+		// phylotree 2.x keeps the tree in `nodes` (a d3 hierarchy). There is no `tree.json`.
+		return tree?.nodes?.descendants?.() || [];
+	}
+
+	function refreshBranchRows() {
+		branchRows = listBranches(treeNodes());
+	}
+
+	$: filteredBranchRows = branchFilter.trim()
+		? branchRows.filter((row) => row.name.toLowerCase().includes(branchFilter.trim().toLowerCase()))
+		: branchRows;
+
+	// Options offered per row: the real sets, plus "unassigned".
+	$: rowSetOptions = effectiveMode === 'multi-set' ? selectionSets : ['Foreground'];
+
+	async function setView(next) {
+		const wasHidden = renderedWhileHidden;
+		view = next;
+
+		if (next === 'list') {
+			refreshBranchRows();
+			return;
+		}
+
+		// Only redraw if the tree was last drawn into a display:none box — there it had no layout, so
+		// getBBox threw and the viewBox was never set. Redrawing unconditionally would also throw away
+		// and rebuild a perfectly good tree every time the already-active Tree button is pressed.
+		if (!wasHidden) return;
+
+		await tick();
+		renderTree(snapshotSelection());
+	}
+
+	function handleRowAssignment(branchName, setName) {
+		if (!tree) return;
+
+		const nodes = treeNodes();
+		const node = nodes.find((n) => branchNameOf(n) === branchName);
+		if (!node) return;
+
+		if (effectiveMode === 'multi-set') {
+			// Prefer phylotree's own set APIs so the tree view's colours agree with the list. addToSet
+			// is already mutually exclusive; removeFromSet needs to be told which set to leave.
+			if (setName && tree.display?.addToSet) {
+				tree.display.addToSet(node, setName);
+			} else if (!setName && tree.display?.removeFromSet) {
+				const current = node._selectionSet;
+				if (current) tree.display.removeFromSet(node, current);
+			} else {
+				// No display (or an older phylotree): fall back to the extracted, DOM-free tagging.
+				assignBranchToSet(nodes, branchName, setName, selectionSets);
+			}
+		} else if (setName) {
+			tree.display?.selectNodes?.([branchName]);
+		} else {
+			tree.display?.deselectNodes?.([branchName]);
+		}
+
+		updateSelectedBranches();
+		enforceMinNodeRadius(treeContainer);
 	}
 
 	// Clear all selections (for single-select mode)
@@ -352,18 +552,11 @@
 					});
 				});
 			} else {
-				// Fallback: manually traverse to find nodes in any set
-				function findSelectedNodes(node) {
-					if (node._selectionSet || selectionSets.some(s => node[s])) {
-						if (!current_selection.includes(node)) {
-							current_selection.push(node);
-						}
-					}
-					node.children?.forEach(findSelectedNodes);
-				}
-				if (tree.json) {
-					findSelectedNodes(tree.json);
-				}
+				// Fallback for a tree with no display: scan the hierarchy directly. (This used to walk
+				// `tree.json`, which phylotree 2.x does not define, so it could never find anything.)
+				current_selection = treeNodes().filter(
+					(node) => node._selectionSet || selectionSets.some((s) => node[s])
+				);
 			}
 		} else {
 			// Single-set mode: use phylotree's getSelection API
@@ -373,6 +566,10 @@
 		internalSelectedBranches = current_selection.map((node) => {
 			return node.data?.name || node.name || `node_${node.id || Math.random()}`;
 		});
+
+		// Keep the list view in step with the tree: both are views of the same phylotree state, so a
+		// click on a branch has to move the corresponding row's <select>, and vice versa.
+		refreshBranchRows();
 
 		// Generate tagged Newick string
 		const taggedNewick = generateTaggedNewick();
@@ -527,13 +724,93 @@
 		</div>
 	{/if}
 
-	<div
-		id={containerId}
-		bind:this={treeContainer}
-		class="tree-container"
-		class:tree-disabled={disabled}
-		style="height: {height}px; width: {width}px;"
-	></div>
+	<div class="view-toggle" role="group" aria-label="Branch selection view">
+		<button
+			type="button"
+			data-testid="branch-view-tree"
+			class="view-toggle-btn"
+			class:active={view === 'tree'}
+			aria-pressed={view === 'tree'}
+			on:click={() => setView('tree')}
+			{disabled}
+		>
+			Tree
+		</button>
+		<button
+			type="button"
+			data-testid="branch-view-list"
+			class="view-toggle-btn"
+			class:active={view === 'list'}
+			aria-pressed={view === 'list'}
+			on:click={() => setView('list')}
+			{disabled}
+		>
+			List
+		</button>
+	</div>
+
+	<!--
+		The pan box is always parent-sized (width: 100%) and scrolls horizontally. The tree inside it
+		keeps its own, larger width. If this box were ever sized by the tree, the ResizeObserver would
+		feed the tree's width back into renderWidth and oscillate.
+
+		It stays mounted in list view (hidden, not destroyed) so that switching views does not throw
+		away the rendered phylotree — which is the shared source of truth for both views.
+	-->
+	<div class="tree-pan" bind:this={hostEl} class:hidden-view={view !== 'tree'}>
+		<div
+			id={containerId}
+			bind:this={treeContainer}
+			class="tree-container"
+			class:tree-disabled={disabled}
+			style="height: {height}px; width: {renderWidth}px;"
+		></div>
+	</div>
+
+	{#if view === 'list'}
+		<div class="branch-list" data-testid="branch-list">
+			<label class="branch-filter-label" for="{containerId}-filter">
+				Filter branches
+				<input
+					id="{containerId}-filter"
+					type="search"
+					bind:value={branchFilter}
+					placeholder="Search by name"
+					{disabled}
+				/>
+			</label>
+
+			{#if filteredBranchRows.length === 0}
+				<p class="no-data-message">
+					{branchRows.length === 0 ? 'No branches to assign yet.' : 'No branches match that filter.'}
+				</p>
+			{:else}
+				<ul class="branch-rows">
+					{#each filteredBranchRows as row (row.name)}
+						<li class="branch-row">
+							<label class="branch-row-label" for="{containerId}-row-{row.name}">
+								<span class="branch-row-name">{row.name}</span>
+								<span class="branch-row-kind">{row.isLeaf ? 'leaf' : 'internal'}</span>
+							</label>
+							<select
+								id="{containerId}-row-{row.name}"
+								data-testid="branch-row-select"
+								data-branch={row.name}
+								value={row.set}
+								on:change={(e) => handleRowAssignment(row.name, e.currentTarget.value)}
+								{disabled}
+							>
+								<option value="">—</option>
+								{#each rowSetOptions as setName}
+									<option value={setName}>{setName}</option>
+								{/each}
+							</select>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
 
 	{#if !treeData}
 		<p class="no-data-message">No tree data provided</p>
@@ -558,12 +835,126 @@
 		pointer-events: none;
 	}
 
+	/* Parent-driven width only — see the comment on the markup. */
+	.tree-pan {
+		width: 100%;
+		max-width: 100%;
+		overflow-x: auto;
+		overflow-y: hidden;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.tree-pan.hidden-view {
+		display: none;
+	}
+
 	.tree-container {
 		background: #f9fafb;
 		overflow: auto;
 		border: 1px solid #ccc;
 		border-radius: 4px;
 	}
+
+	.view-toggle {
+		display: flex;
+		gap: 0.25rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.view-toggle-btn {
+		padding: 0.5rem 1rem;
+		min-height: 44px;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		background: white;
+		font-size: 14px;
+		cursor: pointer;
+	}
+
+	.view-toggle-btn.active {
+		background: #1d4ed8;
+		border-color: #1d4ed8;
+		color: white;
+		font-weight: 600;
+	}
+
+	.branch-list {
+		margin-top: 0.75rem;
+	}
+
+	.branch-filter-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: #374151;
+		margin-bottom: 0.5rem;
+	}
+
+	.branch-filter-label input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		font-size: 14px;
+	}
+
+	.branch-rows {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 20rem;
+		overflow-y: auto;
+		border: 1px solid #e5e7eb;
+		border-radius: 4px;
+	}
+
+	.branch-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border-bottom: 1px solid #f3f4f6;
+	}
+
+	.branch-row:last-child {
+		border-bottom: none;
+	}
+
+	.branch-row-label {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.branch-row-name {
+		font-size: 0.875rem;
+		color: #111827;
+		overflow-wrap: anywhere;
+	}
+
+	.branch-row-kind {
+		font-size: 0.75rem;
+		color: #9ca3af;
+	}
+
+	.branch-row select {
+		min-height: 44px;
+		padding: 0.25rem 0.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		font-size: 14px;
+	}
+
+	/*
+	 * Node hit targets are enlarged by the d3 attribute pass in enforceMinNodeRadius, NOT here.
+	 * `r` as a CSS geometry property is SVG2: unsupported on older engines, and svelte-check flags
+	 * it as an unknown property. Do not "simplify" that pass into a CSS rule — it would silently
+	 * restore the 6px tap target on exactly the browsers least able to hit it.
+	 */
 
 	.tree-container.tree-disabled {
 		pointer-events: none;

--- a/src/lib/DataTab.svelte
+++ b/src/lib/DataTab.svelte
@@ -10,7 +10,12 @@
 	import TabNavigation from './TabNavigation.svelte';
 	import FastaExport from './FastaExport.svelte';
 	import AlignmentViewer from './AlignmentViewer.svelte';
+	import { uploadLimitsCopy } from './config/uploadLimits.js';
 	import { ArrowRight, AlertTriangle, TreeDeciduous, Info } from 'lucide-svelte';
+
+	// Rendered from the constants rather than typed inline: the previous copy claimed 5,000
+	// sequences / >500-needs-a-tree, and both numbers were invented.
+	const limitsCopy = uploadLimitsCopy();
 
 	// Props
 	export let handleFileUpload = () => {};
@@ -19,6 +24,9 @@
 	export let fileMetricsJSON = null;
 	export let handleValidated = () => {};
 	export let handleUseRepaired = () => {};
+	export let handleAlignmentEdited = () => {};
+	// Actions attached to the validation-error card (e.g. restoring the pre-edit alignment).
+	export let validationErrorActions = [];
 
 	// Tab navigation
 	export let activeTab = 'data';
@@ -67,9 +75,8 @@
 		<div class="mt-premium-md flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm text-blue-700">
 			<Info class="mt-0.5 h-4 w-4 flex-shrink-0" />
 			<div>
-				<span class="font-medium">File limits:</span>
-				Max 5,000 sequences, 12,000 alignment sites.
-				Files with &gt;500 sequences require an embedded tree.
+				<span class="font-medium">Upload limits:</span>
+				{limitsCopy}
 			</div>
 		</div>
 
@@ -77,6 +84,8 @@
 		<ErrorHandler
 			error={validationError}
 			level={errorLevel}
+			suggestions={validationErrorActions}
+			on:suggestion={(e) => e.detail?.run?.()}
 			on:dismiss={() => (validationError = null)}
 		/>
 	</div>
@@ -111,7 +120,11 @@
 					Alignment Viewer
 				</h2>
 				<div class="rounded-premium border border-border-platinum bg-white shadow-premium overflow-hidden">
-					<AlignmentViewer alignmentFile={$alignmentFileStore} {fileMetricsJSON} />
+					<AlignmentViewer
+						alignmentFile={$alignmentFileStore}
+						{fileMetricsJSON}
+						on:editsSaved={handleAlignmentEdited}
+					/>
 				</div>
 			</div>
 		{/if}

--- a/src/lib/FileCard.svelte
+++ b/src/lib/FileCard.svelte
@@ -181,9 +181,12 @@
 	$: fileTypeLabel = getFileTypeLabel(file.filename, file.contentType);
 	$: timeAgo = getTimeAgo(file.createdAt);
 
-	// Toggle details visibility
-	function toggleDetails(event) {
-		event.stopPropagation();
+	// aria-controls target for the disclosure button. Per-file so several cards can be open at once.
+	$: detailsId = `file-details-${file.id}`;
+
+	// Toggle details visibility. No stopPropagation: the card body is no longer clickable, so there
+	// is nothing above this to stop.
+	function toggleDetails() {
 		showDetails = !showDetails;
 	}
 
@@ -193,8 +196,7 @@
 	}
 
 	// Delete the file
-	function deleteFile(event) {
-		event.stopPropagation();
+	function deleteFile() {
 		if (confirm(`Are you sure you want to delete "${file.filename}"?`)) {
 			dispatch('delete', { id: file.id });
 		}
@@ -207,9 +209,22 @@
 	class:ring-1={isActive}
 	class:ring-brand-muted={isActive}
 >
-	<div class="cursor-pointer p-3 sm:p-premium-md" on:click={selectFile}>
+	<div class="p-3 sm:p-premium-md">
 		<div class="flex items-center justify-between gap-2">
-			<div class="flex min-w-0 flex-1 items-center">
+			<!--
+				The whole card body used to be a `<div on:click>` — unfocusable, unlabelled, and invisible
+				to the keyboard. It cannot simply become a <button>, because it contains the details and
+				delete buttons and nested buttons are invalid HTML. So the icon + name block is the button
+				and the actions are its sibling: that also puts selection BEFORE the destructive Delete in
+				tab order, which the old DOM order got backwards.
+			-->
+			<button
+				type="button"
+				data-testid="file-select"
+				class="flex min-w-0 flex-1 items-center rounded-premium-sm text-left focus:outline-none focus:ring-2 focus:ring-brand-royal"
+				on:click={selectFile}
+				aria-current={isActive ? 'true' : undefined}
+			>
 				<!-- File icon based on type -->
 				<div
 					class="mr-2 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg sm:mr-premium-md sm:h-10 sm:w-10 sm:rounded-premium-sm {fileTypeColor}"
@@ -227,6 +242,14 @@
 							class="hidden flex-shrink-0 rounded-full bg-brand-whisper px-1.5 py-0.5 text-[10px] text-text-slate xs:inline sm:rounded-premium-xl sm:px-premium-sm sm:text-premium-caption"
 							>{fileTypeLabel}</span
 						>
+						<!-- Selected state was signalled by border colour alone; give it a text channel too. -->
+						{#if isActive}
+							<span
+								data-testid="file-selected-chip"
+								class="flex-shrink-0 rounded-full bg-brand-royal px-1.5 py-0.5 text-[10px] font-semibold text-white sm:rounded-premium-xl sm:px-premium-sm sm:text-premium-caption"
+								>Selected</span
+							>
+						{/if}
 					</div>
 					<div class="flex items-center text-[11px] text-text-silver sm:text-premium-caption">
 						<span>{formatFileSize(file.size)}</span>
@@ -234,7 +257,7 @@
 						<span title={formatDate(file.createdAt)}>{timeAgo}</span>
 					</div>
 				</div>
-			</div>
+			</button>
 
 			<!-- Actions -->
 			<div class="flex flex-shrink-0 items-center gap-0.5 sm:gap-1">
@@ -243,6 +266,8 @@
 					class="flex h-9 w-9 items-center justify-center rounded-lg text-text-slate transition-all duration-premium hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal focus:ring-offset-1 sm:h-11 sm:w-11 sm:rounded-premium-sm"
 					title={showDetails ? 'Hide details' : 'Show details'}
 					aria-label={showDetails ? 'Hide details' : 'Show details'}
+					aria-expanded={showDetails}
+					aria-controls={detailsId}
 				>
 					{#if showDetails}
 						<ChevronUp class="h-4 w-4 sm:h-5 sm:w-5" />
@@ -264,7 +289,7 @@
 
 		<!-- Details panel (conditional) -->
 		{#if showDetails}
-			<div class="details-panel mt-premium-md rounded-premium bg-brand-whisper p-premium-md">
+			<div id={detailsId} class="details-panel mt-premium-md rounded-premium bg-brand-whisper p-premium-md">
 				<!-- File preview, if available -->
 				{#if preview}
 					<div class="mb-premium-md">

--- a/src/lib/FileCard.svelte
+++ b/src/lib/FileCard.svelte
@@ -321,6 +321,13 @@
 						<div class="text-text-slate">Upload Date:</div>
 						<div class="font-medium text-text-rich">{formatDate(file.createdAt)}</div>
 
+						<!-- Written only when an upload replaced this record's contents in place, which is
+						     the one case where "Upload Date" no longer describes the bytes. -->
+						{#if file.updatedAt && file.updatedAt !== file.createdAt}
+							<div class="text-text-slate">Last modified:</div>
+							<div class="font-medium text-text-rich">{formatDate(file.updatedAt)}</div>
+						{/if}
+
 						<div class="text-text-slate">ID:</div>
 						<div class="font-mono text-[10px] text-text-silver opacity-70">{file.id}</div>
 					</div>

--- a/src/lib/FileCard.svelte
+++ b/src/lib/FileCard.svelte
@@ -296,6 +296,13 @@
 						<div class="text-text-slate">Upload Date:</div>
 						<div class="font-medium text-text-rich">{formatDate(file.createdAt)}</div>
 
+						<!-- Written only when an upload replaced this record's contents in place, which is
+						     the one case where "Upload Date" no longer describes the bytes. -->
+						{#if file.updatedAt && file.updatedAt !== file.createdAt}
+							<div class="text-text-slate">Last modified:</div>
+							<div class="font-medium text-text-rich">{formatDate(file.updatedAt)}</div>
+						{/if}
+
 						<div class="text-text-slate">ID:</div>
 						<div class="font-mono text-[10px] text-text-silver opacity-70">{file.id}</div>
 					</div>

--- a/src/lib/FileConflictPrompt.svelte
+++ b/src/lib/FileConflictPrompt.svelte
@@ -1,0 +1,74 @@
+<!--
+	Shown when an UPLOAD would land on a filename that already has a record.
+
+	Not window.confirm, for two reasons: a store should not open a browser dialog, and a native
+	dialog cannot be driven from Playwright the way a real element can.
+
+	Deliberately two choices, no cancel. By the time this is on screen +page.svelte has already
+	cleared fileMetricsJSON / fileMetricsStore / alignmentFileStore for the incoming file, so a
+	cancel would leave the user looking at the empty state with nothing selected — a third button
+	that produces a worse outcome than either real answer.
+-->
+<script>
+	import { createEventDispatcher } from 'svelte';
+	import { AlertTriangle } from 'lucide-svelte';
+
+	/** @type {{ filename: string, keepBothName: string, analysisCount: number }|null} */
+	export let conflict = null;
+
+	const dispatch = createEventDispatcher();
+
+	function choose(choice) {
+		dispatch('choose', choice);
+	}
+</script>
+
+{#if conflict}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="file-conflict-title"
+		data-testid="file-conflict-prompt"
+	>
+		<div
+			class="w-full max-w-md rounded-premium border border-border-platinum bg-white p-6 shadow-premium"
+		>
+			<div class="flex items-start gap-3">
+				<div
+					class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-amber-100"
+				>
+					<AlertTriangle class="h-5 w-5 text-amber-600" />
+				</div>
+				<div class="min-w-0">
+					<h2 id="file-conflict-title" class="text-premium-body font-semibold text-text-rich">
+						You already have a file called {conflict.filename}
+					</h2>
+					<p class="mt-1 text-sm text-text-slate">
+						Replacing it keeps its history, so
+						{conflict.analysisCount === 1
+							? 'the 1 analysis already filed under this name'
+							: `the ${conflict.analysisCount} analyses already filed under this name`}
+						will be listed against the new contents. Keeping both starts a separate file with its own
+						history.
+					</p>
+				</div>
+			</div>
+
+			<div class="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+				<button
+					class="rounded-lg border border-border-platinum px-4 py-2 text-sm font-medium text-text-slate hover:bg-brand-whisper"
+					on:click={() => choose('replace')}
+				>
+					Replace it
+				</button>
+				<button
+					class="rounded-lg bg-brand-gradient px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-deep"
+					on:click={() => choose('keep-both')}
+				>
+					Keep both — save as {conflict.keepBothName}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1149,14 +1149,21 @@
 		});
 	}
 
-	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged
+	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged.
+	//
+	// Read through methodOptions[selectedMethod], NOT methodOptions.relax: this map is keyed by the
+	// method string exactly as the dropdown supplies it ('RELAX'), which initializeMethodOptions and
+	// handleBranchSelectionChange both use. The lowercase lookup was always undefined, so
+	// relaxHasTestBranches was permanently false and RELAX's Run button could never be enabled no
+	// matter what the user tagged. contrastFelBranchesValid below already uses the indexed form.
+	$: relaxOptions = selectedMethod ? methodOptions?.[selectedMethod] : null;
 	$: relaxHasTestBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		methodOptions?.relax?.interactiveTree?.includes('{TEST}');
+		relaxOptions?.interactiveTree?.includes('{TEST}');
 	$: relaxHasReferenceBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		(methodOptions?.relax?.interactiveTree?.includes('{REFERENCE}') ||
-			methodOptions?.relax?.referenceBranches === 'All');
+		(relaxOptions?.interactiveTree?.includes('{REFERENCE}') ||
+			relaxOptions?.referenceBranches === 'All');
 	$: relaxBranchesValid =
 		selectedMethod?.toLowerCase() !== 'relax' ||
 		(relaxHasTestBranches && relaxHasReferenceBranches);
@@ -1602,10 +1609,13 @@
 				{#if selectedTreeData}
 					<div class="tree-selector-wrapper">
 						{#key selectedMethod}
+							<!-- No `width`: BranchSelector measures its own pan box and draws at least
+							     minWidth, scrolling inside the box. The hard-coded 1000px used to push the
+							     PAGE 693px wider than a 393px phone. Do NOT widen this {#key} to include a
+							     width — every resize would remount and discard the current selection. -->
 							<BranchSelector
 								treeData={selectedTreeData}
 								height={500}
-								width={1000}
 								mode={selectedMethod?.toLowerCase() === 'contrast-fel' ||
 								selectedMethod?.toLowerCase() === 'relax'
 									? 'multi-set'

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -17,6 +17,7 @@
 	// callModes.js is a leaf (no imports) precisely so this line costs the main chunk nothing but the
 	// constants — see the note at the top of that file.
 	import { describeCallMode, CALL_DEFAULTS } from './services/axomeme/callModes.js';
+	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -191,26 +192,6 @@
 		: localRunInFlight && wouldRunLocally
 			? 'Another analysis is running in this tab — only one can run here at a time'
 			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
 
 	// Method-specific advanced options configurations
 	const METHOD_ADVANCED_OPTIONS = {
@@ -1183,9 +1164,11 @@
 					})
 			: [];
 
-	// Update genetic code ID when name changes
+	// Update genetic code ID when name changes. The selector's VALUE is HyPhy's own identifier
+	// (what the browser path passes to --code); the id is what the server path and the codon
+	// validator use. Both come from the same row, so they cannot disagree.
 	$: {
-		const codeEntry = GENETIC_CODES.find((code) => code.name === geneticCode);
+		const codeEntry = GENETIC_CODES.find((code) => code.hyphy === geneticCode);
 		if (codeEntry) {
 			geneticCodeId = codeEntry.id;
 		}
@@ -1556,7 +1539,9 @@
 								Genetic Code:
 								<select bind:value={geneticCode} class="option-select">
 									{#each GENETIC_CODES as code}
-										<option value={code.name}>{code.label}</option>
+										<!-- value is HyPhy's own identifier, label is ours: the value is
+										     passed verbatim to `hyphy --code`, so it is not free text. -->
+										<option value={code.hyphy}>{code.label}</option>
 									{/each}
 								</select>
 							</label>

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1,7 +1,9 @@
 <!-- src/lib/MethodSelector.svelte -->
 <script>
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { backendConnectivity } from '../stores/backendConnectivity.js';
+	import { analysisConfig } from '../stores/analysisConfig.js';
+	import { METHOD_ADVANCED_OPTIONS } from './config/methodAdvancedOptions.js';
 	import { fileMetricsStore } from '../stores/fileInfo';
 	import { treeStore } from '../stores/tree';
 	import BranchSelector from './BranchSelector.svelte';
@@ -193,797 +195,87 @@
 			? 'Another analysis is running in this tab — only one can run here at a time'
 			: null;
 
-	// Method-specific advanced options configurations
-	const METHOD_ADVANCED_OPTIONS = {
-		// AxoMEME exposes almost nothing on purpose. It is a fitted model with one set of weights:
-		// there are no branch sets to select (it consumes the whole tree as a distance matrix), no
-		// rate-variation switch, and no genetic code choice — the code table is baked into the
-		// model's tokenizer as the universal one. Offering knobs that do not reach the model would be
-		// worse than offering none. Calling mode is the one real choice, because it is a threshold
-		// applied AFTER inference and genuinely changes what gets reported.
-		axomeme: {
-			callMode: {
-				type: 'select',
-				label: 'How to rank sites',
-				// percentile, not the reference driver's pvalue default. The model's predicted LRT does
-				// not reach the chi-square gates pvalue compares against — measured across 12 real
-				// submissions, one site in 662 cleared 3.12 and none cleared 4.45 — so pvalue makes the
-				// method silent. See CALL_DEFAULTS in postprocess.js.
-				default: 'percentile',
-				options: ['percentile', 'zscore', 'pvalue'],
-				description:
-					'percentile and zscore rank sites within this alignment, which is what the model is built to do. pvalue compares against fixed LRT gates (4.45 / 3.12) that its scores rarely reach — it will usually report nothing.'
-			}
+	// Genetic code mapping (HyPhy uses numeric IDs)
+	const GENETIC_CODES = [
+		{ id: 0, name: 'Universal', label: 'Universal code' },
+		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
+		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
+		{
+			id: 3,
+			name: 'Mold mitochondrial',
+			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
 		},
-		fel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No']
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple']
-			},
-			siteMultihit: {
-				type: 'select',
-				label: 'Site Multihit',
-				default: 'Estimate',
-				options: ['Estimate', 'Global'],
-				dependsOn: 'multipleHits',
-				enabledWhen: ['Double', 'Double+Triple']
-			},
-			// Advanced parameters (matching the form structure)
-			resample: {
-				type: 'number',
-				label: 'Resample (parametric bootstrap replicates)',
-				default: 0,
-				min: 0,
-				max: 1000,
-				step: 1,
-				description:
-					'Advanced setting - will result in MUCH SLOWER run time. Recommended for small to medium (<30 sequences) datasets.'
-			},
-			confidenceIntervals: {
-				type: 'boolean',
-				label: 'Compute confidence intervals',
-				default: false,
-				description: 'Compute profile likelihood confidence intervals for each variable site'
-			},
-			// Keep existing parameters for backward compatibility
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			}
-		},
-		meme: {
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'P-value threshold for calling a site under selection'
-			},
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 2,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of site rate classes'
-			},
-			multiple_hits: {
-				type: 'select',
-				label: 'Multiple hits',
-				default: 'None',
-				options: ['None', 'Double', 'Triple', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			site_multihit: {
-				type: 'select',
-				label: 'Site multiple hits',
-				default: 'Estimate',
-				options: ['Estimate', 'None'],
-				description: 'How to handle multiple hits per site'
-			},
-			impute_states: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Impute ancestral states for internal nodes'
-			}
-		},
-		slac: {
-			// Branch selection options (similar to FEL)
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// SLAC-specific parameters
-			samples: {
-				type: 'number',
-				label: 'Ancestral reconstruction samples',
-				default: 100,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Number of samples for ancestral reconstruction uncertainty'
-			},
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for selection'
-			}
-		},
-		fubar: {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Specifies the number of grid points for the Bayesian analysis'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description:
-					'The concentration parameter for the Dirichlet prior in the Bayesian estimation'
-			},
-			posteriorThreshold: {
-				type: 'number',
-				label: 'Posterior probability threshold',
-				default: 0.9,
-				min: 0.5,
-				max: 0.99,
-				step: 0.01,
-				description:
-					'Sites with posterior probability above this threshold are considered under positive selection'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		absrel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test (default: All)'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core aBSREL parameters
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			srv: {
-				type: 'select',
-				label: 'Synonymous Rate Variation',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation'
-			},
-			// Advanced parameters
-			blb: {
-				type: 'number',
-				label: 'Bag of Little Bootstrap (BLB) Rate',
-				default: 1.0,
-				min: 0.0,
-				max: 1.0,
-				step: 0.1,
-				description: '[Advanced] Bag of little bootstrap alignment resampling rate'
-			}
-		},
-		busted: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Foreground Branches',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description:
-					'Select foreground branches to test for positive selection. All other branches will be treated as background.'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom foreground branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern for foreground branches'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select foreground branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them as foreground branches for testing'
-			},
-			// Core BUSTED parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (BUSTED-S)',
-				default: 'Yes',
-				options: ['Yes', 'No', 'Branch-site'],
-				description: 'Include variations in synonymous substitution rates'
-			},
-			errorSink: {
-				type: 'select',
-				label: 'Error protection (BUSTED-E)',
-				default: 'No',
-				options: ['Yes', 'No'],
-				description: 'Enhance robustness against alignment errors'
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Support for handling multiple nucleotide substitutions'
-			},
-			// Advanced parameters
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes in the model'
-			},
-			synRates: {
-				type: 'number',
-				label: 'Synonymous rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of synonymous rate classes in the model'
-			},
-			gridSize: {
-				type: 'number',
-				label: 'Grid size',
-				default: 250,
-				min: 50,
-				max: 1000,
-				step: 50,
-				description: 'Number of points in initial distributional guess for likelihood fitting'
-			},
-			startingPoints: {
-				type: 'number',
-				label: 'Starting points',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of initial random guesses to seed rate values optimization'
-			}
-		},
-		gard: {
-			datatype: {
-				type: 'select',
-				label: 'Data type',
-				default: 'nucleotide',
-				options: ['codon', 'nucleotide', 'protein'],
-				description: 'Type of data to analyze for recombination'
-			},
-			model: {
-				type: 'select',
-				label: 'Substitution model',
-				default: 'GTR',
-				options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
-				filteredOptionsBy: 'datatype',
-				filteredOptions: {
-					codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
-				},
-				filteredDefaults: {
-					codon: 'GTR',
-					nucleotide: 'GTR',
-					protein: 'JTT'
-				},
-				description: 'Substitution model to use for the analysis'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Normal',
-				options: ['Normal', 'Faster'],
-				description: 'Normal: thorough analysis; Faster: quicker but less comprehensive'
-			},
-			rv: {
-				type: 'select',
-				label: 'Site-to-site rate variation',
-				default: 'None',
-				options: ['None', 'GDD', 'Gamma'],
-				description: 'Model for rate variation among sites (None, General Discrete, Beta-Gamma)'
-			},
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 4,
-				min: 2,
-				max: 10,
-				description: 'Number of discrete rate classes for rate variation'
-			}
-		},
-		bgm: {
-			steps: {
-				type: 'number',
-				label: 'Chain length steps',
-				default: 10000,
-				min: 1000,
-				max: 100000000,
-				step: 1000,
-				description: 'Length of each MCMC chain'
-			},
-			burnIn: {
-				type: 'number',
-				label: 'Burn-in samples',
-				default: 1000,
-				min: 100,
-				max: 100000,
-				step: 100,
-				description: 'Number of burn-in samples to discard'
-			},
-			samples: {
-				type: 'number',
-				label: 'Samples',
-				default: 100,
-				min: 10,
-				max: 10000,
-				step: 10,
-				description: 'Number of samples to collect'
-			},
-			maxParents: {
-				type: 'number',
-				label: 'Maximum parents per node',
-				default: 1,
-				min: 0,
-				max: 10,
-				step: 1,
-				description: 'Maximum number of parents allowed per node in the graphical model'
-			},
-			minSubs: {
-				type: 'number',
-				label: 'Minimum substitutions per site',
-				default: 1,
-				min: 1,
-				max: 100,
-				step: 1,
-				description: 'Minimum number of substitutions required per site'
-			}
-		},
-		fade: {
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			},
-			gridPoints: { type: 'number', label: 'Grid points', default: 20, min: 5, max: 50 },
-			mcmcChains: { type: 'number', label: 'MCMC chains', default: 5, min: 2, max: 20 },
-			mcmcSamples: {
-				type: 'number',
-				label: 'MCMC samples',
-				default: 2000000,
-				min: 100000,
-				max: 10000000,
-				step: 100000
-			}
-		},
-		relax: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Interactive'],
-				description: 'Select TEST and REFERENCE branches interactively on the tree'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select TEST and REFERENCE branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to TEST or REFERENCE sets'
-			},
-			// RELAX-specific parameters
-			models: {
-				type: 'select',
-				label: 'Analysis models',
-				default: 'All',
-				options: ['All', 'Minimal'],
-				description: 'All: descriptive models and RELAX test; Minimal: RELAX test only'
-			},
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Classic mode',
-				options: ['Classic mode'],
-				description: 'RELAX analysis mode'
-			},
-			killZeroLengths: {
-				type: 'select',
-				label: 'Kill zero-length branches',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'How to handle zero-length branches'
-			}
-		},
-		'multi-hit': {
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 3,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes to include in the model'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use separate rate parameter for synonymous triple-hit substitutions'
-			}
-		},
-		nrm: {
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of rate classes for the analysis'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use triple islands for the analysis'
-			}
-		},
-		prime: {
-			// PRIME variant selection
-			variant: {
-				type: 'select',
-				label: 'PRIME Variant',
-				default: 'S-PRIME',
-				options: [
-					'S-PRIME',
-					{ value: 'G-PRIME', label: 'G-PRIME (coming soon)', disabled: true },
-					{ value: 'E-PRIME', label: 'E-PRIME (coming soon)', disabled: true }
-				],
-				description: 'S-PRIME: site-level property-informed model'
-			},
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Interactive'],
-				description: 'Which branches to test for property-dependent selection'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Property set selection
-			propertySet: {
-				type: 'select',
-				label: 'Amino Acid Property Set',
-				default: '5PROP',
-				options: ['5PROP', '4PROP', '3PROP', '2PROP', 'Atchley', 'LCAP'],
-				description:
-					'Set of amino acid properties to model (5PROP: hydrophobicity, polarity, volume, charge, iso-electric point)'
-			},
-			// P-value threshold
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for property-dependent selection'
-			},
-			// Impute states
-			imputeStates: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use site-level model fits to impute likely character states'
-			}
-		},
-		'contrast-fel': {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Custom', 'Interactive'],
-				description: 'How to specify branch sets for comparison'
-			},
-			// Custom branch set configuration (when not using Interactive)
-			branchSet1: {
-				type: 'text',
-				label: 'Branch Set 1 (Source)',
-				default: 'Source',
-				placeholder: 'e.g. Source, Internal, Leaves',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'First group of branches to compare'
-			},
-			branchSet2: {
-				type: 'text',
-				label: 'Branch Set 2 (Test)',
-				default: 'Test',
-				placeholder: 'e.g. Test, Unlabeled, Custom',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Second group of branches to compare'
-			},
-			branchSet3: {
-				type: 'text',
-				label: 'Branch Set 3 (optional)',
-				default: '',
-				placeholder: 'e.g. Reference, Background',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Optional third group of branches for comparison'
-			},
-			// Interactive tree selection
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branch sets on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to different sets for comparison'
-			},
-			// Core Contrast-FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation in the model'
-			},
-			permutations: {
-				type: 'select',
-				label: 'Perform permutation tests',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Use permutation tests to evaluate significance'
-			},
-			// Statistical thresholds
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.05,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Significance value for site tests'
-			},
-			qvalue: {
-				type: 'number',
-				label: 'Q-value threshold (FDR)',
-				default: 0.2,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'False Discovery Rate threshold for reporting'
-			},
-			// Output options
-			output: {
-				type: 'text',
-				label: 'Output file name (optional)',
-				default: '',
-				placeholder: 'e.g. contrast_results.json',
-				description: 'Custom name for output file (defaults to automatic naming)'
-			}
-		}
-	};
+		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
+		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
+		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
+		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
+		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
+		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
+		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
+		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
+	];
 
 	// Method-specific advanced options state
 	let methodOptions = {};
+
+	// SURVIVING A TAB SWITCH.
+	//
+	// This component is mounted inside {#if activeTab === 'analyze'} in +page.svelte, so Svelte
+	// destroys it — and every local below — the moment the user looks at Results. The five values are
+	// kept as plain locals because ~60 references and two bind:value depend on them; they are hydrated
+	// from the store here and mirrored back on every change.
+	//
+	// Hydration happens in onMount rather than at declaration ON PURPOSE. The reactive block that
+	// initialises a method's option bag is gated on the bag being ABSENT
+	// (`if (selectedMethod && !methodOptions[selectedMethod])`) because initializeMethodOptions
+	// overwrites it wholesale with defaults. Restoring before that block first runs is what lets the
+	// restored options survive it. Keep that gate.
+	let restoredNotice = null;
+	let hydrated = false;
+
+	onMount(() => {
+		const saved = analysisConfig.current();
+		if (saved.selectedMethod) selectedMethod = saved.selectedMethod;
+		if (saved.geneticCode) geneticCode = saved.geneticCode;
+		if (Number.isFinite(saved.geneticCodeId)) geneticCodeId = saved.geneticCodeId;
+		// Restoring 'backend' onto a session where the server is unreachable would arm a run that
+		// fails at submission. Clamp it; the radio is still there for the user to change back.
+		if (saved.executionMode) {
+			executionMode =
+				saved.executionMode === 'backend' && !$backendConnectivity?.isConnected
+					? 'local'
+					: saved.executionMode;
+		}
+		if (saved.methodOptions) methodOptions = { ...saved.methodOptions };
+
+		if (saved.restoredFromAnalysisId && saved.selectedMethod) {
+			// AxoMEME records carry no arguments at all, so there is nothing to claim was restored.
+			// Say what is true and no more.
+			restoredNotice = saved.restoredSummary
+				? `Restored your ${saved.selectedMethod.toUpperCase()} settings — ${saved.restoredSummary}.`
+				: `Selected ${saved.selectedMethod.toUpperCase()}.`;
+		}
+
+		// Announce a restore once, not on every subsequent tab switch.
+		analysisConfig.update((state) => ({ ...state, restoredFromAnalysisId: null }));
+		hydrated = true;
+	});
+
+	// Mirror back. One assignment, so the store can never hold half a configuration.
+	//
+	// Gated on `hydrated` because reactive statements run during the FIRST render, before onMount:
+	// ungated, this would write the component's blank defaults over the very state it is about to
+	// read back, and the feature would silently do nothing.
+	$: if (hydrated) {
+		analysisConfig.update((state) => ({
+			...state,
+			selectedMethod,
+			geneticCode,
+			geneticCodeId,
+			executionMode,
+			methodOptions
+		}));
+	}
 
 	// Tree data from store (auto-subscription; Svelte cleans it up on destroy)
 	$: trees = $treeStore;
@@ -1401,6 +693,20 @@
 				{/each}
 			</select>
 		</div>
+
+		<!-- What a Re-run actually brought back. Built from the restored values, never from a fixed
+		     field list, so it cannot claim to have restored something it did not. -->
+		{#if restoredNotice}
+			<div class="restored-notice" data-testid="restored-settings-notice">
+				<span>{restoredNotice}</span>
+				<button
+					type="button"
+					class="restored-dismiss"
+					aria-label="Dismiss"
+					on:click={() => (restoredNotice = null)}>×</button
+				>
+			</div>
+		{/if}
 
 		<!-- Method Description -->
 		{#if currentMethod}
@@ -1846,6 +1152,30 @@
 		font-size: 0.8125rem;
 		line-height: 1.4;
 		color: #475569;
+	}
+
+	.restored-notice {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin-top: 8px;
+		padding: 6px 10px;
+		border: 1px solid #cbd5e0;
+		border-radius: 6px;
+		background: #f7fafc;
+		color: #2d3748;
+		font-size: 13px;
+	}
+
+	.restored-dismiss {
+		border: none;
+		background: none;
+		color: #4a5568;
+		cursor: pointer;
+		font-size: 16px;
+		line-height: 1;
+		padding: 0 2px;
 	}
 
 	.method-dropdown {

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1185,14 +1185,21 @@
 		});
 	}
 
-	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged
+	// RELAX branch validation - requires TEST and REFERENCE branches to be tagged.
+	//
+	// Read through methodOptions[selectedMethod], NOT methodOptions.relax: this map is keyed by the
+	// method string exactly as the dropdown supplies it ('RELAX'), which initializeMethodOptions and
+	// handleBranchSelectionChange both use. The lowercase lookup was always undefined, so
+	// relaxHasTestBranches was permanently false and RELAX's Run button could never be enabled no
+	// matter what the user tagged. contrastFelBranchesValid below already uses the indexed form.
+	$: relaxOptions = selectedMethod ? methodOptions?.[selectedMethod] : null;
 	$: relaxHasTestBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		methodOptions?.relax?.interactiveTree?.includes('{TEST}');
+		relaxOptions?.interactiveTree?.includes('{TEST}');
 	$: relaxHasReferenceBranches =
 		selectedMethod?.toLowerCase() === 'relax' &&
-		(methodOptions?.relax?.interactiveTree?.includes('{REFERENCE}') ||
-			methodOptions?.relax?.referenceBranches === 'All');
+		(relaxOptions?.interactiveTree?.includes('{REFERENCE}') ||
+			relaxOptions?.referenceBranches === 'All');
 	$: relaxBranchesValid =
 		selectedMethod?.toLowerCase() !== 'relax' ||
 		(relaxHasTestBranches && relaxHasReferenceBranches);
@@ -1678,10 +1685,13 @@
 				{#if selectedTreeData}
 					<div class="tree-selector-wrapper">
 						{#key selectedMethod}
+							<!-- No `width`: BranchSelector measures its own pan box and draws at least
+							     minWidth, scrolling inside the box. The hard-coded 1000px used to push the
+							     PAGE 693px wider than a 393px phone. Do NOT widen this {#key} to include a
+							     width — every resize would remount and discard the current selection. -->
 							<BranchSelector
 								treeData={selectedTreeData}
 								height={500}
-								width={1000}
 								mode={selectedMethod?.toLowerCase() === 'contrast-fel' ||
 								selectedMethod?.toLowerCase() === 'relax'
 									? 'multi-set'

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -13,6 +13,10 @@
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	import { executionAdvice } from './utils/executionAdvice.js';
+	// callModes.js is a leaf (no imports) precisely so this line costs the main chunk nothing but the
+	// constants — see the note at the top of that file.
+	import { describeCallMode, CALL_DEFAULTS } from './services/axomeme/callModes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -151,6 +155,11 @@
 	let geneticCode = 'Universal';
 	let geneticCodeId = 0; // For matching HyPhy numeric codes
 	let executionMode = 'local'; // 'local' or 'backend'
+	// Has the user touched the execution-mode radios for the method+file currently on screen? The
+	// advice below may move the radio, but only until someone disagrees with it: an estimate is a
+	// curve fitted at R² ≈ 0.63, a click is a decision, and the decision wins.
+	let executionModeTouched = false;
+	let lastAdvisedFor = null;
 	let isSubmitting = false; // Track submission state for button feedback
 
 	// WHY THE RUN BUTTON IS BLOCKED, derived from the analysis store rather than a timer.
@@ -1061,6 +1070,50 @@
 		executionModeBeforeBrowserOnly = null;
 	}
 
+	// WHERE THIS RUN SHOULD GO, and why the default is no longer always Local.
+	//
+	// executionMode was hard-coded to 'local' and nothing ever moved it, including for datasets this
+	// app's own estimator calls Very Slow: BGM on 20x255 reads "~2h 15m" in the panel three rows below
+	// these radios while Local sits selected, and a local run dies with the tab. The advice comes from
+	// the same estimator the panel prints, so the two can never contradict each other.
+	//
+	// The counts are read WITHOUT AnalysisTimingEstimate's `|| 10` / `|| 1000` fallbacks. Those exist
+	// so the panel can show its shape before a file is parsed; borrowing them here would let a
+	// fabricated dataset move a radio with nothing loaded.
+	$: seqCount = $fileMetricsStore?.FILE_INFO?.sequences ?? $currentFile?.sequences ?? 0;
+	$: siteCount = $fileMetricsStore?.FILE_INFO?.sites ?? $currentFile?.sites ?? 0;
+	$: advice = executionAdvice({
+		method: selectedMethod,
+		sequences: seqCount,
+		sites: siteCount,
+		methodOptions: methodOptions[selectedMethod] || {},
+		serverConnected: $backendConnectivity.isConnected
+	});
+
+	// A different method, or a different file, is a different question — so the advice gets to answer
+	// it again. Within one method+file, a click is final.
+	$: adviceKey = `${selectedMethod ?? ''}|${$currentFile?.id ?? ''}`;
+	$: if (adviceKey !== lastAdvisedFor) {
+		lastAdvisedFor = adviceKey;
+		executionModeTouched = false;
+	}
+
+	// ORDERED AFTER the browserOnly restore above, deliberately. Both write executionMode; if a
+	// browser-only method ever returns, the restore must have the last word or the two ping-pong.
+	$: if (!executionModeTouched && advice.recommend === 'backend' && executionMode !== 'backend') {
+		executionMode = 'backend';
+	}
+	// Safety rail, and it fixes something older than the advice: pick Backend, lose the socket, and
+	// the radio greys out while executionMode stays 'backend' — the run then throws "Backend server is
+	// not connected" (AnalyzeTab.svelte:215-217) with a disabled radio still claiming to be selected.
+	$: if (!$backendConnectivity.isConnected && executionMode === 'backend') {
+		executionMode = 'local';
+	}
+	// Only true while the recommendation is actually in force. The advice sentence itself never claims
+	// which radio is selected, because the user may have clicked Local a second ago.
+	$: autoSelectedBackend =
+		advice.recommend === 'backend' && !executionModeTouched && executionMode === 'backend';
+
 	// Get current method's advanced options
 	$: currentMethodOptions = selectedMethod
 		? METHOD_ADVANCED_OPTIONS[selectedMethod.toLowerCase()] || {}
@@ -1260,10 +1313,10 @@
 		}
 	}
 
-	// Smart default: suggest backend for larger datasets
-	function getSmartDefault(fileSequenceCount = 0) {
-		return fileSequenceCount > 1000 ? 'backend' : 'local';
-	}
+	// getSmartDefault(fileSequenceCount > 1000 ? 'backend' : 'local') used to live here. It was never
+	// called by anything, and a second, contradicting threshold — sequence count alone, ignoring
+	// sites and the method — would now disagree with executionAdvice() on exactly the datasets this
+	// panel is about (BGM on 20 sequences is hours; FEL on 900 is not).
 
 	// Handle branch selection from interactive tree
 	function handleBranchSelectionChange(event) {
@@ -1400,10 +1453,18 @@
 							bind:group={executionMode}
 							value="local"
 							class="execution-mode-radio"
+							on:change={() => (executionModeTouched = true)}
 						/>
 						<div class="execution-mode-content">
 							<div class="execution-mode-name">Local (Browser)</div>
-							<div class="execution-mode-desc">Fast • Small datasets</div>
+							<!-- "Fast • Small datasets" was a claim about the dataset the app had already
+							     measured and disagreed with. Where there is a fitted equation, say the number;
+							     where there is not, say the consequence, which is true either way. -->
+							<div class="execution-mode-desc">
+								{advice.local
+									? `${advice.local.description} in this tab`
+									: 'Runs in this tab — it must stay open'}
+							</div>
 						</div>
 					</label>
 					<label class="execution-mode-option">
@@ -1413,12 +1474,15 @@
 							value="backend"
 							class="execution-mode-radio"
 							disabled={!$backendConnectivity.isConnected}
+							on:change={() => (executionModeTouched = true)}
 						/>
 						<div class="execution-mode-content">
 							<div class="execution-mode-name">Backend Server</div>
 							<div class="execution-mode-desc">
 								{#if $backendConnectivity.isConnected}
-									Powerful • Large datasets
+									{advice.server
+										? `${advice.server.description} on the server`
+										: 'Runs on the server — you can close the tab'}
 								{:else}
 									Server unavailable
 								{/if}
@@ -1426,10 +1490,26 @@
 						</div>
 					</label>
 				</div>
+				{#if $backendConnectivity.isConnected && advice.advice}
+					<p class="execution-mode-advice" data-testid="execution-mode-advice">
+						{advice.advice}{#if autoSelectedBackend}
+							The server is selected; choose Local to run it here anyway.{/if}
+					</p>
+				{/if}
 				{#if !$backendConnectivity.isConnected}
 					<div class="backend-status-warning">
 						<AlertTriangle class="warning-icon" />
-						<span>Server temporarily unavailable. Please use Local mode.</span>
+						<!-- The slow-run sentence extends the existing warning rather than opening a second,
+						     competing box next to it. The two branches are mutually exclusive, so the testid
+						     stays unique on the page. -->
+						<div class="warning-lines">
+							<span>Server temporarily unavailable. Please use Local mode.</span>
+							{#if advice.advice}
+								<p class="execution-mode-advice" data-testid="execution-mode-advice">
+									{advice.advice}
+								</p>
+							{/if}
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -1562,6 +1642,17 @@
 									{/if}
 								</div>
 							{/each}
+							<!-- What the SELECTED mode will actually do, which the option renderer above cannot
+							     say: it prints one static `config.description` for all three modes, and the
+							     consequence that matters here is specific to one of them. percentile always
+							     calls a fixed share of the variable sites, whether or not any site is under
+							     selection — the results table says so afterwards ("Top 2%"), and before the run
+							     nothing did. -->
+							{#if selectedMethod?.toLowerCase() === 'axomeme'}
+								<p class="call-mode-consequence" data-testid="axomeme-call-consequence">
+									{describeCallMode(methodOptions[selectedMethod]?.callMode ?? CALL_DEFAULTS.mode)}
+								</p>
+							{/if}
 						{:else}
 							<div class="no-options">
 								<span class="no-options-text">This method uses default parameters</span>
@@ -1907,9 +1998,19 @@
 		color: #718096;
 	}
 
+	/* Sits directly under the two radios and reads as their caption, not as an alert: it is a
+	   comparison of two durations the user can act on, and colouring it would make an ordinary
+	   large-dataset run look like an error. */
+	.execution-mode-advice {
+		margin: 8px 0 0;
+		font-size: 12px;
+		line-height: 1.45;
+		color: #4a5568;
+	}
+
 	.backend-status-warning {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 8px;
 		margin-top: 12px;
 		padding: 8px 12px;
@@ -1918,6 +2019,19 @@
 		border-radius: 4px;
 		font-size: 12px;
 		color: #92400e;
+	}
+
+	.warning-lines {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	/* Inside the warning it is a second line of the same message, so it takes the warning's colour
+	   and drops its own top margin. */
+	.backend-status-warning .execution-mode-advice {
+		margin: 0;
+		color: inherit;
 	}
 
 	.warning-icon {
@@ -2163,6 +2277,16 @@
 		margin-top: 4px;
 		line-height: 1.4;
 		font-style: italic;
+	}
+
+	/* Upright, unlike .option-description above it: that one compares the three modes, this one states
+	   what the chosen mode will do to this alignment. Different job, so it should not look like more
+	   of the same caption. */
+	.call-mode-consequence {
+		margin: 8px 0 0;
+		font-size: 12px;
+		line-height: 1.45;
+		color: #4a5568;
 	}
 
 	.option-group.disabled {

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -10,7 +10,7 @@
 	import RunOutlook from './RunOutlook.svelte';
 	import RunStrip from './RunStrip.svelte';
 	import { analysisStore } from '../stores/analyses';
-	import { currentFile } from '../stores/fileInfo';
+	import { currentFile, revalidatingFileId } from '../stores/fileInfo';
 	import { treeHasBranchLengths } from './services/prescreen/scope.js';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
@@ -18,7 +18,7 @@
 	import { executionAdvice } from './utils/executionAdvice.js';
 	// callModes.js is a leaf (no imports) precisely so this line costs the main chunk nothing but the
 	// constants — see the note at the top of that file.
-	import { describeCallMode, CALL_DEFAULTS } from './services/axomeme/callModes.js';
+	import { describeCallMode, CALL_DEFAULTS } from './services/axomeme/callModes.js';	// Shared with the Data tab, which needs to turn datareader's gencodeid back into a name.
 	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
@@ -189,31 +189,20 @@
 	);
 	$: localRunInFlight = liveRuns.some((a) => a.metadata?.executionMode !== 'backend');
 	$: wouldRunLocally = executionMode !== 'backend';
-	$: runBlockedReason = sameMethodRunning
-		? `${selectedMethod?.toUpperCase()} is already running on this file`
-		: localRunInFlight && wouldRunLocally
-			? 'Another analysis is running in this tab — only one can run here at a time'
-			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
+	//   - The current file is being re-read after an alignment edit -> block. This one is not in
+	//     liveRuns: MethodSelector filters datareader out of it (a file's own validation must never
+	//     look like a running analysis), so the re-read is invisible here without its own flag. For
+	//     the seconds it takes, fileMetricsStore is null and canonicalFasta does not exist, so a Run
+	//     started now would submit the user's original blob — the alignment they just edited away.
+	$: revalidatingThisFile =
+		Boolean($revalidatingFileId) && $revalidatingFileId === $currentFile?.id;
+	$: runBlockedReason = revalidatingThisFile
+		? 'Re-checking your edited alignment…'
+		: sameMethodRunning
+			? `${selectedMethod?.toUpperCase()} is already running on this file`
+			: localRunInFlight && wouldRunLocally
+				? 'Another analysis is running in this tab — only one can run here at a time'
+				: null;
 
 	// Method-specific advanced options state
 	let methodOptions = {};
@@ -1088,7 +1077,11 @@
 					Starting Analysis...
 				{:else if runBlockedReason}
 					<Loader2 class="run-icon spinning" />
-					{sameMethodRunning ? `${currentMethod?.info.name ?? ''} running` : 'Analysis running'}
+					{revalidatingThisFile
+						? 'Re-checking alignment…'
+						: sameMethodRunning
+							? `${currentMethod?.info.name ?? ''} running`
+							: 'Analysis running'}
 				{:else if currentMethod?.info.supported}
 					<Play class="run-icon" />
 					Run {currentMethod?.info.name || ''} Analysis

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -13,6 +13,7 @@
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -182,26 +183,6 @@
 		: localRunInFlight && wouldRunLocally
 			? 'Another analysis is running in this tab — only one can run here at a time'
 			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
 
 	// Method-specific advanced options configurations
 	const METHOD_ADVANCED_OPTIONS = {
@@ -1130,9 +1111,11 @@
 					})
 			: [];
 
-	// Update genetic code ID when name changes
+	// Update genetic code ID when name changes. The selector's VALUE is HyPhy's own identifier
+	// (what the browser path passes to --code); the id is what the server path and the codon
+	// validator use. Both come from the same row, so they cannot disagree.
 	$: {
-		const codeEntry = GENETIC_CODES.find((code) => code.name === geneticCode);
+		const codeEntry = GENETIC_CODES.find((code) => code.hyphy === geneticCode);
 		if (codeEntry) {
 			geneticCodeId = codeEntry.id;
 		}
@@ -1476,7 +1459,9 @@
 								Genetic Code:
 								<select bind:value={geneticCode} class="option-select">
 									{#each GENETIC_CODES as code}
-										<option value={code.name}>{code.label}</option>
+										<!-- value is HyPhy's own identifier, label is ours: the value is
+										     passed verbatim to `hyphy --code`, so it is not free text. -->
+										<option value={code.hyphy}>{code.label}</option>
 									{/each}
 								</select>
 							</label>

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -8,11 +8,13 @@
 	import RunOutlook from './RunOutlook.svelte';
 	import RunStrip from './RunStrip.svelte';
 	import { analysisStore } from '../stores/analyses';
-	import { currentFile } from '../stores/fileInfo';
+	import { currentFile, revalidatingFileId } from '../stores/fileInfo';
 	import { treeHasBranchLengths } from './services/prescreen/scope.js';
 	import { AlertTriangle, Play, Loader2 } from 'lucide-svelte';
 	import { trackEvent } from './utils/analytics.js';
 	import { countBranchGroups, contrastFelHasEnoughGroups } from './utils/branchGroupValidation.js';
+	// Shared with the Data tab, which needs to turn datareader's gencodeid back into a name.
+	import { GENETIC_CODES } from './config/geneticCodes.js';
 
 	export let methodConfig;
 	export let runMethod = null;
@@ -177,31 +179,20 @@
 	);
 	$: localRunInFlight = liveRuns.some((a) => a.metadata?.executionMode !== 'backend');
 	$: wouldRunLocally = executionMode !== 'backend';
-	$: runBlockedReason = sameMethodRunning
-		? `${selectedMethod?.toUpperCase()} is already running on this file`
-		: localRunInFlight && wouldRunLocally
-			? 'Another analysis is running in this tab — only one can run here at a time'
-			: null;
-
-	// Genetic code mapping (HyPhy uses numeric IDs)
-	const GENETIC_CODES = [
-		{ id: 0, name: 'Universal', label: 'Universal code' },
-		{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
-		{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
-		{
-			id: 3,
-			name: 'Mold mitochondrial',
-			label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
-		},
-		{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
-		{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
-		{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
-		{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
-		{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
-		{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
-		{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
-		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
-	];
+	//   - The current file is being re-read after an alignment edit -> block. This one is not in
+	//     liveRuns: MethodSelector filters datareader out of it (a file's own validation must never
+	//     look like a running analysis), so the re-read is invisible here without its own flag. For
+	//     the seconds it takes, fileMetricsStore is null and canonicalFasta does not exist, so a Run
+	//     started now would submit the user's original blob — the alignment they just edited away.
+	$: revalidatingThisFile =
+		Boolean($revalidatingFileId) && $revalidatingFileId === $currentFile?.id;
+	$: runBlockedReason = revalidatingThisFile
+		? 'Re-checking your edited alignment…'
+		: sameMethodRunning
+			? `${selectedMethod?.toUpperCase()} is already running on this file`
+			: localRunInFlight && wouldRunLocally
+				? 'Another analysis is running in this tab — only one can run here at a time'
+				: null;
 
 	// Method-specific advanced options configurations
 	const METHOD_ADVANCED_OPTIONS = {
@@ -1696,7 +1687,11 @@
 					Starting Analysis...
 				{:else if runBlockedReason}
 					<Loader2 class="run-icon spinning" />
-					{sameMethodRunning ? `${currentMethod?.info.name ?? ''} running` : 'Analysis running'}
+					{revalidatingThisFile
+						? 'Re-checking alignment…'
+						: sameMethodRunning
+							? `${currentMethod?.info.name ?? ''} running`
+							: 'Analysis running'}
 				{:else if currentMethod?.info.supported}
 					<Play class="run-icon" />
 					Run {currentMethod?.info.name || ''} Analysis

--- a/src/lib/MethodSelector.svelte
+++ b/src/lib/MethodSelector.svelte
@@ -1,7 +1,9 @@
 <!-- src/lib/MethodSelector.svelte -->
 <script>
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { backendConnectivity } from '../stores/backendConnectivity.js';
+	import { analysisConfig } from '../stores/analysisConfig.js';
+	import { METHOD_ADVANCED_OPTIONS } from './config/methodAdvancedOptions.js';
 	import { fileMetricsStore } from '../stores/fileInfo';
 	import { treeStore } from '../stores/tree';
 	import BranchSelector from './BranchSelector.svelte';
@@ -203,797 +205,67 @@
 		{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
 	];
 
-	// Method-specific advanced options configurations
-	const METHOD_ADVANCED_OPTIONS = {
-		// AxoMEME exposes almost nothing on purpose. It is a fitted model with one set of weights:
-		// there are no branch sets to select (it consumes the whole tree as a distance matrix), no
-		// rate-variation switch, and no genetic code choice — the code table is baked into the
-		// model's tokenizer as the universal one. Offering knobs that do not reach the model would be
-		// worse than offering none. Calling mode is the one real choice, because it is a threshold
-		// applied AFTER inference and genuinely changes what gets reported.
-		axomeme: {
-			callMode: {
-				type: 'select',
-				label: 'How to rank sites',
-				// percentile, not the reference driver's pvalue default. The model's predicted LRT does
-				// not reach the chi-square gates pvalue compares against — measured across 12 real
-				// submissions, one site in 662 cleared 3.12 and none cleared 4.45 — so pvalue makes the
-				// method silent. See CALL_DEFAULTS in postprocess.js.
-				default: 'percentile',
-				options: ['percentile', 'zscore', 'pvalue'],
-				description:
-					'percentile and zscore rank sites within this alignment, which is what the model is built to do. pvalue compares against fixed LRT gates (4.45 / 3.12) that its scores rarely reach — it will usually report nothing.'
-			}
-		},
-		fel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No']
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple']
-			},
-			siteMultihit: {
-				type: 'select',
-				label: 'Site Multihit',
-				default: 'Estimate',
-				options: ['Estimate', 'Global'],
-				dependsOn: 'multipleHits',
-				enabledWhen: ['Double', 'Double+Triple']
-			},
-			// Advanced parameters (matching the form structure)
-			resample: {
-				type: 'number',
-				label: 'Resample (parametric bootstrap replicates)',
-				default: 0,
-				min: 0,
-				max: 1000,
-				step: 1,
-				description:
-					'Advanced setting - will result in MUCH SLOWER run time. Recommended for small to medium (<30 sequences) datasets.'
-			},
-			confidenceIntervals: {
-				type: 'boolean',
-				label: 'Compute confidence intervals',
-				default: false,
-				description: 'Compute profile likelihood confidence intervals for each variable site'
-			},
-			// Keep existing parameters for backward compatibility
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			}
-		},
-		meme: {
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'P-value threshold for calling a site under selection'
-			},
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 2,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of site rate classes'
-			},
-			multiple_hits: {
-				type: 'select',
-				label: 'Multiple hits',
-				default: 'None',
-				options: ['None', 'Double', 'Triple', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			site_multihit: {
-				type: 'select',
-				label: 'Site multiple hits',
-				default: 'Estimate',
-				options: ['Estimate', 'None'],
-				description: 'How to handle multiple hits per site'
-			},
-			impute_states: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Impute ancestral states for internal nodes'
-			}
-		},
-		slac: {
-			// Branch selection options (similar to FEL)
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test for positive selection'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// SLAC-specific parameters
-			samples: {
-				type: 'number',
-				label: 'Ancestral reconstruction samples',
-				default: 100,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Number of samples for ancestral reconstruction uncertainty'
-			},
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for selection'
-			}
-		},
-		fubar: {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Specifies the number of grid points for the Bayesian analysis'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description:
-					'The concentration parameter for the Dirichlet prior in the Bayesian estimation'
-			},
-			posteriorThreshold: {
-				type: 'number',
-				label: 'Posterior probability threshold',
-				default: 0.9,
-				min: 0.5,
-				max: 0.99,
-				step: 0.01,
-				description:
-					'Sites with posterior probability above this threshold are considered under positive selection'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		'b-still': {
-			grid: {
-				type: 'number',
-				label: 'Number of grid points',
-				default: 20,
-				min: 5,
-				max: 50,
-				description: 'Grid points per dimension (total grid = D²)'
-			},
-			concentration_parameter: {
-				type: 'number',
-				label: 'Concentration parameter',
-				default: 0.5,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Dirichlet prior concentration parameter'
-			},
-			method: {
-				type: 'select',
-				label: 'Posterior estimation method',
-				default: 'Variational-Bayes',
-				options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
-				description: 'Method for estimating the posterior distribution'
-			},
-			ebf: {
-				type: 'number',
-				label: 'EBF threshold',
-				default: 10,
-				min: 1,
-				max: 1000,
-				step: 1,
-				description: 'Empirical Bayes Factor threshold for reporting invariant sites'
-			},
-			radius_threshold: {
-				type: 'number',
-				label: 'Radius threshold',
-				default: 0.5,
-				min: 0,
-				max: 10,
-				step: 0.1,
-				description: 'Expected substitution multiplier for near-zero regime'
-			}
-		},
-		absrel: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description: 'Which branches to test (default: All)'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Core aBSREL parameters
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Include support for multiple nucleotide substitutions'
-			},
-			srv: {
-				type: 'select',
-				label: 'Synonymous Rate Variation',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation'
-			},
-			// Advanced parameters
-			blb: {
-				type: 'number',
-				label: 'Bag of Little Bootstrap (BLB) Rate',
-				default: 1.0,
-				min: 0.0,
-				max: 1.0,
-				step: 0.1,
-				description: '[Advanced] Bag of little bootstrap alignment resampling rate'
-			}
-		},
-		busted: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Foreground Branches',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
-				description:
-					'Select foreground branches to test for positive selection. All other branches will be treated as background.'
-			},
-			customBranches: {
-				type: 'text',
-				label: 'Custom foreground branches (comma-separated or regex)',
-				default: '',
-				placeholder: 'e.g. Node1,Node2 or /^human/i',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Comma-separated branch names or regex pattern for foreground branches'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select foreground branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them as foreground branches for testing'
-			},
-			// Core BUSTED parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (BUSTED-S)',
-				default: 'Yes',
-				options: ['Yes', 'No', 'Branch-site'],
-				description: 'Include variations in synonymous substitution rates'
-			},
-			errorSink: {
-				type: 'select',
-				label: 'Error protection (BUSTED-E)',
-				default: 'No',
-				options: ['Yes', 'No'],
-				description: 'Enhance robustness against alignment errors'
-			},
-			multipleHits: {
-				type: 'select',
-				label: 'Multiple Hits',
-				default: 'None',
-				options: ['None', 'Double', 'Double+Triple'],
-				description: 'Support for handling multiple nucleotide substitutions'
-			},
-			// Advanced parameters
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes in the model'
-			},
-			synRates: {
-				type: 'number',
-				label: 'Synonymous rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of synonymous rate classes in the model'
-			},
-			gridSize: {
-				type: 'number',
-				label: 'Grid size',
-				default: 250,
-				min: 50,
-				max: 1000,
-				step: 50,
-				description: 'Number of points in initial distributional guess for likelihood fitting'
-			},
-			startingPoints: {
-				type: 'number',
-				label: 'Starting points',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of initial random guesses to seed rate values optimization'
-			}
-		},
-		gard: {
-			datatype: {
-				type: 'select',
-				label: 'Data type',
-				default: 'nucleotide',
-				options: ['codon', 'nucleotide', 'protein'],
-				description: 'Type of data to analyze for recombination'
-			},
-			model: {
-				type: 'select',
-				label: 'Substitution model',
-				default: 'GTR',
-				options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
-				filteredOptionsBy: 'datatype',
-				filteredOptions: {
-					codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
-					protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
-				},
-				filteredDefaults: {
-					codon: 'GTR',
-					nucleotide: 'GTR',
-					protein: 'JTT'
-				},
-				description: 'Substitution model to use for the analysis'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Normal',
-				options: ['Normal', 'Faster'],
-				description: 'Normal: thorough analysis; Faster: quicker but less comprehensive'
-			},
-			rv: {
-				type: 'select',
-				label: 'Site-to-site rate variation',
-				default: 'None',
-				options: ['None', 'GDD', 'Gamma'],
-				description: 'Model for rate variation among sites (None, General Discrete, Beta-Gamma)'
-			},
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 4,
-				min: 2,
-				max: 10,
-				description: 'Number of discrete rate classes for rate variation'
-			}
-		},
-		bgm: {
-			steps: {
-				type: 'number',
-				label: 'Chain length steps',
-				default: 10000,
-				min: 1000,
-				max: 100000000,
-				step: 1000,
-				description: 'Length of each MCMC chain'
-			},
-			burnIn: {
-				type: 'number',
-				label: 'Burn-in samples',
-				default: 1000,
-				min: 100,
-				max: 100000,
-				step: 100,
-				description: 'Number of burn-in samples to discard'
-			},
-			samples: {
-				type: 'number',
-				label: 'Samples',
-				default: 100,
-				min: 10,
-				max: 10000,
-				step: 10,
-				description: 'Number of samples to collect'
-			},
-			maxParents: {
-				type: 'number',
-				label: 'Maximum parents per node',
-				default: 1,
-				min: 0,
-				max: 10,
-				step: 1,
-				description: 'Maximum number of parents allowed per node in the graphical model'
-			},
-			minSubs: {
-				type: 'number',
-				label: 'Minimum substitutions per site',
-				default: 1,
-				min: 1,
-				max: 100,
-				step: 1,
-				description: 'Minimum number of substitutions required per site'
-			}
-		},
-		fade: {
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001
-			},
-			gridPoints: { type: 'number', label: 'Grid points', default: 20, min: 5, max: 50 },
-			mcmcChains: { type: 'number', label: 'MCMC chains', default: 5, min: 2, max: 20 },
-			mcmcSamples: {
-				type: 'number',
-				label: 'MCMC samples',
-				default: 2000000,
-				min: 100000,
-				max: 10000000,
-				step: 100000
-			}
-		},
-		relax: {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Interactive'],
-				description: 'Select TEST and REFERENCE branches interactively on the tree'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select TEST and REFERENCE branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to TEST or REFERENCE sets'
-			},
-			// RELAX-specific parameters
-			models: {
-				type: 'select',
-				label: 'Analysis models',
-				default: 'All',
-				options: ['All', 'Minimal'],
-				description: 'All: descriptive models and RELAX test; Minimal: RELAX test only'
-			},
-			rates: {
-				type: 'number',
-				label: 'Omega rate classes',
-				default: 3,
-				min: 2,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes'
-			},
-			mode: {
-				type: 'select',
-				label: 'Run mode',
-				default: 'Classic mode',
-				options: ['Classic mode'],
-				description: 'RELAX analysis mode'
-			},
-			killZeroLengths: {
-				type: 'select',
-				label: 'Kill zero-length branches',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'How to handle zero-length branches'
-			}
-		},
-		'multi-hit': {
-			rates: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 3,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of omega rate classes to include in the model'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use separate rate parameter for synonymous triple-hit substitutions'
-			}
-		},
-		nrm: {
-			rate_classes: {
-				type: 'number',
-				label: 'Rate classes',
-				default: 1,
-				min: 1,
-				max: 10,
-				step: 1,
-				description: 'Number of rate classes for the analysis'
-			},
-			triple_islands: {
-				type: 'select',
-				label: 'Triple islands',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use triple islands for the analysis'
-			}
-		},
-		prime: {
-			// PRIME variant selection
-			variant: {
-				type: 'select',
-				label: 'PRIME Variant',
-				default: 'S-PRIME',
-				options: [
-					'S-PRIME',
-					{ value: 'G-PRIME', label: 'G-PRIME (coming soon)', disabled: true },
-					{ value: 'E-PRIME', label: 'E-PRIME (coming soon)', disabled: true }
-				],
-				description: 'S-PRIME: site-level property-informed model'
-			},
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branches to Test',
-				default: 'All',
-				options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Interactive'],
-				description: 'Which branches to test for property-dependent selection'
-			},
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branches on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to select them for testing'
-			},
-			// Property set selection
-			propertySet: {
-				type: 'select',
-				label: 'Amino Acid Property Set',
-				default: '5PROP',
-				options: ['5PROP', '4PROP', '3PROP', '2PROP', 'Atchley', 'LCAP'],
-				description:
-					'Set of amino acid properties to model (5PROP: hydrophobicity, polarity, volume, charge, iso-electric point)'
-			},
-			// P-value threshold
-			pValueThreshold: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.1,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'The p-value threshold to use when testing for property-dependent selection'
-			},
-			// Impute states
-			imputeStates: {
-				type: 'select',
-				label: 'Impute states',
-				default: 'No',
-				options: ['No', 'Yes'],
-				description: 'Use site-level model fits to impute likely character states'
-			}
-		},
-		'contrast-fel': {
-			// Branch selection options
-			branchesToTest: {
-				type: 'select',
-				label: 'Branch Selection Mode',
-				default: 'Interactive',
-				options: ['Custom', 'Interactive'],
-				description: 'How to specify branch sets for comparison'
-			},
-			// Custom branch set configuration (when not using Interactive)
-			branchSet1: {
-				type: 'text',
-				label: 'Branch Set 1 (Source)',
-				default: 'Source',
-				placeholder: 'e.g. Source, Internal, Leaves',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'First group of branches to compare'
-			},
-			branchSet2: {
-				type: 'text',
-				label: 'Branch Set 2 (Test)',
-				default: 'Test',
-				placeholder: 'e.g. Test, Unlabeled, Custom',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Second group of branches to compare'
-			},
-			branchSet3: {
-				type: 'text',
-				label: 'Branch Set 3 (optional)',
-				default: '',
-				placeholder: 'e.g. Reference, Background',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Custom'],
-				description: 'Optional third group of branches for comparison'
-			},
-			// Interactive tree selection
-			interactiveTree: {
-				type: 'interactive-tree',
-				label: 'Select branch sets on tree',
-				default: '',
-				dependsOn: 'branchesToTest',
-				enabledWhen: ['Interactive'],
-				description: 'Click on tree branches to assign them to different sets for comparison'
-			},
-			// Core Contrast-FEL parameters
-			srv: {
-				type: 'select',
-				label: 'Synonymous rate variation (recommended)',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Include synonymous rate variation in the model'
-			},
-			permutations: {
-				type: 'select',
-				label: 'Perform permutation tests',
-				default: 'Yes',
-				options: ['Yes', 'No'],
-				description: 'Use permutation tests to evaluate significance'
-			},
-			// Statistical thresholds
-			pvalue: {
-				type: 'number',
-				label: 'P-value threshold',
-				default: 0.05,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'Significance value for site tests'
-			},
-			qvalue: {
-				type: 'number',
-				label: 'Q-value threshold (FDR)',
-				default: 0.2,
-				min: 0.001,
-				max: 1,
-				step: 0.001,
-				description: 'False Discovery Rate threshold for reporting'
-			},
-			// Output options
-			output: {
-				type: 'text',
-				label: 'Output file name (optional)',
-				default: '',
-				placeholder: 'e.g. contrast_results.json',
-				description: 'Custom name for output file (defaults to automatic naming)'
-			}
-		}
-	};
-
 	// Method-specific advanced options state
 	let methodOptions = {};
+
+	// SURVIVING A TAB SWITCH.
+	//
+	// This component is mounted inside {#if activeTab === 'analyze'} in +page.svelte, so Svelte
+	// destroys it — and every local below — the moment the user looks at Results. The five values are
+	// kept as plain locals because ~60 references and two bind:value depend on them; they are hydrated
+	// from the store here and mirrored back on every change.
+	//
+	// Hydration happens in onMount rather than at declaration ON PURPOSE. The reactive block that
+	// initialises a method's option bag is gated on the bag being ABSENT
+	// (`if (selectedMethod && !methodOptions[selectedMethod])`) because initializeMethodOptions
+	// overwrites it wholesale with defaults. Restoring before that block first runs is what lets the
+	// restored options survive it. Keep that gate.
+	let restoredNotice = null;
+	let hydrated = false;
+
+	onMount(() => {
+		const saved = analysisConfig.current();
+		if (saved.selectedMethod) selectedMethod = saved.selectedMethod;
+		if (saved.geneticCode) geneticCode = saved.geneticCode;
+		if (Number.isFinite(saved.geneticCodeId)) geneticCodeId = saved.geneticCodeId;
+		// Restoring 'backend' onto a session where the server is unreachable would arm a run that
+		// fails at submission. Clamp it; the radio is still there for the user to change back.
+		if (saved.executionMode) {
+			executionMode =
+				saved.executionMode === 'backend' && !$backendConnectivity?.isConnected
+					? 'local'
+					: saved.executionMode;
+		}
+		if (saved.methodOptions) methodOptions = { ...saved.methodOptions };
+
+		if (saved.restoredFromAnalysisId && saved.selectedMethod) {
+			// AxoMEME records carry no arguments at all, so there is nothing to claim was restored.
+			// Say what is true and no more.
+			restoredNotice = saved.restoredSummary
+				? `Restored your ${saved.selectedMethod.toUpperCase()} settings — ${saved.restoredSummary}.`
+				: `Selected ${saved.selectedMethod.toUpperCase()}.`;
+		}
+
+		// Announce a restore once, not on every subsequent tab switch.
+		analysisConfig.update((state) => ({ ...state, restoredFromAnalysisId: null }));
+		hydrated = true;
+	});
+
+	// Mirror back. One assignment, so the store can never hold half a configuration.
+	//
+	// Gated on `hydrated` because reactive statements run during the FIRST render, before onMount:
+	// ungated, this would write the component's blank defaults over the very state it is about to
+	// read back, and the feature would silently do nothing.
+	$: if (hydrated) {
+		analysisConfig.update((state) => ({
+			...state,
+			selectedMethod,
+			geneticCode,
+			geneticCodeId,
+			executionMode,
+			methodOptions
+		}));
+	}
 
 	// Tree data from store (auto-subscription; Svelte cleans it up on destroy)
 	$: trees = $treeStore;
@@ -1358,6 +630,20 @@
 				{/each}
 			</select>
 		</div>
+
+		<!-- What a Re-run actually brought back. Built from the restored values, never from a fixed
+		     field list, so it cannot claim to have restored something it did not. -->
+		{#if restoredNotice}
+			<div class="restored-notice" data-testid="restored-settings-notice">
+				<span>{restoredNotice}</span>
+				<button
+					type="button"
+					class="restored-dismiss"
+					aria-label="Dismiss"
+					on:click={() => (restoredNotice = null)}>×</button
+				>
+			</div>
+		{/if}
 
 		<!-- Method Description -->
 		{#if currentMethod}
@@ -1760,6 +1046,30 @@
 		font-size: 0.8125rem;
 		line-height: 1.4;
 		color: #475569;
+	}
+
+	.restored-notice {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin-top: 8px;
+		padding: 6px 10px;
+		border: 1px solid #cbd5e0;
+		border-radius: 6px;
+		background: #f7fafc;
+		color: #2d3748;
+		font-size: 13px;
+	}
+
+	.restored-dismiss {
+		border: none;
+		background: none;
+		color: #4a5568;
+		cursor: pointer;
+		font-size: 16px;
+		line-height: 1;
+		padding: 0 2px;
 	}
 
 	.method-dropdown {

--- a/src/lib/SequenceWarnings.svelte
+++ b/src/lib/SequenceWarnings.svelte
@@ -1,6 +1,7 @@
 <!-- src/lib/SequenceWarnings.svelte -->
 <script>
 	import { AlertCircle, AlertTriangle, Info } from 'lucide-svelte';
+	import { buildWarnings } from './utils/datareaderWarnings.js';
 
 	export let fileMetricsJSON = null;
 
@@ -8,89 +9,13 @@
 	let warnings = [];
 	let showAllWarnings = false;
 
-	// Watch for changes in fileMetricsJSON
-	$: if (fileMetricsJSON) {
-		generateWarnings(fileMetricsJSON);
-	}
+	// The generator lives in datareaderWarnings.js: the copy is the whole point of these warnings,
+	// and inside a component there was no seam a test could reach it through.
+	$: warnings = buildWarnings(fileMetricsJSON?.FILE_INFO);
 
-	// Generate warnings based on file metrics
-	function generateWarnings(data) {
-		warnings = [];
-
-		if (!data || !data.FILE_INFO) return;
-
-		// Check for duplicate sequences
-		if (data.FILE_INFO.duplicate_sequences && data.FILE_INFO.duplicate_sequences > 0) {
-			warnings.push({
-				type: 'warning',
-				title: 'Duplicate Sequences Detected',
-				message: `Found ${data.FILE_INFO.duplicate_sequences} duplicate sequence${data.FILE_INFO.duplicate_sequences === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Duplicate sequences can affect the accuracy of selection analysis. Consider removing duplicates for more reliable results.',
-				action: null
-			});
-		}
-
-		// Check for short alignment
-		if (data.FILE_INFO.sites && data.FILE_INFO.sites < 30) {
-			warnings.push({
-				type: 'info',
-				title: 'Short Alignment',
-				message: `Your alignment has only ${data.FILE_INFO.sites} sites, which is relatively short.`,
-				details:
-					'Short alignments may have limited statistical power for detecting selection. Consider adding more sequences or sites if possible.',
-				action: null
-			});
-		}
-
-		// Check for small number of sequences
-		if (data.FILE_INFO.sequences && data.FILE_INFO.sequences < 8) {
-			warnings.push({
-				type: 'info',
-				title: 'Small Sample Size',
-				message: `Your alignment has only ${data.FILE_INFO.sequences} sequences, which is a small sample.`,
-				details:
-					'Selection analyses generally perform better with larger samples. Consider adding more sequences if possible.',
-				action: null
-			});
-		}
-
-		// Check for ambiguous characters
-		if (data.FILE_INFO.ambiguous_sites && data.FILE_INFO.ambiguous_sites > 0) {
-			warnings.push({
-				type: 'warning',
-				title: 'Ambiguous Characters',
-				message: `Found ${data.FILE_INFO.ambiguous_sites} ambiguous character${data.FILE_INFO.ambiguous_sites === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Ambiguous characters (like N, X, etc.) may cause issues with some analyses. Consider resolving these ambiguities if possible.',
-				action: null
-			});
-		}
-
-		// Check for stop codons
-		if (data.FILE_INFO.stop_codons && data.FILE_INFO.stop_codons > 0) {
-			warnings.push({
-				type: 'error',
-				title: 'Stop Codons Detected',
-				message: `Found ${data.FILE_INFO.stop_codons} stop codon${data.FILE_INFO.stop_codons === 1 ? '' : 's'} in your alignment.`,
-				details:
-					'Stop codons within the alignment may indicate frame shifts, sequencing errors, or pseudogenes. Verify your alignment and genetic code selection.',
-				action: null
-			});
-		}
-
-		// Check for frameshift issues (uneven codon count)
-		if (data.FILE_INFO.rawsites && data.FILE_INFO.rawsites % 3 !== 0) {
-			warnings.push({
-				type: 'error',
-				title: 'Alignment Length Not Divisible by 3',
-				message: `Your alignment length (${data.FILE_INFO.rawsites}) is not divisible by 3.`,
-				details:
-					'Codon-based analyses require sequence lengths to be multiples of 3. Check for frameshifts or alignment errors.',
-				action: null
-			});
-		}
-	}
+	// How many names to show inline before collapsing the rest into a count. Long enough to be
+	// useful on a hand-curated alignment, short enough not to bury the message.
+	const MAX_LISTED_NAMES = 10;
 
 	// Get the color class based on warning type
 	function getWarningColorClass(type) {
@@ -153,6 +78,21 @@
 						<h4 class="text-sm font-semibold">{warning.title}</h4>
 						<p class="text-sm">{warning.message}</p>
 
+						{#if warning.items && warning.items.length > 0}
+							<ul class="mt-1.5 space-y-0.5 font-mono text-xs opacity-90">
+								{#each warning.items.slice(0, MAX_LISTED_NAMES) as item}
+									<li class="break-all">{item}</li>
+								{/each}
+							</ul>
+							{#if warning.items.length > MAX_LISTED_NAMES || warning.truncated}
+								<p class="mt-1 text-xs opacity-70">
+									+{warning.items.length -
+										Math.min(warning.items.length, MAX_LISTED_NAMES) +
+										(warning.truncated || 0)} more not listed
+								</p>
+							{/if}
+						{/if}
+
 						{#if warning.details}
 							<p class="mt-1 text-xs opacity-80">{warning.details}</p>
 						{/if}
@@ -180,7 +120,7 @@
 	</div>
 
 	<p class="mt-2 text-xs text-text-silver">
-		These warnings are meant to help you improve your analysis results. Minor issues may not
-		significantly affect results.
+		These notes describe what your file contained and what the reader did with it before analysis.
+		They are not errors, and none of them changed the file you uploaded.
 	</p>
 {/if}

--- a/src/lib/SmartTabNavigation.svelte
+++ b/src/lib/SmartTabNavigation.svelte
@@ -41,6 +41,41 @@
 	$: isAnalyzeDisabled = !hasFiles || currentFileFailedValidation;
 	$: isResultsDisabled = !hasAnalyses;
 
+	// Roving tabindex: the tab bar is ONE tab stop, and Arrow/Home/End move between tabs. This is
+	// the WAI-ARIA tabs pattern; without it a keyboard user cannot tell the three buttons form a
+	// group, and the gate reason was hover-only (a `title` tooltip), i.e. invisible to them entirely.
+	const TAB_ORDER = ['data', 'analyze', 'results'];
+
+	function focusTabAt(index) {
+		const name = TAB_ORDER[(index + TAB_ORDER.length) % TAB_ORDER.length];
+		const el = document.getElementById(`tab-${name}`);
+		el?.focus();
+	}
+
+	function handleTabKeydown(event) {
+		const currentIndex = TAB_ORDER.indexOf(activeTab);
+		const from = currentIndex === -1 ? 0 : currentIndex;
+
+		switch (event.key) {
+			case 'ArrowRight':
+				event.preventDefault();
+				focusTabAt(from + 1);
+				break;
+			case 'ArrowLeft':
+				event.preventDefault();
+				focusTabAt(from - 1);
+				break;
+			case 'Home':
+				event.preventDefault();
+				focusTabAt(0);
+				break;
+			case 'End':
+				event.preventDefault();
+				focusTabAt(TAB_ORDER.length - 1);
+				break;
+		}
+	}
+
 	// Function to handle tab clicks with context-aware behavior
 	function handleTabClick(tabName) {
 		// Data tab is always accessible
@@ -69,7 +104,7 @@
 
 <div class="mb-4 sm:mb-premium-xl">
 	<div class="rounded-premium bg-brand-ghost p-1 sm:p-premium-xs">
-		<div class="flex border-b border-border-platinum">
+		<div class="flex border-b border-border-platinum" role="tablist" aria-label="Analysis workflow">
 			<!-- Data Tab - Always Enabled -->
 			<button
 				class="relative min-h-[48px] flex-1 px-2 py-3 text-xs font-semibold transition-all duration-premium sm:flex-none sm:px-premium-xl sm:py-premium-lg sm:text-premium-brand"
@@ -79,6 +114,12 @@
 				class:hover:bg-brand-whisper={activeTab !== 'data'}
 				on:click={() => handleTabClick('data')}
 				title="Manage sequence data"
+				role="tab"
+				id="tab-data"
+				aria-selected={activeTab === 'data'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'data' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -113,6 +154,12 @@
 				on:click={() => handleTabClick('analyze')}
 				title={isAnalyzeDisabled ? 'Upload data first' : 'Run analysis on selected data'}
 				aria-disabled={isAnalyzeDisabled}
+				role="tab"
+				id="tab-analyze"
+				aria-selected={activeTab === 'analyze'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'analyze' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -150,6 +197,12 @@
 				on:click={() => handleTabClick('results')}
 				title={isResultsDisabled ? 'Run analysis first' : 'View analysis results'}
 				aria-disabled={isResultsDisabled}
+				role="tab"
+				id="tab-results"
+				aria-selected={activeTab === 'results'}
+				aria-controls="tab-panel"
+				tabindex={activeTab === 'results' ? 0 : -1}
+				on:keydown={handleTabKeydown}
 			>
 				<span class="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
 					<div
@@ -177,6 +230,27 @@
 				{/if}
 			</button>
 		</div>
+
+		<!--
+			Why a locked tab is locked, stated in the page rather than in a `title` tooltip: hover does
+			not exist on touch and is not reachable by keyboard. The three-way split matters —
+			isAnalyzeDisabled is true for two different reasons, and a file that failed validation must
+			NOT be told to load a file it has already loaded (issue #189).
+		-->
+		{#if currentFileFailedValidation || isAnalyzeDisabled || isResultsDisabled}
+			<p
+				data-testid="tab-gate-hint"
+				class="px-2 pt-2 text-xs text-text-slate sm:px-premium-xl sm:pt-premium-sm sm:text-premium-caption"
+			>
+				{#if currentFileFailedValidation}
+					This file could not be read — load a different alignment to unlock Analyze.
+				{:else if isAnalyzeDisabled}
+					Load a file on the Data tab to unlock Analyze.
+				{:else}
+					Run an analysis to unlock Results.
+				{/if}
+			</p>
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/config/geneticCodes.js
+++ b/src/lib/config/geneticCodes.js
@@ -1,0 +1,128 @@
+/**
+ * geneticCodes.js — the single source of truth for genetic code identity in this app.
+ *
+ * There are three consumers and they had three different tables, which is how a UI that said
+ * "Vertebrate mitochondrial DNA code" ended up analysing data under the universal code:
+ *
+ *   - the browser (WASM) path passes a NAME to HyPhy on the command line (`--code <name>`), and
+ *     HyPhy only accepts the identifiers it declares itself;
+ *   - the server path passes a numeric ID (`gencodeid`), which HyPhy resolves BY POSITION in that
+ *     same table;
+ *   - the stop-codon validator (fastaValidation.js) keys its per-code stop sets by that same ID.
+ *
+ * WHERE `hyphy` COMES FROM, and why it looks nothing like what this repo used to send:
+ * the authority is the engine we actually ship — static/wasm/hyphy/2.5.98/hyphy.data, whose packed
+ * `_geneticCodeOptionMatrix` declares hyphenated, space-free identifiers ('Vertebrate-mtDNA').
+ * It is NOT src/data/shared/chooseGeneticCode.def, which is an older vendored copy carrying spaced
+ * spellings ('Vertebrate mtDNA'); that file is mounted only for the upload-time datareader, which
+ * never selects a code, so its drift went unnoticed. Passing any spaced name to the shipped engine
+ * gets it rejected outright:
+ *
+ *     'mtDNA' is not a valid choice passed to 'Choose Genetic Code' ChoiceList
+ *
+ * src/test/genetic-codes-table.test.js reads hyphy.data and fails if this table drifts from it.
+ * `label` is ours and may be reworded freely; it is display only.
+ *
+ * WHY ONLY TWELVE. The shipped engine offers twenty-two codes; ids 12-21 (Chlorophycean-mtDNA and
+ * later) are deliberately not exposed. They are unverified against the analysis server, which
+ * receives the numeric id, and they are absent from STOP_CODONS_BY_GENETIC_CODE in
+ * fastaValidation.js, where an unknown id falls back to the universal stop set — a stop-codon
+ * check that quietly validates against the wrong code is worse than a code we do not offer.
+ * Exposing them means extending both, and verifying the server, first.
+ *
+ * LEGACY_CODE_ALIASES exists because two older spellings are still in circulation: the names the
+ * MethodSelector invented ('Vertebrate mitochondrial'), which sit in saved analysis configs and in
+ * Storybook fixtures, and the spaced names from the vendored .def and methodOptions.toml
+ * ('Vertebrate mtDNA'). Resolving them keeps an old config running the code it names instead of
+ * silently falling back to Universal.
+ */
+
+/** @typedef {{ id: number, hyphy: string, label: string }} GeneticCode */
+
+/** Ordered exactly as the shipped engine declares them; `id` is the row index HyPhy indexes by. */
+export const GENETIC_CODES = [
+	{ id: 0, hyphy: 'Universal', label: 'Universal code' },
+	{ id: 1, hyphy: 'Vertebrate-mtDNA', label: 'Vertebrate mitochondrial DNA code' },
+	{ id: 2, hyphy: 'Yeast-mtDNA', label: 'Yeast mitochondrial DNA code' },
+	{
+		id: 3,
+		hyphy: 'Mold-Protozoan-mtDNA',
+		label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
+	},
+	{ id: 4, hyphy: 'Invertebrate-mtDNA', label: 'Invertebrate mitochondrial DNA code' },
+	{ id: 5, hyphy: 'Ciliate-Nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
+	{ id: 6, hyphy: 'Echinoderm-mtDNA', label: 'Echinoderm mitochondrial DNA code' },
+	{ id: 7, hyphy: 'Euplotid-Nuclear', label: 'Euplotid Nuclear code' },
+	{ id: 8, hyphy: 'Alt-Yeast-Nuclear', label: 'Alternative Yeast Nuclear code' },
+	{ id: 9, hyphy: 'Ascidian-mtDNA', label: 'Ascidian mitochondrial DNA code' },
+	{ id: 10, hyphy: 'Flatworm-mtDNA', label: 'Flatworm mitochondrial DNA code' },
+	{ id: 11, hyphy: 'Blepharisma-Nuclear', label: 'Blepharisma Nuclear code' }
+];
+
+/**
+ * Older spellings, mapped to the identifier the shipped engine declares.
+ *
+ * Two generations of them:
+ *   - the MethodSelector's invented names ('Vertebrate mitochondrial'), stored in saved configs;
+ *   - the spaced names from the vendored chooseGeneticCode.def and methodOptions.toml
+ *     ('Vertebrate mtDNA').
+ *
+ * Neither is a HyPhy identifier for the engine we ship. Do not add new entries — new code should
+ * use the canonical names above.
+ */
+export const LEGACY_CODE_ALIASES = {
+	Universal: 'Universal',
+	'Vertebrate mitochondrial': 'Vertebrate-mtDNA',
+	'Yeast mitochondrial': 'Yeast-mtDNA',
+	'Mold mitochondrial': 'Mold-Protozoan-mtDNA',
+	'Invertebrate mitochondrial': 'Invertebrate-mtDNA',
+	'Ciliate nuclear': 'Ciliate-Nuclear',
+	'Echinoderm mitochondrial': 'Echinoderm-mtDNA',
+	'Euplotid nuclear': 'Euplotid-Nuclear',
+	'Alternative yeast nuclear': 'Alt-Yeast-Nuclear',
+	'Ascidian mitochondrial': 'Ascidian-mtDNA',
+	'Flatworm mitochondrial': 'Flatworm-mtDNA',
+	'Blepharisma nuclear': 'Blepharisma-Nuclear',
+	'Vertebrate mtDNA': 'Vertebrate-mtDNA',
+	'Yeast mtDNA': 'Yeast-mtDNA',
+	'Mold/Protozoan mtDNA': 'Mold-Protozoan-mtDNA',
+	'Invertebrate mtDNA': 'Invertebrate-mtDNA',
+	'Ciliate Nuclear': 'Ciliate-Nuclear',
+	'Echinoderm mtDNA': 'Echinoderm-mtDNA',
+	'Euplotid Nuclear': 'Euplotid-Nuclear',
+	'Alt. Yeast Nuclear': 'Alt-Yeast-Nuclear',
+	'Ascidian mtDNA': 'Ascidian-mtDNA',
+	'Flatworm mtDNA': 'Flatworm-mtDNA',
+	'Blepharisma Nuclear': 'Blepharisma-Nuclear'
+};
+
+/**
+ * Resolve a canonical-or-legacy genetic code name to the identifier HyPhy accepts.
+ *
+ * Unknown names are returned UNCHANGED rather than coerced to 'Universal': on the WASM path this
+ * value goes straight to `--code`, and HyPhy rejecting an unrecognised name loudly is far better
+ * than this app quietly analysing the data under a different code than the one displayed.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function canonicalGeneticCodeName(name) {
+	if (!name) return 'Universal';
+	if (GENETIC_CODES.some((code) => code.hyphy === name)) return name;
+	return LEGACY_CODE_ALIASES[name] ?? name;
+}
+
+/**
+ * Resolve a canonical-or-legacy genetic code name to the numeric id HyPhy indexes by.
+ *
+ * Falls back to 0 (Universal) for unknown names, matching the server path's long-standing
+ * behaviour — the backend requires *some* numeric id and has no way to express "unknown".
+ *
+ * @param {string} name
+ * @returns {number}
+ */
+export function geneticCodeId(name) {
+	const canonical = canonicalGeneticCodeName(name);
+	const entry = GENETIC_CODES.find((code) => code.hyphy === canonical);
+	return entry ? entry.id : 0;
+}

--- a/src/lib/config/geneticCodes.js
+++ b/src/lib/config/geneticCodes.js
@@ -1,0 +1,27 @@
+/**
+ * HyPhy's genetic code table, keyed by the numeric ID HyPhy uses on the command line and in
+ * datareader's FILE_INFO.gencodeid.
+ *
+ * This lived inside MethodSelector.svelte, which meant the Data tab had no way to turn a
+ * gencodeid back into a name and printed the bare integer instead. One home, two consumers.
+ * The `name` values are the option labels in the Analyze tab's dropdown and are mapped back to
+ * `id` there — do not reword them without checking that mapping.
+ */
+export const GENETIC_CODES = [
+	{ id: 0, name: 'Universal', label: 'Universal code' },
+	{ id: 1, name: 'Vertebrate mitochondrial', label: 'Vertebrate mitochondrial DNA code' },
+	{ id: 2, name: 'Yeast mitochondrial', label: 'Yeast mitochondrial DNA code' },
+	{
+		id: 3,
+		name: 'Mold mitochondrial',
+		label: 'Mold, Protozoan and Coelenterate mt; Mycloplasma/Spiroplasma'
+	},
+	{ id: 4, name: 'Invertebrate mitochondrial', label: 'Invertebrate mitochondrial DNA code' },
+	{ id: 5, name: 'Ciliate nuclear', label: 'Ciliate, Dasycladacean and Hexamita Nuclear code' },
+	{ id: 6, name: 'Echinoderm mitochondrial', label: 'Echinoderm mitochondrial DNA code' },
+	{ id: 7, name: 'Euplotid nuclear', label: 'Euplotid Nuclear code' },
+	{ id: 8, name: 'Alternative yeast nuclear', label: 'Alternative Yeast Nuclear code' },
+	{ id: 9, name: 'Ascidian mitochondrial', label: 'Ascidian mitochondrial DNA code' },
+	{ id: 10, name: 'Flatworm mitochondrial', label: 'Flatworm mitochondrial DNA code' },
+	{ id: 11, name: 'Blepharisma nuclear', label: 'Blepharisma Nuclear code' }
+];

--- a/src/lib/config/methodAdvancedOptions.js
+++ b/src/lib/config/methodAdvancedOptions.js
@@ -1,0 +1,796 @@
+/**
+ * METHOD_ADVANCED_OPTIONS — the per-method advanced-option schema.
+ *
+ * Lifted out of MethodSelector.svelte because it is data, not markup, and two places now need it:
+ * the selector renders it, and analysisConfig.restoreFrom filters a re-run's saved settings against
+ * it so an option a later release removed cannot resurrect a control that no longer exists.
+ *
+ * Adding a method still means adding a section here — same content, one file over.
+ */
+
+export const METHOD_ADVANCED_OPTIONS = {
+	// AxoMEME exposes almost nothing on purpose. It is a fitted model with one set of weights:
+	// there are no branch sets to select (it consumes the whole tree as a distance matrix), no
+	// rate-variation switch, and no genetic code choice — the code table is baked into the
+	// model's tokenizer as the universal one. Offering knobs that do not reach the model would be
+	// worse than offering none. Calling mode is the one real choice, because it is a threshold
+	// applied AFTER inference and genuinely changes what gets reported.
+	axomeme: {
+		callMode: {
+			type: 'select',
+			label: 'How to rank sites',
+			// percentile, not the reference driver's pvalue default. The model's predicted LRT does
+			// not reach the chi-square gates pvalue compares against — measured across 12 real
+			// submissions, one site in 662 cleared 3.12 and none cleared 4.45 — so pvalue makes the
+			// method silent. See CALL_DEFAULTS in postprocess.js.
+			default: 'percentile',
+			options: ['percentile', 'zscore', 'pvalue'],
+			description:
+				'percentile and zscore rank sites within this alignment, which is what the model is built to do. pvalue compares against fixed LRT gates (4.45 / 3.12) that its scores rarely reach — it will usually report nothing.'
+		}
+	},
+	fel: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test for positive selection'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Core FEL parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (recommended)',
+			default: 'Yes',
+			options: ['Yes', 'No']
+		},
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple']
+		},
+		siteMultihit: {
+			type: 'select',
+			label: 'Site Multihit',
+			default: 'Estimate',
+			options: ['Estimate', 'Global'],
+			dependsOn: 'multipleHits',
+			enabledWhen: ['Double', 'Double+Triple']
+		},
+		// Advanced parameters (matching the form structure)
+		resample: {
+			type: 'number',
+			label: 'Resample (parametric bootstrap replicates)',
+			default: 0,
+			min: 0,
+			max: 1000,
+			step: 1,
+			description:
+				'Advanced setting - will result in MUCH SLOWER run time. Recommended for small to medium (<30 sequences) datasets.'
+		},
+		confidenceIntervals: {
+			type: 'boolean',
+			label: 'Compute confidence intervals',
+			default: false,
+			description: 'Compute profile likelihood confidence intervals for each variable site'
+		},
+		// Keep existing parameters for backward compatibility
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001
+		}
+	},
+	meme: {
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'P-value threshold for calling a site under selection'
+		},
+		rates: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 2,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of site rate classes'
+		},
+		multiple_hits: {
+			type: 'select',
+			label: 'Multiple hits',
+			default: 'None',
+			options: ['None', 'Double', 'Triple', 'Double+Triple'],
+			description: 'Include support for multiple nucleotide substitutions'
+		},
+		site_multihit: {
+			type: 'select',
+			label: 'Site multiple hits',
+			default: 'Estimate',
+			options: ['Estimate', 'None'],
+			description: 'How to handle multiple hits per site'
+		},
+		impute_states: {
+			type: 'select',
+			label: 'Impute states',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Impute ancestral states for internal nodes'
+		}
+	},
+	slac: {
+		// Branch selection options (similar to FEL)
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test for positive selection'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// SLAC-specific parameters
+		samples: {
+			type: 'number',
+			label: 'Ancestral reconstruction samples',
+			default: 100,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Number of samples for ancestral reconstruction uncertainty'
+		},
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The p-value threshold to use when testing for selection'
+		}
+	},
+	fubar: {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Specifies the number of grid points for the Bayesian analysis'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The concentration parameter for the Dirichlet prior in the Bayesian estimation'
+		},
+		posteriorThreshold: {
+			type: 'number',
+			label: 'Posterior probability threshold',
+			default: 0.9,
+			min: 0.5,
+			max: 0.99,
+			step: 0.01,
+			description:
+				'Sites with posterior probability above this threshold are considered under positive selection'
+		}
+	},
+	'b-still': {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Grid points per dimension (total grid = D²)'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Dirichlet prior concentration parameter'
+		},
+		method: {
+			type: 'select',
+			label: 'Posterior estimation method',
+			default: 'Variational-Bayes',
+			options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
+			description: 'Method for estimating the posterior distribution'
+		},
+		ebf: {
+			type: 'number',
+			label: 'EBF threshold',
+			default: 10,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Empirical Bayes Factor threshold for reporting invariant sites'
+		},
+		radius_threshold: {
+			type: 'number',
+			label: 'Radius threshold',
+			default: 0.5,
+			min: 0,
+			max: 10,
+			step: 0.1,
+			description: 'Expected substitution multiplier for near-zero regime'
+		}
+	},
+	'b-still': {
+		grid: {
+			type: 'number',
+			label: 'Number of grid points',
+			default: 20,
+			min: 5,
+			max: 50,
+			description: 'Grid points per dimension (total grid = D²)'
+		},
+		concentration_parameter: {
+			type: 'number',
+			label: 'Concentration parameter',
+			default: 0.5,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Dirichlet prior concentration parameter'
+		},
+		method: {
+			type: 'select',
+			label: 'Posterior estimation method',
+			default: 'Variational-Bayes',
+			options: ['Variational-Bayes', 'Collapsed-Gibbs', 'Metropolis-Hastings'],
+			description: 'Method for estimating the posterior distribution'
+		},
+		ebf: {
+			type: 'number',
+			label: 'EBF threshold',
+			default: 10,
+			min: 1,
+			max: 1000,
+			step: 1,
+			description: 'Empirical Bayes Factor threshold for reporting invariant sites'
+		},
+		radius_threshold: {
+			type: 'number',
+			label: 'Radius threshold',
+			default: 0.5,
+			min: 0,
+			max: 10,
+			step: 0.1,
+			description: 'Expected substitution multiplier for near-zero regime'
+		}
+	},
+	absrel: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description: 'Which branches to test (default: All)'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Core aBSREL parameters
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple'],
+			description: 'Include support for multiple nucleotide substitutions'
+		},
+		srv: {
+			type: 'select',
+			label: 'Synonymous Rate Variation',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Include synonymous rate variation'
+		},
+		// Advanced parameters
+		blb: {
+			type: 'number',
+			label: 'Bag of Little Bootstrap (BLB) Rate',
+			default: 1.0,
+			min: 0.0,
+			max: 1.0,
+			step: 0.1,
+			description: '[Advanced] Bag of little bootstrap alignment resampling rate'
+		}
+	},
+	busted: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Foreground Branches',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Custom', 'Interactive'],
+			description:
+				'Select foreground branches to test for positive selection. All other branches will be treated as background.'
+		},
+		customBranches: {
+			type: 'text',
+			label: 'Custom foreground branches (comma-separated or regex)',
+			default: '',
+			placeholder: 'e.g. Node1,Node2 or /^human/i',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Comma-separated branch names or regex pattern for foreground branches'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select foreground branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them as foreground branches for testing'
+		},
+		// Core BUSTED parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (BUSTED-S)',
+			default: 'Yes',
+			options: ['Yes', 'No', 'Branch-site'],
+			description: 'Include variations in synonymous substitution rates'
+		},
+		errorSink: {
+			type: 'select',
+			label: 'Error protection (BUSTED-E)',
+			default: 'No',
+			options: ['Yes', 'No'],
+			description: 'Enhance robustness against alignment errors'
+		},
+		multipleHits: {
+			type: 'select',
+			label: 'Multiple Hits',
+			default: 'None',
+			options: ['None', 'Double', 'Double+Triple'],
+			description: 'Support for handling multiple nucleotide substitutions'
+		},
+		// Advanced parameters
+		rates: {
+			type: 'number',
+			label: 'Omega rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes in the model'
+		},
+		synRates: {
+			type: 'number',
+			label: 'Synonymous rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of synonymous rate classes in the model'
+		},
+		gridSize: {
+			type: 'number',
+			label: 'Grid size',
+			default: 250,
+			min: 50,
+			max: 1000,
+			step: 50,
+			description: 'Number of points in initial distributional guess for likelihood fitting'
+		},
+		startingPoints: {
+			type: 'number',
+			label: 'Starting points',
+			default: 1,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of initial random guesses to seed rate values optimization'
+		}
+	},
+	gard: {
+		datatype: {
+			type: 'select',
+			label: 'Data type',
+			default: 'nucleotide',
+			options: ['codon', 'nucleotide', 'protein'],
+			description: 'Type of data to analyze for recombination'
+		},
+		model: {
+			type: 'select',
+			label: 'Substitution model',
+			default: 'GTR',
+			options: ['JTT', 'WAG', 'LG', 'Dayhoff', 'GTR', 'HKY85', 'TN93', 'JC69'],
+			filteredOptionsBy: 'datatype',
+			filteredOptions: {
+				codon: ['GTR', 'HKY85', 'TN93', 'JC69'],
+				nucleotide: ['GTR', 'HKY85', 'TN93', 'JC69'],
+				protein: ['JTT', 'WAG', 'LG', 'Dayhoff']
+			},
+			filteredDefaults: {
+				codon: 'GTR',
+				nucleotide: 'GTR',
+				protein: 'JTT'
+			},
+			description: 'Substitution model to use for the analysis'
+		},
+		mode: {
+			type: 'select',
+			label: 'Run mode',
+			default: 'Normal',
+			options: ['Normal', 'Faster'],
+			description: 'Normal: thorough analysis; Faster: quicker but less comprehensive'
+		},
+		rv: {
+			type: 'select',
+			label: 'Site-to-site rate variation',
+			default: 'None',
+			options: ['None', 'GDD', 'Gamma'],
+			description: 'Model for rate variation among sites (None, General Discrete, Beta-Gamma)'
+		},
+		rate_classes: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 4,
+			min: 2,
+			max: 10,
+			description: 'Number of discrete rate classes for rate variation'
+		}
+	},
+	bgm: {
+		steps: {
+			type: 'number',
+			label: 'Chain length steps',
+			default: 10000,
+			min: 1000,
+			max: 100000000,
+			step: 1000,
+			description: 'Length of each MCMC chain'
+		},
+		burnIn: {
+			type: 'number',
+			label: 'Burn-in samples',
+			default: 1000,
+			min: 100,
+			max: 100000,
+			step: 100,
+			description: 'Number of burn-in samples to discard'
+		},
+		samples: {
+			type: 'number',
+			label: 'Samples',
+			default: 100,
+			min: 10,
+			max: 10000,
+			step: 10,
+			description: 'Number of samples to collect'
+		},
+		maxParents: {
+			type: 'number',
+			label: 'Maximum parents per node',
+			default: 1,
+			min: 0,
+			max: 10,
+			step: 1,
+			description: 'Maximum number of parents allowed per node in the graphical model'
+		},
+		minSubs: {
+			type: 'number',
+			label: 'Minimum substitutions per site',
+			default: 1,
+			min: 1,
+			max: 100,
+			step: 1,
+			description: 'Minimum number of substitutions required per site'
+		}
+	},
+	fade: {
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001
+		},
+		gridPoints: { type: 'number', label: 'Grid points', default: 20, min: 5, max: 50 },
+		mcmcChains: { type: 'number', label: 'MCMC chains', default: 5, min: 2, max: 20 },
+		mcmcSamples: {
+			type: 'number',
+			label: 'MCMC samples',
+			default: 2000000,
+			min: 100000,
+			max: 10000000,
+			step: 100000
+		}
+	},
+	relax: {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branch Selection Mode',
+			default: 'Interactive',
+			options: ['Interactive'],
+			description: 'Select TEST and REFERENCE branches interactively on the tree'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select TEST and REFERENCE branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to assign them to TEST or REFERENCE sets'
+		},
+		// RELAX-specific parameters
+		models: {
+			type: 'select',
+			label: 'Analysis models',
+			default: 'All',
+			options: ['All', 'Minimal'],
+			description: 'All: descriptive models and RELAX test; Minimal: RELAX test only'
+		},
+		rates: {
+			type: 'number',
+			label: 'Omega rate classes',
+			default: 3,
+			min: 2,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes'
+		},
+		mode: {
+			type: 'select',
+			label: 'Run mode',
+			default: 'Classic mode',
+			options: ['Classic mode'],
+			description: 'RELAX analysis mode'
+		},
+		killZeroLengths: {
+			type: 'select',
+			label: 'Kill zero-length branches',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'How to handle zero-length branches'
+		}
+	},
+	'multi-hit': {
+		rates: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 3,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of omega rate classes to include in the model'
+		},
+		triple_islands: {
+			type: 'select',
+			label: 'Triple islands',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use separate rate parameter for synonymous triple-hit substitutions'
+		}
+	},
+	nrm: {
+		rate_classes: {
+			type: 'number',
+			label: 'Rate classes',
+			default: 1,
+			min: 1,
+			max: 10,
+			step: 1,
+			description: 'Number of rate classes for the analysis'
+		},
+		triple_islands: {
+			type: 'select',
+			label: 'Triple islands',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use triple islands for the analysis'
+		}
+	},
+	prime: {
+		// PRIME variant selection
+		variant: {
+			type: 'select',
+			label: 'PRIME Variant',
+			default: 'S-PRIME',
+			options: [
+				'S-PRIME',
+				{ value: 'G-PRIME', label: 'G-PRIME (coming soon)', disabled: true },
+				{ value: 'E-PRIME', label: 'E-PRIME (coming soon)', disabled: true }
+			],
+			description: 'S-PRIME: site-level property-informed model'
+		},
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branches to Test',
+			default: 'All',
+			options: ['All', 'Internal', 'Leaves', 'Unlabeled', 'Interactive'],
+			description: 'Which branches to test for property-dependent selection'
+		},
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branches on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to select them for testing'
+		},
+		// Property set selection
+		propertySet: {
+			type: 'select',
+			label: 'Amino Acid Property Set',
+			default: '5PROP',
+			options: ['5PROP', '4PROP', '3PROP', '2PROP', 'Atchley', 'LCAP'],
+			description:
+				'Set of amino acid properties to model (5PROP: hydrophobicity, polarity, volume, charge, iso-electric point)'
+		},
+		// P-value threshold
+		pValueThreshold: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.1,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'The p-value threshold to use when testing for property-dependent selection'
+		},
+		// Impute states
+		imputeStates: {
+			type: 'select',
+			label: 'Impute states',
+			default: 'No',
+			options: ['No', 'Yes'],
+			description: 'Use site-level model fits to impute likely character states'
+		}
+	},
+	'contrast-fel': {
+		// Branch selection options
+		branchesToTest: {
+			type: 'select',
+			label: 'Branch Selection Mode',
+			default: 'Interactive',
+			options: ['Custom', 'Interactive'],
+			description: 'How to specify branch sets for comparison'
+		},
+		// Custom branch set configuration (when not using Interactive)
+		branchSet1: {
+			type: 'text',
+			label: 'Branch Set 1 (Source)',
+			default: 'Source',
+			placeholder: 'e.g. Source, Internal, Leaves',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'First group of branches to compare'
+		},
+		branchSet2: {
+			type: 'text',
+			label: 'Branch Set 2 (Test)',
+			default: 'Test',
+			placeholder: 'e.g. Test, Unlabeled, Custom',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Second group of branches to compare'
+		},
+		branchSet3: {
+			type: 'text',
+			label: 'Branch Set 3 (optional)',
+			default: '',
+			placeholder: 'e.g. Reference, Background',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Custom'],
+			description: 'Optional third group of branches for comparison'
+		},
+		// Interactive tree selection
+		interactiveTree: {
+			type: 'interactive-tree',
+			label: 'Select branch sets on tree',
+			default: '',
+			dependsOn: 'branchesToTest',
+			enabledWhen: ['Interactive'],
+			description: 'Click on tree branches to assign them to different sets for comparison'
+		},
+		// Core Contrast-FEL parameters
+		srv: {
+			type: 'select',
+			label: 'Synonymous rate variation (recommended)',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Include synonymous rate variation in the model'
+		},
+		permutations: {
+			type: 'select',
+			label: 'Perform permutation tests',
+			default: 'Yes',
+			options: ['Yes', 'No'],
+			description: 'Use permutation tests to evaluate significance'
+		},
+		// Statistical thresholds
+		pvalue: {
+			type: 'number',
+			label: 'P-value threshold',
+			default: 0.05,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'Significance value for site tests'
+		},
+		qvalue: {
+			type: 'number',
+			label: 'Q-value threshold (FDR)',
+			default: 0.2,
+			min: 0.001,
+			max: 1,
+			step: 0.001,
+			description: 'False Discovery Rate threshold for reporting'
+		},
+		// Output options
+		output: {
+			type: 'text',
+			label: 'Output file name (optional)',
+			default: '',
+			placeholder: 'e.g. contrast_results.json',
+			description: 'Custom name for output file (defaults to automatic naming)'
+		}
+	}
+};

--- a/src/lib/config/methodOptions.toml
+++ b/src/lib/config/methodOptions.toml
@@ -9,17 +9,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[fel.options]]
@@ -140,17 +140,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[slac.options]]
@@ -317,17 +317,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[contrast-fel.options]]
@@ -410,17 +410,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[gard.options]]
@@ -510,17 +510,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[multi-hit.options]]
@@ -584,17 +584,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[nrm.options]]
@@ -651,17 +651,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[prime.options]]
@@ -740,17 +740,17 @@ type = "string"
 default = "Universal"
 choices = [
     { value = "Universal", description = "Universal code" },
-    { value = "Vertebrate mtDNA", description = "Vertebrate mitochondrial DNA code" },
-    { value = "Yeast mtDNA", description = "Yeast mitochondrial DNA code" },
-    { value = "Mold/Protozoan mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
-    { value = "Invertebrate mtDNA", description = "Invertebrate mitochondrial DNA code" },
-    { value = "Ciliate Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
-    { value = "Echinoderm mtDNA", description = "Echinoderm mitochondrial DNA code" },
-    { value = "Euplotid Nuclear", description = "Euplotid Nuclear code" },
-    { value = "Alt. Yeast Nuclear", description = "Alternative Yeast Nuclear code" },
-    { value = "Ascidian mtDNA", description = "Ascidian mitochondrial DNA code" },
-    { value = "Flatworm mtDNA", description = "Flatworm mitochondrial DNA code" },
-    { value = "Blepharisma Nuclear", description = "Blepharisma Nuclear code" },
+    { value = "Vertebrate-mtDNA", description = "Vertebrate mitochondrial DNA code" },
+    { value = "Yeast-mtDNA", description = "Yeast mitochondrial DNA code" },
+    { value = "Mold-Protozoan-mtDNA", description = "Mold, Protozoan and Coelenterate mt; Mycoplasma/Spiroplasma" },
+    { value = "Invertebrate-mtDNA", description = "Invertebrate mitochondrial DNA code" },
+    { value = "Ciliate-Nuclear", description = "Ciliate, Dasycladacean and Hexamita Nuclear code" },
+    { value = "Echinoderm-mtDNA", description = "Echinoderm mitochondrial DNA code" },
+    { value = "Euplotid-Nuclear", description = "Euplotid Nuclear code" },
+    { value = "Alt-Yeast-Nuclear", description = "Alternative Yeast Nuclear code" },
+    { value = "Ascidian-mtDNA", description = "Ascidian mitochondrial DNA code" },
+    { value = "Flatworm-mtDNA", description = "Flatworm mitochondrial DNA code" },
+    { value = "Blepharisma-Nuclear", description = "Blepharisma Nuclear code" },
 ]
 
 [[relax.options]]

--- a/src/lib/config/uploadLimits.js
+++ b/src/lib/config/uploadLimits.js
@@ -1,0 +1,34 @@
+/**
+ * The limits the upload path actually enforces.
+ *
+ * SOURCE OF TRUTH: src/data/shared/HyPhyGlobals.ibf
+ *   :10  maxDMSites     = 12000   -> rejects when the CODON filter has more sites than this
+ *   :15  maxSLACSize    = 10000   -> above this, datareader.bf:489 refuses to build an NJ tree,
+ *                                    so the file must carry its own
+ *   :33  maxUploadSize  = 25000   -> datareader.bf:359 rejects more sequences than this
+ *
+ * The copy these produce is deliberately about UPLOAD, not about analysis. Individual methods are
+ * lower (HyPhyGlobals.ibf:17 maxMEMESize = 10000, :27 maxGARDSize = 500), so advertising 25,000 as
+ * "the limit" full stop would swap one wrong number for another. The method-specific ceilings
+ * belong next to the method, not next to the file input.
+ */
+export const uploadLimits = {
+	maxSequences: 25000,
+	maxCodons: 12000,
+	treeRequiredAbove: 10000
+};
+
+const groupDigits = (n) => Number(n).toLocaleString('en-US');
+
+/**
+ * The single sentence shown under the file input. Built from the constants above so a limit change
+ * in HyPhyGlobals.ibf has exactly one place to land on this side.
+ * @returns {string}
+ */
+export function uploadLimitsCopy(limits = uploadLimits) {
+	return (
+		`Up to ${groupDigits(limits.maxSequences)} sequences and ${groupDigits(limits.maxCodons)} codons ` +
+		`(about ${groupDigits(limits.maxCodons * 3)} nucleotides). ` +
+		`Above ${groupDigits(limits.treeRequiredAbove)} sequences, your file must include a tree.`
+	);
+}

--- a/src/lib/dataReaderResults.svelte
+++ b/src/lib/dataReaderResults.svelte
@@ -1,5 +1,6 @@
 <script>
 	import PhyloTree from './phylotree.svelte';
+	import { formatAlignmentLength, formatGeneticCode } from './utils/fileMetricsDisplay.js';
 	import { AlertTriangle, Check, Info, ChevronRight, Copy } from 'lucide-svelte';
 
 	export let fileMetricsJSON = null;
@@ -103,14 +104,16 @@
 					<span class="font-medium text-text-rich">{fileMetricsJSON.FILE_INFO.partitions}</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-text-slate">Sites</span>
+					<span class="text-text-slate">Length</span>
 					<span class="font-medium text-text-rich">
-						{fileMetricsJSON.FILE_INFO.rawsites} raw → {fileMetricsJSON.FILE_INFO.sites} processed
+						{formatAlignmentLength(fileMetricsJSON.FILE_INFO)}
 					</span>
 				</div>
 				<div class="flex justify-between">
 					<span class="text-text-slate">Genetic Code</span>
-					<span class="font-medium text-text-rich">{fileMetricsJSON.FILE_INFO.gencodeid}</span>
+					<span class="font-medium text-text-rich"
+						>{formatGeneticCode(fileMetricsJSON.FILE_INFO.gencodeid)}</span
+					>
 				</div>
 				{#if fileMetricsJSON.FILE_INFO.type}
 					<div class="flex justify-between">
@@ -134,16 +137,22 @@
 						<span class="font-medium text-status-warning">{fileMetricsJSON.FILE_INFO.sequences_renamed}</span>
 					</div>
 				{/if}
-				{#if fileMetricsJSON.FILE_INFO.ambiguous_sites}
+				<!-- `padded_sequences` is a real count; `ambiguous_sites` is the legacy boolean that
+				     carried the same signal (datareader.bf padWarning) and is all a cached record has. -->
+				{#if fileMetricsJSON.FILE_INFO.padded_sequences || fileMetricsJSON.FILE_INFO.ambiguous_sites}
 					<div class="flex justify-between">
-						<span class="text-text-slate">Ambiguous Sites</span>
-						<span class="font-medium text-status-warning">Present</span>
+						<span class="text-text-slate">Sequences Padded</span>
+						<span class="font-medium text-status-warning">
+							{fileMetricsJSON.FILE_INFO.padded_sequences ?? 'Present'}
+						</span>
 					</div>
 				{/if}
-				{#if fileMetricsJSON.FILE_INFO.stop_codons_stripped > 0}
+				{#if fileMetricsJSON.FILE_INFO.stop_codons_stripped}
+					<!-- Boolean, not a count: datareader sets it to 1 when EVERY sequence ended in a
+					     stop codon and that whole final column was dropped. -->
 					<div class="flex justify-between">
-						<span class="text-text-slate">Stop Codons Stripped</span>
-						<span class="font-medium text-status-warning">{fileMetricsJSON.FILE_INFO.stop_codons_stripped}</span>
+						<span class="text-text-slate">Trailing Stop Codons Stripped</span>
+						<span class="font-medium text-status-warning">Yes</span>
 					</div>
 				{/if}
 			</div>

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -57,11 +57,28 @@ function stripEmbeddedTrees(alignmentData) {
 	return result;
 }
 
+/**
+ * How long a submission may sit with no word from the server before we go and ask about it.
+ *
+ * Generous on purpose. The server acknowledges a spawn as soon as the job row exists, but a busy
+ * scheduler can take a while to get there, and declaring a job lost that is merely queued is far
+ * worse than a minute of silence. Expiry does NOT fail the run — it triggers a probe (see
+ * probeSubmission), which is the only thing that can distinguish "queued" from "never accepted".
+ */
+const SUBMISSION_ACK_TIMEOUT_MS = 60000;
+
+/** Ack window on the job:status probe itself. Matches the reconnect path's timeout (issue #177). */
+const STATUS_PROBE_TIMEOUT_MS = 10000;
+
 class BackendAnalysisRunner extends BaseAnalysisRunner {
 	constructor() {
 		super();
 		this.socket = null;
 		this.serverUrl = DATAMONKEY_SERVER_URL;
+
+		// jobId -> timeoutId, for jobs submitted but not yet acknowledged by the server.
+		// Armed only by runAnalysis; reconnectToJobs has its own 10s ack and must not arm these.
+		this.submissionWatchdogs = new Map();
 	}
 
 	/**
@@ -114,6 +131,8 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// Try to find the analysis ID for this status update
 			if (statusJobId && this.activeAnalyses.has(statusJobId)) {
 				const analysisId = this.activeAnalyses.get(statusJobId);
+				// Any word from the server about this job is proof it was accepted.
+				this.clearSubmissionWatchdog(statusJobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -123,6 +142,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			} else if (this.activeAnalyses.size === 1) {
 				// If only one analysis is running, we can safely assume it's for that one
 				const [jobId, analysisId] = this.activeAnalyses.entries().next().value;
+				this.clearSubmissionWatchdog(jobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -169,10 +189,12 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 
 			if (jobId && this.activeAnalyses.has(jobId)) {
 				const analysisId = this.activeAnalyses.get(jobId);
+				this.clearSubmissionWatchdog(jobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(jobId);
 			} else if (!jobId && this.activeAnalyses.size === 1) {
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -204,6 +226,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			const errorJobId = error.jobId || error.id;
 			if (errorJobId && this.activeAnalyses.has(errorJobId)) {
 				const analysisId = this.activeAnalyses.get(errorJobId);
+				this.clearSubmissionWatchdog(errorJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(errorJobId);
 			} else if (!errorJobId && this.activeAnalyses.size === 1) {
@@ -212,6 +235,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				// sitting at "running" forever. With two or more it is genuinely ambiguous, so the
 				// branch below still refuses rather than killing an innocent concurrent job.
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -230,10 +254,183 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// This is handled per-analysis in runAnalysis method
 		});
 
-		this.socket.on('job queue', (jobs) => {
-			console.log('📋 Backend job queue:', jobs);
-			// Could update UI with queue information
+		// THE SUBMISSION ACKNOWLEDGEMENT. Not dead code — do not delete.
+		//
+		// The server already tells us it accepted a job; we used to throw that away. app/hyphyjob.js
+		// (262-299) publishes `{ type:'job created', id, torque_id, status, scheduler, created_time,
+		// sites, sequences }` on the redis channel keyed by the job id the moment the job row exists,
+		// and lib/clientsocket.js:60 forwards it to this socket verbatim. `job metadata` (hyphyjob.js
+		// 489-513) carries the same shape later in the job's life.
+		//
+		// `id` is the jobId WE generated and sent in `job.id` — analysis-factory.js:117-124 resolves
+		// `params.job.id || params.id` — so it routes exactly, with no single-job heuristic needed.
+		//
+		// This is the only positive confirmation a spawn was accepted, and it is what disarms the
+		// submission watchdog.
+		this.socket.on('job created', (packet) => this.handleServerAck(packet));
+		this.socket.on('job metadata', (packet) => this.handleServerAck(packet));
+
+		// DELIBERATELY NOT LISTENING FOR / EMITTING `job queue`.
+		//
+		// server.js:54-59 answers a `job queue` request with `socket.emit('job queue', jobs);
+		// socket.disconnect();` — asking the server where we are in the queue tears down the socket
+		// carrying every in-flight job's status stream. Queue position is not worth that.
+		//
+		// The `status` field on `job created` / `job metadata` above already reports whether this
+		// particular job is queued or running, which is the part the user actually needs, at no
+		// protocol cost.
+	}
+
+	/**
+	 * Handle `job created` / `job metadata` — the server confirming it took the job.
+	 *
+	 * Moves the run off the bare "Job submitted" state and onto what the scheduler says: Torque/PBS
+	 * reports 'Q' while queued and 'R' once it is running (some deployments spell them out). Anything
+	 * unrecognised is treated as queued, because a job that has been acknowledged but not started is
+	 * exactly that.
+	 */
+	handleServerAck(packet) {
+		const jobId = packet?.id ?? packet?.jobId;
+		if (!jobId || !this.activeAnalyses.has(jobId)) return;
+
+		const analysisId = this.activeAnalyses.get(jobId);
+		this.clearSubmissionWatchdog(jobId);
+
+		const reported = String(packet?.status ?? '').toLowerCase();
+		const isRunning = reported === 'r' || reported === 'running';
+
+		console.log(`📨 Server acknowledged job ${jobId} (status: ${packet?.status ?? 'unreported'})`);
+
+		this.updateProgress(
+			analysisId,
+			isRunning ? 'running' : 'pending',
+			10,
+			isRunning ? 'Running on the server' : 'Queued on the server'
+		);
+	}
+
+	/**
+	 * Start the clock on an unacknowledged submission.
+	 *
+	 * MUST be called only from runAnalysis. Jobs restored by reconnectToJobs already have their own
+	 * 10s job:status ack and arming this for them would double-probe.
+	 */
+	armSubmissionWatchdog(analysisId, jobId, submittedAt = Date.now()) {
+		this.clearSubmissionWatchdog(jobId);
+		const timer = setTimeout(() => {
+			this.submissionWatchdogs.delete(jobId);
+			this.probeSubmission(analysisId, jobId, submittedAt);
+		}, SUBMISSION_ACK_TIMEOUT_MS);
+		this.submissionWatchdogs.set(jobId, timer);
+	}
+
+	clearSubmissionWatchdog(jobId) {
+		const timer = this.submissionWatchdogs.get(jobId);
+		if (timer) {
+			clearTimeout(timer);
+			this.submissionWatchdogs.delete(jobId);
+		}
+	}
+
+	clearAllSubmissionWatchdogs() {
+		for (const timer of this.submissionWatchdogs.values()) {
+			clearTimeout(timer);
+		}
+		this.submissionWatchdogs.clear();
+	}
+
+	/**
+	 * The watchdog expired: ask the server whether it has this job, and DO NOT assume it does not.
+	 *
+	 * Silence is not loss. The spawn event is fire-and-forget (see the emit in runAnalysis for why it
+	 * must stay that way), and the ack we listen for rides a redis subscription that can attach a beat
+	 * late — so a perfectly healthy job can arrive here. `job:status` is genuinely ack-capable
+	 * (server.js:62 `socket.on('job:status', function (params, callback)`) and reads the persisted
+	 * hash, so it can answer for a job whose events we missed.
+	 */
+	probeSubmission(analysisId, jobId, submittedAt) {
+		// Completed, failed or cancelled while we were waiting — nothing to chase.
+		if (!this.activeAnalyses.has(jobId)) return;
+
+		if (!this.socket) {
+			this.markSubmissionLost(analysisId, jobId, 'The server never confirmed this job.');
+			return;
+		}
+
+		this.socket
+			.timeout(STATUS_PROBE_TIMEOUT_MS)
+			.emit('job:status', { jobId }, async (err, response) => {
+				try {
+					if (err || !response) {
+						// No answer at all: the socket is not carrying anything for this job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server never confirmed this job.'
+						);
+						return;
+					}
+
+					if (response.status === 'not_found') {
+						// The one unambiguous negative. The server looked and has no such job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server has no record of this job. It was never accepted.'
+						);
+						return;
+					}
+
+					if (response.status === 'completed' && response.results) {
+						// We missed the whole event stream for this job but the results are sitting there.
+						// Same recovery the reconnect path performs.
+						console.log(`✅ Job ${jobId} had already completed; collecting results from probe`);
+						this.clearSubmissionWatchdog(jobId);
+						this.activeAnalyses.delete(jobId);
+						await this.completeAnalysis(analysisId, true, response.results);
+						return;
+					}
+
+					// EVERYTHING ELSE MEANS KEEP WAITING — and 'unknown' above all.
+					//
+					// This is where this handler deliberately differs from reconnectToJobs, which treats an
+					// unrecognised status as connection_lost. app/hyphyjob.js:91 hSets the `params` field the
+					// instant init() runs, before any `status` field exists, so server.js:76 answers
+					// `status:'unknown'` for a perfectly healthy job sitting in the submit -> qsub window.
+					// Failing on that would kill good jobs on a busy scheduler.
+					const waitedMinutes = Math.max(1, Math.round((Date.now() - submittedAt) / 60000));
+					const running = response.status === 'running';
+					this.updateProgress(
+						analysisId,
+						running ? 'running' : 'pending',
+						running ? 10 : 5,
+						running
+							? 'Running on the server'
+							: `Waiting for the server to start this job (queued ${waitedMinutes} min)`
+					);
+					this.armSubmissionWatchdog(analysisId, jobId, submittedAt);
+				} catch (error) {
+					console.error(`Error probing submission for job ${jobId}:`, error);
+				}
+			});
+	}
+
+	/**
+	 * Resolve a job we can no longer account for.
+	 *
+	 * Reuses `connection_lost` rather than inventing a status: AnalysisCard and runStatusLine already
+	 * render it, and it already offers a Re-run.
+	 */
+	async markSubmissionLost(analysisId, jobId, message) {
+		console.warn(`⏱️ Submission for job ${jobId} unconfirmed: ${message}`);
+		this.clearSubmissionWatchdog(jobId);
+		await analysisStore.updateAnalysis(analysisId, {
+			status: 'connection_lost',
+			error: message,
+			updatedAt: Date.now()
 		});
+		this.activeAnalyses.delete(jobId);
+		analysisStore.removeFromActiveAnalyses(analysisId);
 	}
 
 	/**
@@ -304,10 +501,27 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				}
 			};
 
+			// TWO ARGUMENTS, NEVER THREE. Do not "improve" this into
+			// `socket.timeout(ms).emit(eventName, submitData, cb)`.
+			//
+			// The server registers every spawn event through a stream wrapper: lib/router.js:26 is
+			// `socket.on(key, function (stream, data))`. A third argument makes socket.io deliver
+			// stream=submitData and data=<ack function>, the adjustment guard at router.js:29
+			// (`data === undefined`) does not fire, and analysis-routes.js:47-51 then reads `params` as
+			// the ack function — so `!params.job` is true and EVERY submission is answered with
+			// 'Invalid job parameters'. The server never calls the ack either, so the timeout would
+			// also fire on every healthy run.
+			//
+			// The acknowledgement therefore cannot ride the emit. It arrives as the `job created`
+			// event (see setupGlobalHandlers), and armSubmissionWatchdog below covers its absence.
 			this.socket.emit(eventName, submitData);
 
 			// Update progress
 			this.updateProgress(analysisId, 'pending', 5, `Job submitted - ID: ${jobId}`);
+
+			// Nothing else ever revisited this state before: a job the server silently dropped sat at
+			// "pending" until the user gave up. Start the clock.
+			this.armSubmissionWatchdog(analysisId, jobId);
 
 			return {
 				analysisId,
@@ -316,6 +530,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			};
 		} catch (error) {
 			console.error('❌ Backend analysis submission failed:', error);
+			this.clearSubmissionWatchdog(jobId);
 			await this.completeAnalysis(analysisId, false, null, `Submission failed: ${error.message}`);
 			this.activeAnalyses.delete(jobId);
 			throw error;
@@ -720,6 +935,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				if (this.socket && this.socket.connected) {
 					this.socket.emit('cancel', { jobId });
 				}
+				this.clearSubmissionWatchdog(jobId);
 				this.activeAnalyses.delete(jobId);
 				break;
 			}
@@ -764,6 +980,9 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			this.socket.disconnect();
 			this.socket = null;
 		}
+		// Drop the timers with the socket. Left armed they would fire against a dead connection —
+		// and in a test suite that reuses this singleton they leak across cases.
+		this.clearAllSubmissionWatchdogs();
 		this.activeAnalyses.clear();
 	}
 

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -56,11 +56,28 @@ function stripEmbeddedTrees(alignmentData) {
 	return result;
 }
 
+/**
+ * How long a submission may sit with no word from the server before we go and ask about it.
+ *
+ * Generous on purpose. The server acknowledges a spawn as soon as the job row exists, but a busy
+ * scheduler can take a while to get there, and declaring a job lost that is merely queued is far
+ * worse than a minute of silence. Expiry does NOT fail the run — it triggers a probe (see
+ * probeSubmission), which is the only thing that can distinguish "queued" from "never accepted".
+ */
+const SUBMISSION_ACK_TIMEOUT_MS = 60000;
+
+/** Ack window on the job:status probe itself. Matches the reconnect path's timeout (issue #177). */
+const STATUS_PROBE_TIMEOUT_MS = 10000;
+
 class BackendAnalysisRunner extends BaseAnalysisRunner {
 	constructor() {
 		super();
 		this.socket = null;
 		this.serverUrl = DATAMONKEY_SERVER_URL;
+
+		// jobId -> timeoutId, for jobs submitted but not yet acknowledged by the server.
+		// Armed only by runAnalysis; reconnectToJobs has its own 10s ack and must not arm these.
+		this.submissionWatchdogs = new Map();
 	}
 
 	/**
@@ -113,6 +130,8 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// Try to find the analysis ID for this status update
 			if (statusJobId && this.activeAnalyses.has(statusJobId)) {
 				const analysisId = this.activeAnalyses.get(statusJobId);
+				// Any word from the server about this job is proof it was accepted.
+				this.clearSubmissionWatchdog(statusJobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -122,6 +141,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			} else if (this.activeAnalyses.size === 1) {
 				// If only one analysis is running, we can safely assume it's for that one
 				const [jobId, analysisId] = this.activeAnalyses.entries().next().value;
+				this.clearSubmissionWatchdog(jobId);
 				this.updateProgress(
 					analysisId,
 					'running',
@@ -168,10 +188,12 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 
 			if (jobId && this.activeAnalyses.has(jobId)) {
 				const analysisId = this.activeAnalyses.get(jobId);
+				this.clearSubmissionWatchdog(jobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(jobId);
 			} else if (!jobId && this.activeAnalyses.size === 1) {
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, true, results);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -203,6 +225,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			const errorJobId = error.jobId || error.id;
 			if (errorJobId && this.activeAnalyses.has(errorJobId)) {
 				const analysisId = this.activeAnalyses.get(errorJobId);
+				this.clearSubmissionWatchdog(errorJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(errorJobId);
 			} else if (!errorJobId && this.activeAnalyses.size === 1) {
@@ -211,6 +234,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				// sitting at "running" forever. With two or more it is genuinely ambiguous, so the
 				// branch below still refuses rather than killing an innocent concurrent job.
 				const [onlyJobId, analysisId] = [...this.activeAnalyses.entries()][0];
+				this.clearSubmissionWatchdog(onlyJobId);
 				await this.completeAnalysis(analysisId, false, null, userFacingError);
 				this.activeAnalyses.delete(onlyJobId);
 			} else {
@@ -229,10 +253,183 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			// This is handled per-analysis in runAnalysis method
 		});
 
-		this.socket.on('job queue', (jobs) => {
-			console.log('📋 Backend job queue:', jobs);
-			// Could update UI with queue information
+		// THE SUBMISSION ACKNOWLEDGEMENT. Not dead code — do not delete.
+		//
+		// The server already tells us it accepted a job; we used to throw that away. app/hyphyjob.js
+		// (262-299) publishes `{ type:'job created', id, torque_id, status, scheduler, created_time,
+		// sites, sequences }` on the redis channel keyed by the job id the moment the job row exists,
+		// and lib/clientsocket.js:60 forwards it to this socket verbatim. `job metadata` (hyphyjob.js
+		// 489-513) carries the same shape later in the job's life.
+		//
+		// `id` is the jobId WE generated and sent in `job.id` — analysis-factory.js:117-124 resolves
+		// `params.job.id || params.id` — so it routes exactly, with no single-job heuristic needed.
+		//
+		// This is the only positive confirmation a spawn was accepted, and it is what disarms the
+		// submission watchdog.
+		this.socket.on('job created', (packet) => this.handleServerAck(packet));
+		this.socket.on('job metadata', (packet) => this.handleServerAck(packet));
+
+		// DELIBERATELY NOT LISTENING FOR / EMITTING `job queue`.
+		//
+		// server.js:54-59 answers a `job queue` request with `socket.emit('job queue', jobs);
+		// socket.disconnect();` — asking the server where we are in the queue tears down the socket
+		// carrying every in-flight job's status stream. Queue position is not worth that.
+		//
+		// The `status` field on `job created` / `job metadata` above already reports whether this
+		// particular job is queued or running, which is the part the user actually needs, at no
+		// protocol cost.
+	}
+
+	/**
+	 * Handle `job created` / `job metadata` — the server confirming it took the job.
+	 *
+	 * Moves the run off the bare "Job submitted" state and onto what the scheduler says: Torque/PBS
+	 * reports 'Q' while queued and 'R' once it is running (some deployments spell them out). Anything
+	 * unrecognised is treated as queued, because a job that has been acknowledged but not started is
+	 * exactly that.
+	 */
+	handleServerAck(packet) {
+		const jobId = packet?.id ?? packet?.jobId;
+		if (!jobId || !this.activeAnalyses.has(jobId)) return;
+
+		const analysisId = this.activeAnalyses.get(jobId);
+		this.clearSubmissionWatchdog(jobId);
+
+		const reported = String(packet?.status ?? '').toLowerCase();
+		const isRunning = reported === 'r' || reported === 'running';
+
+		console.log(`📨 Server acknowledged job ${jobId} (status: ${packet?.status ?? 'unreported'})`);
+
+		this.updateProgress(
+			analysisId,
+			isRunning ? 'running' : 'pending',
+			10,
+			isRunning ? 'Running on the server' : 'Queued on the server'
+		);
+	}
+
+	/**
+	 * Start the clock on an unacknowledged submission.
+	 *
+	 * MUST be called only from runAnalysis. Jobs restored by reconnectToJobs already have their own
+	 * 10s job:status ack and arming this for them would double-probe.
+	 */
+	armSubmissionWatchdog(analysisId, jobId, submittedAt = Date.now()) {
+		this.clearSubmissionWatchdog(jobId);
+		const timer = setTimeout(() => {
+			this.submissionWatchdogs.delete(jobId);
+			this.probeSubmission(analysisId, jobId, submittedAt);
+		}, SUBMISSION_ACK_TIMEOUT_MS);
+		this.submissionWatchdogs.set(jobId, timer);
+	}
+
+	clearSubmissionWatchdog(jobId) {
+		const timer = this.submissionWatchdogs.get(jobId);
+		if (timer) {
+			clearTimeout(timer);
+			this.submissionWatchdogs.delete(jobId);
+		}
+	}
+
+	clearAllSubmissionWatchdogs() {
+		for (const timer of this.submissionWatchdogs.values()) {
+			clearTimeout(timer);
+		}
+		this.submissionWatchdogs.clear();
+	}
+
+	/**
+	 * The watchdog expired: ask the server whether it has this job, and DO NOT assume it does not.
+	 *
+	 * Silence is not loss. The spawn event is fire-and-forget (see the emit in runAnalysis for why it
+	 * must stay that way), and the ack we listen for rides a redis subscription that can attach a beat
+	 * late — so a perfectly healthy job can arrive here. `job:status` is genuinely ack-capable
+	 * (server.js:62 `socket.on('job:status', function (params, callback)`) and reads the persisted
+	 * hash, so it can answer for a job whose events we missed.
+	 */
+	probeSubmission(analysisId, jobId, submittedAt) {
+		// Completed, failed or cancelled while we were waiting — nothing to chase.
+		if (!this.activeAnalyses.has(jobId)) return;
+
+		if (!this.socket) {
+			this.markSubmissionLost(analysisId, jobId, 'The server never confirmed this job.');
+			return;
+		}
+
+		this.socket
+			.timeout(STATUS_PROBE_TIMEOUT_MS)
+			.emit('job:status', { jobId }, async (err, response) => {
+				try {
+					if (err || !response) {
+						// No answer at all: the socket is not carrying anything for this job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server never confirmed this job.'
+						);
+						return;
+					}
+
+					if (response.status === 'not_found') {
+						// The one unambiguous negative. The server looked and has no such job.
+						await this.markSubmissionLost(
+							analysisId,
+							jobId,
+							'The server has no record of this job. It was never accepted.'
+						);
+						return;
+					}
+
+					if (response.status === 'completed' && response.results) {
+						// We missed the whole event stream for this job but the results are sitting there.
+						// Same recovery the reconnect path performs.
+						console.log(`✅ Job ${jobId} had already completed; collecting results from probe`);
+						this.clearSubmissionWatchdog(jobId);
+						this.activeAnalyses.delete(jobId);
+						await this.completeAnalysis(analysisId, true, response.results);
+						return;
+					}
+
+					// EVERYTHING ELSE MEANS KEEP WAITING — and 'unknown' above all.
+					//
+					// This is where this handler deliberately differs from reconnectToJobs, which treats an
+					// unrecognised status as connection_lost. app/hyphyjob.js:91 hSets the `params` field the
+					// instant init() runs, before any `status` field exists, so server.js:76 answers
+					// `status:'unknown'` for a perfectly healthy job sitting in the submit -> qsub window.
+					// Failing on that would kill good jobs on a busy scheduler.
+					const waitedMinutes = Math.max(1, Math.round((Date.now() - submittedAt) / 60000));
+					const running = response.status === 'running';
+					this.updateProgress(
+						analysisId,
+						running ? 'running' : 'pending',
+						running ? 10 : 5,
+						running
+							? 'Running on the server'
+							: `Waiting for the server to start this job (queued ${waitedMinutes} min)`
+					);
+					this.armSubmissionWatchdog(analysisId, jobId, submittedAt);
+				} catch (error) {
+					console.error(`Error probing submission for job ${jobId}:`, error);
+				}
+			});
+	}
+
+	/**
+	 * Resolve a job we can no longer account for.
+	 *
+	 * Reuses `connection_lost` rather than inventing a status: AnalysisCard and runStatusLine already
+	 * render it, and it already offers a Re-run.
+	 */
+	async markSubmissionLost(analysisId, jobId, message) {
+		console.warn(`⏱️ Submission for job ${jobId} unconfirmed: ${message}`);
+		this.clearSubmissionWatchdog(jobId);
+		await analysisStore.updateAnalysis(analysisId, {
+			status: 'connection_lost',
+			error: message,
+			updatedAt: Date.now()
 		});
+		this.activeAnalyses.delete(jobId);
+		analysisStore.removeFromActiveAnalyses(analysisId);
 	}
 
 	/**
@@ -303,10 +500,27 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				}
 			};
 
+			// TWO ARGUMENTS, NEVER THREE. Do not "improve" this into
+			// `socket.timeout(ms).emit(eventName, submitData, cb)`.
+			//
+			// The server registers every spawn event through a stream wrapper: lib/router.js:26 is
+			// `socket.on(key, function (stream, data))`. A third argument makes socket.io deliver
+			// stream=submitData and data=<ack function>, the adjustment guard at router.js:29
+			// (`data === undefined`) does not fire, and analysis-routes.js:47-51 then reads `params` as
+			// the ack function — so `!params.job` is true and EVERY submission is answered with
+			// 'Invalid job parameters'. The server never calls the ack either, so the timeout would
+			// also fire on every healthy run.
+			//
+			// The acknowledgement therefore cannot ride the emit. It arrives as the `job created`
+			// event (see setupGlobalHandlers), and armSubmissionWatchdog below covers its absence.
 			this.socket.emit(eventName, submitData);
 
 			// Update progress
 			this.updateProgress(analysisId, 'pending', 5, `Job submitted - ID: ${jobId}`);
+
+			// Nothing else ever revisited this state before: a job the server silently dropped sat at
+			// "pending" until the user gave up. Start the clock.
+			this.armSubmissionWatchdog(analysisId, jobId);
 
 			return {
 				analysisId,
@@ -315,6 +529,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			};
 		} catch (error) {
 			console.error('❌ Backend analysis submission failed:', error);
+			this.clearSubmissionWatchdog(jobId);
 			await this.completeAnalysis(analysisId, false, null, `Submission failed: ${error.message}`);
 			this.activeAnalyses.delete(jobId);
 			throw error;
@@ -726,6 +941,7 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 				if (this.socket && this.socket.connected) {
 					this.socket.emit('cancel', { jobId });
 				}
+				this.clearSubmissionWatchdog(jobId);
 				this.activeAnalyses.delete(jobId);
 				break;
 			}
@@ -770,6 +986,9 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 			this.socket.disconnect();
 			this.socket = null;
 		}
+		// Drop the timers with the socket. Left armed they would fire against a dead connection —
+		// and in a test suite that reuses this singleton they leak across cases.
+		this.clearAllSubmissionWatchdogs();
 		this.activeAnalyses.clear();
 	}
 

--- a/src/lib/services/BackendAnalysisRunner.js
+++ b/src/lib/services/BackendAnalysisRunner.js
@@ -8,6 +8,7 @@ import { DATAMONKEY_SERVER_URL } from '../config/env.ts';
 import { BaseAnalysisRunner } from './BaseAnalysisRunner.js';
 import { analysisStore } from '../../stores/analyses.js';
 import { sanitizeSequenceNames } from '../utils/fastaValidation.js';
+import { geneticCodeId } from '../config/geneticCodes.js';
 
 /**
  * Strip embedded trees from alignment data
@@ -426,24 +427,17 @@ class BackendAnalysisRunner extends BaseAnalysisRunner {
 	}
 
 	/**
-	 * Map genetic code name to numeric ID (for backward compatibility)
+	 * Map genetic code name to the numeric ID the server expects.
+	 *
+	 * Delegates to the shared table, which resolves BOTH the identifiers the selector now emits
+	 * ('Vertebrate-mtDNA') and the spellings older builds stored ('Vertebrate mitochondrial').
+	 * That second half is not cosmetic: the fallback here is 0, so a name this fails to recognise
+	 * makes the server silently run the UNIVERSAL code while the UI still shows the code the user
+	 * picked — a wrong answer with no error anywhere. Keeping a second copy of the table in this
+	 * file is what made that possible; do not reintroduce one.
 	 */
 	mapGeneticCodeToId(geneticCode) {
-		const codeMap = {
-			Universal: 0,
-			'Vertebrate mitochondrial': 1,
-			'Yeast mitochondrial': 2,
-			'Mold mitochondrial': 3,
-			'Invertebrate mitochondrial': 4,
-			'Ciliate nuclear': 5,
-			'Echinoderm mitochondrial': 6,
-			'Euplotid nuclear': 7,
-			'Alternative yeast nuclear': 8,
-			'Ascidian mitochondrial': 9,
-			'Flatworm mitochondrial': 10,
-			'Blepharisma nuclear': 11
-		};
-		return codeMap[geneticCode] || 0;
+		return geneticCodeId(geneticCode);
 	}
 
 	/**

--- a/src/lib/services/WasmAnalysisRunner.js
+++ b/src/lib/services/WasmAnalysisRunner.js
@@ -10,6 +10,7 @@ import { get } from 'svelte/store';
 import { getCachedOrCompute, generateAnalysisKey } from '../utils/cacheUtils.js';
 import { sanitizeSequenceNames } from '../utils/fastaValidation.js';
 import { safeParseJSON } from '../utils/jsonUtils.js';
+import { canonicalGeneticCodeName } from '../config/geneticCodes.js';
 
 /**
  * hyphy-analyses custom analyses that are NOT packed into the WASM /res/ image.
@@ -234,20 +235,23 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 
 		this.updateProgress(analysisId, 'running', 20, 'Building analysis command...');
 
-		// Build arguments
+		// Build arguments as an argv ARRAY — one shell token per element, never
+		// "--flag value" in a single string. Aioli's exec() only splits on spaces when it is
+		// handed a command string, so under the old form any value containing a space was torn
+		// apart before HyPhy saw it. See the exec() call below for the full mechanism.
 		const args = [];
-		args.push(`--alignment ${inputFiles[0]}`);
+		args.push('--alignment', inputFiles[0]);
 
 		// Add tree argument if tree data was provided
 		if (sanitizedTree && sanitizedTree.trim()) {
-			args.push(`--tree ${inputFiles[1]}`);
+			args.push('--tree', inputFiles[1]);
 		}
 
 		// NRM (nucleotide non-reversibility) writes its JSON to <alignment>.NRM.json by
 		// default; pass --output explicitly so the result path matches what we download
 		// below, regardless of how the batch file derives its default.
 		if (method.toLowerCase() === 'nrm') {
-			args.push(`--output ${inputFiles[0]}.NRM.json`);
+			args.push('--output', `${inputFiles[0]}.NRM.json`);
 		}
 
 		// Map configuration parameters to HyPhy command line arguments
@@ -263,7 +267,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				key !== 'branchSet2' &&
 				key !== 'testBranches' &&
 				key !== 'referenceBranches' &&
-				key !== 'variant'
+				key !== 'variant' &&
+				// UI-side companion of geneticCode. HyPhy's CLI takes the NAME, not the id;
+				// without this skip the generic branch below emitted a bogus
+				// '--genetic-code-id 0' on every local run.
+				key !== 'geneticCodeId'
 			) {
 				// Handle specific FEL parameter mappings
 				if (key === 'branchesToTest') {
@@ -282,79 +290,78 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 							// Skip - RELAX uses --test and --reference parameters
 						} else {
 							console.log('🌳 WASM - Converting Interactive to FG for HyPhy');
-							args.push(`--branches FG`);
+							args.push('--branches', 'FG');
 						}
 					} else {
 						// Always pass --branches explicitly (including 'All') to avoid
 						// stale state issues with Emscripten's callMain between invocations
-						args.push(`--branches ${value || 'All'}`);
+						args.push('--branches', String(value || 'All'));
 					}
 				} else if (key === 'propertySet') {
 					// PRIME property set parameter
-					args.push(`--property-set ${value}`);
+					args.push('--property-set', String(value));
 				} else if (key === 'imputeStates') {
 					// PRIME impute states parameter
-					args.push(`--impute-states ${value}`);
+					args.push('--impute-states', String(value));
 				} else if (key === 'geneticCode') {
-					// Pass the descriptive string value (HyPhy WASM does not accept the
-					// numeric code id on the CLI). Known limitation: aioli's exec() does
-					// a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
-					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
-					// proper fix is to refactor args into an array passed to
-					// cliObj.exec(cmd, argsArray) — tracked separately.
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// HyPhy's CLI takes the code's NAME, not the numeric id, and the shipped engine
+					// accepts only the identifiers it declares — hyphenated ones like
+					// 'Vertebrate-mtDNA'. Normalise the spellings older builds stored so a saved
+					// config keeps running the code it names instead of being rejected outright.
+					// See src/lib/config/geneticCodes.js for where that list comes from.
+					const codeName = canonicalGeneticCodeName(String(value));
+					console.log('🧬 WASM - Using genetic code:', codeName);
+					args.push('--code', codeName);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
-					args.push(`--srv ${value}`);
+					args.push('--srv', String(value));
 				} else if (key === 'multipleHits') {
 					// Multiple hits parameter
 					if (value !== 'None') {
-						args.push(`--multiple-hits ${value}`);
+						args.push('--multiple-hits', String(value));
 					}
 				} else if (key === 'siteMultihit') {
 					// Site multihit parameter (only when multiple hits enabled)
 					if (config.multipleHits && config.multipleHits !== 'None') {
-						args.push(`--site-multihit ${value}`);
+						args.push('--site-multihit', String(value));
 					}
 				} else if (key === 'resample' && value > 0) {
 					// Bootstrap resampling
-					args.push(`--resample ${value}`);
+					args.push('--resample', String(value));
 				} else if (key === 'confidenceIntervals') {
 					// Confidence intervals
-					args.push(`--ci ${value ? 'Yes' : 'No'}`);
+					args.push('--ci', value ? 'Yes' : 'No');
 				} else if (key === 'blb') {
 					// Bag of Little Bootstrap parameter for aBSREL
-					args.push(`--blb ${value}`);
+					args.push('--blb', String(value));
 				} else if (key === 'pValueThreshold') {
 					// P-value threshold (custom parameter, not standard HyPhy)
 					// This would be handled post-processing
 					continue;
 				} else if (key === 'steps') {
 					// BGM chain length steps
-					args.push(`--steps ${value}`);
+					args.push('--steps', String(value));
 				} else if (key === 'burnIn') {
 					// BGM burn-in samples
-					args.push(`--burn-in ${value}`);
+					args.push('--burn-in', String(value));
 				} else if (key === 'samples') {
 					// BGM samples
-					args.push(`--samples ${value}`);
+					args.push('--samples', String(value));
 				} else if (key === 'maxParents') {
 					// BGM maximum parents per node
-					args.push(`--max-parents ${value}`);
+					args.push('--max-parents', String(value));
 				} else if (key === 'minSubs') {
 					// BGM minimum substitutions per site
-					args.push(`--min-subs ${value}`);
+					args.push('--min-subs', String(value));
 				} else if (key === 'rates') {
 					// Multi-Hit rate classes parameter
-					args.push(`--rates ${value}`);
+					args.push('--rates', String(value));
 				} else if (key === 'rate_classes') {
 					// NRM rate classes parameter (convert underscore to hyphen)
-					args.push(`--rate-classes ${value}`);
+					args.push('--rate-classes', String(value));
 				} else if (key === 'triple_islands') {
 					// Multi-Hit triple islands parameter (convert underscore to hyphen)
-					args.push(`--triple-islands ${value}`);
+					args.push('--triple-islands', String(value));
 				} else if (key === 'mode') {
 					// RELAX mode parameter - skip if default value to avoid space-in-value issues
 					// "Classic mode" is the default, so we only need to pass it if different
@@ -365,11 +372,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// Skip passing --mode parameter
 				} else if (typeof value === 'boolean') {
 					// Boolean parameters
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value ? 'Yes' : 'No'}`);
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, value ? 'Yes' : 'No');
 				} else if (value !== null && value !== undefined && value !== '') {
-					// All other parameters (including strings with spaces)
-					// Don't add quotes - HyPhy WASM doesn't parse them correctly
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value}`);
+					// All other parameters. Values containing spaces are safe now that each
+					// argv token is its own array element.
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, String(value));
 				}
 			}
 		}
@@ -402,15 +409,17 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 			}
 		}
 
-		// Add method-specific default arguments for BGM
+		// Add method-specific default arguments for BGM.
+		// Flags are their own argv tokens now, so an exact match is both correct and cheaper
+		// than the substring scan this used to do.
 		if (method.toLowerCase() === 'bgm') {
 			// BGM requires explicit data type specification
-			if (!args.some((arg) => arg.includes('--type'))) {
-				args.push('--type codon');
+			if (!args.includes('--type')) {
+				args.push('--type', 'codon');
 			}
 			// BGM requires branches specification
-			if (!args.some((arg) => arg.includes('--branches'))) {
-				args.push('--branches All');
+			if (!args.includes('--branches')) {
+				args.push('--branches', 'All');
 			}
 		}
 
@@ -444,18 +453,29 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				? `/res/TemplateBatchFiles/${batchFile}`
 				: methodKey;
 
-		// Build and execute the command
-		const fullHyphyCommand = `hyphy LIBPATH=/res/ ${hyphyCommand} ${args.join(' ')}`;
-		console.log(`Executing HyPhy command: ${fullHyphyCommand}`);
+		// Build and execute the command.
+		//
+		// The argv array is passed to exec() as its SECOND argument. Aioli's worker only does
+		// `command.split(' ')` when that second argument is null; given an array it hands the
+		// tokens to Emscripten's callMain untouched, so a value keeps whatever characters it has.
+		// In this form the first argument must be the bare program name and must NOT be repeated
+		// inside the array — the worker looks the tool up by `program == 'hyphy'` and throws
+		// 'Program ... not found' otherwise.
+		//
+		// displayCommand is for humans (logs, the stored arguments record) only. It is NOT what
+		// runs, and it is ambiguous for any value containing a space; do not feed it back to exec.
+		const argv = ['LIBPATH=/res/', hyphyCommand, ...args];
+		const displayCommand = ['hyphy', ...argv].join(' ');
+		console.log(`Executing HyPhy command: ${displayCommand}`);
 
 		this.updateProgress(analysisId, 'running', 40, `Executing ${method} analysis...`);
 
 		// Run the analysis
-		const cmdResult = await cliObj.exec(fullHyphyCommand);
+		const cmdResult = await cliObj.exec('hyphy', argv);
 		const stdout = await cmdResult.stdout;
 
 		// Add command execution details to stdout for debugging
-		const commandInfo = `\n=== HyPhy Command Execution ===\nCommand: ${fullHyphyCommand}\nFiles mounted: ${filesToMount.map((f) => f.name).join(', ')}\nTree data provided: ${sanitizedTree && sanitizedTree.trim() ? 'Yes' : 'No'}\n================================\n\n`;
+		const commandInfo = `\n=== HyPhy Command Execution ===\nCommand: ${displayCommand}\nFiles mounted: ${filesToMount.map((f) => f.name).join(', ')}\nTree data provided: ${sanitizedTree && sanitizedTree.trim() ? 'Yes' : 'No'}\n================================\n\n`;
 		const enhancedStdout = commandInfo + stdout;
 
 		// Check for common HyPhy errors
@@ -527,12 +547,15 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 	 * Build arguments preview for database storage (before actual execution)
 	 */
 	buildArgumentsPreview(method, config, treeData) {
+		// Same argv-array tokenisation as executeWasmAnalysis — see the comments there. The two
+		// must stay in step: this is the record a user reads when an analysis fails, and a preview
+		// that differs from what actually ran is worse than no preview.
 		const args = [];
-		args.push(`--alignment user.nex`);
+		args.push('--alignment', 'user.nex');
 
 		// Add tree argument if tree data was provided
 		if (treeData && treeData.trim()) {
-			args.push(`--tree user.tree`);
+			args.push('--tree', 'user.tree');
 		}
 
 		// Map configuration parameters to HyPhy command line arguments
@@ -548,7 +571,9 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 				key !== 'branchSet2' &&
 				key !== 'testBranches' &&
 				key !== 'referenceBranches' &&
-				key !== 'variant'
+				key !== 'variant' &&
+				// See executeWasmAnalysis: the id is UI state, the CLI takes the name.
+				key !== 'geneticCodeId'
 			) {
 				// Handle specific FEL parameter mappings
 				if (key === 'branchesToTest') {
@@ -560,76 +585,71 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 						} else if (method.toLowerCase() === 'relax') {
 							// Skip - RELAX uses --test and --reference parameters
 						} else {
-							args.push(`--branches FG`);
+							args.push('--branches', 'FG');
 						}
 					} else {
 						// Always pass --branches explicitly (including 'All') to avoid
 						// stale state issues with Emscripten's callMain between invocations
-						args.push(`--branches ${value || 'All'}`);
+						args.push('--branches', String(value || 'All'));
 					}
 				} else if (key === 'propertySet') {
 					// PRIME property set parameter
-					args.push(`--property-set ${value}`);
+					args.push('--property-set', String(value));
 				} else if (key === 'imputeStates') {
 					// PRIME impute states parameter
-					args.push(`--impute-states ${value}`);
+					args.push('--impute-states', String(value));
 				} else if (key === 'geneticCode') {
-					// Pass the descriptive string value (HyPhy WASM does not accept the
-					// numeric code id on the CLI). Known limitation: aioli's exec() does
-					// a plain command.split(' '), so multi-word names like
-					// 'Vertebrate mitochondrial' get split into '--code Vertebrate' +
-					// stray 'mitochondrial' and HyPhy rejects the truncated value. The
-					// proper fix is to refactor args into an array passed to
-					// cliObj.exec(cmd, argsArray) — tracked separately.
-					console.log('🧬 WASM - Using genetic code:', value);
-					args.push(`--code ${value}`);
+					// Normalised to the HyPhy identifier, exactly as the executed command does.
+					const codeName = canonicalGeneticCodeName(String(value));
+					console.log('🧬 WASM - Using genetic code:', codeName);
+					args.push('--code', codeName);
 				} else if (key === 'srv') {
 					// Synonymous rate variation
-					args.push(`--srv ${value}`);
+					args.push('--srv', String(value));
 				} else if (key === 'multipleHits') {
 					// Multiple hits parameter
 					if (value !== 'None') {
-						args.push(`--multiple-hits ${value}`);
+						args.push('--multiple-hits', String(value));
 					}
 				} else if (key === 'siteMultihit') {
 					// Site multihit parameter (only when multiple hits enabled)
 					if (config.multipleHits && config.multipleHits !== 'None') {
-						args.push(`--site-multihit ${value}`);
+						args.push('--site-multihit', String(value));
 					}
 				} else if (key === 'resample' && value > 0) {
 					// Bootstrap resampling
-					args.push(`--resample ${value}`);
+					args.push('--resample', String(value));
 				} else if (key === 'confidenceIntervals') {
 					// Confidence intervals
-					args.push(`--ci ${value ? 'Yes' : 'No'}`);
+					args.push('--ci', value ? 'Yes' : 'No');
 				} else if (key === 'blb') {
 					// Bag of Little Bootstrap parameter for aBSREL
-					args.push(`--blb ${value}`);
+					args.push('--blb', String(value));
 				} else if (key === 'pValueThreshold') {
 					// P-value threshold (custom parameter, not standard HyPhy)
 					// This would be handled post-processing
 					continue;
 				} else if (key === 'steps') {
 					// BGM chain length steps
-					args.push(`--steps ${value}`);
+					args.push('--steps', String(value));
 				} else if (key === 'burnIn') {
 					// BGM burn-in samples
-					args.push(`--burn-in ${value}`);
+					args.push('--burn-in', String(value));
 				} else if (key === 'samples') {
 					// BGM samples
-					args.push(`--samples ${value}`);
+					args.push('--samples', String(value));
 				} else if (key === 'maxParents') {
 					// BGM maximum parents per node
-					args.push(`--max-parents ${value}`);
+					args.push('--max-parents', String(value));
 				} else if (key === 'minSubs') {
 					// BGM minimum substitutions per site
-					args.push(`--min-subs ${value}`);
+					args.push('--min-subs', String(value));
 				} else if (key === 'rates') {
 					// Multi-Hit rate classes parameter
-					args.push(`--rates ${value}`);
+					args.push('--rates', String(value));
 				} else if (key === 'triple_islands') {
 					// Multi-Hit triple islands parameter (convert underscore to hyphen)
-					args.push(`--triple-islands ${value}`);
+					args.push('--triple-islands', String(value));
 				} else if (key === 'mode') {
 					// RELAX mode parameter - skip if default value to avoid space-in-value issues
 					if (value !== 'Classic mode') {
@@ -638,11 +658,11 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 					// Skip passing --mode parameter
 				} else if (typeof value === 'boolean') {
 					// Boolean parameters
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value ? 'Yes' : 'No'}`);
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, value ? 'Yes' : 'No');
 				} else if (value !== null && value !== undefined && value !== '') {
-					// All other parameters (including strings with spaces)
-					// Don't add quotes - HyPhy WASM doesn't parse them correctly
-					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()} ${value}`);
+					// All other parameters. Values containing spaces are safe now that each
+					// argv token is its own array element.
+					args.push(`--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`, String(value));
 				}
 			}
 		}
@@ -673,17 +693,23 @@ class WasmAnalysisRunner extends BaseAnalysisRunner {
 		// Add method-specific default arguments for BGM (preview version)
 		if (method.toLowerCase() === 'bgm') {
 			// BGM requires explicit data type specification
-			if (!args.some((arg) => arg.includes('--type'))) {
-				args.push('--type codon');
+			if (!args.includes('--type')) {
+				args.push('--type', 'codon');
 			}
 			// BGM requires branches specification
-			if (!args.some((arg) => arg.includes('--branches'))) {
-				args.push('--branches All');
+			if (!args.includes('--branches')) {
+				args.push('--branches', 'All');
 			}
 		}
 
+		// Preview shows the method name rather than the batch-file path, for readability.
+		// `argv` is the exact token list; `command` is the same thing joined for display, and is
+		// ambiguous wherever a value contains a space — which is why both are stored.
+		const argv = ['LIBPATH=/res/', method.toLowerCase(), ...args];
+
 		return {
-			command: `hyphy LIBPATH=/res/ ${method.toLowerCase()} ${args.join(' ')}`, // Preview shows method name for readability
+			command: ['hyphy', ...argv].join(' '),
+			argv,
 			method: method.toUpperCase(),
 			parameters: config,
 			treeData: treeData

--- a/src/lib/services/axomeme/callModes.js
+++ b/src/lib/services/axomeme/callModes.js
@@ -1,0 +1,95 @@
+/**
+ * callModes.js — the tier gates AxoMEME calls sites with, and one sentence saying what each mode
+ * will actually do to this alignment.
+ *
+ * A LEAF MODULE ON PURPOSE. The gates used to live in postprocess.js, which imports tokenizer.js and
+ * its 64-codon genetic-code table. MethodSelector is on every user's critical path and needs the
+ * numbers to describe the choice before a run, so importing postprocess.js there would pull the
+ * model's tokenizer into the main chunk for the fourteen methods that will never touch it — the same
+ * leakage RunOutlook lazy-loads MemeHitLikelihood to avoid. postprocess.js re-exports CALL_DEFAULTS
+ * from here, so every existing import site is unchanged and there is still exactly one definition.
+ */
+
+/**
+ * Default tier gates.
+ *
+ * THE DEFAULT MODE IS `percentile`, WHICH IS NOT THE REFERENCE'S DEFAULT, and the reason is measured
+ * rather than preferential. The reference defaults to `pvalue`, which compares the predicted LRT
+ * against 4.45 and 3.12 — chi-square thresholds for a GENUINE likelihood ratio. The model's output
+ * does not live on that scale. Across 12 real DataMonkey submissions and 662 variable sites, the
+ * highest predicted LRT anywhere was 3.902; exactly one site cleared 3.12 and none cleared 4.45.
+ * On an alignment where MEME itself reports 17 sites at p <= 0.05, the model's maximum was 2.484.
+ *
+ * So under `pvalue` this feature ships reporting nothing on real data. That is not a threshold worth
+ * tuning — it reflects what the model is: a RANKER. The metric its authors report is Spearman rank
+ * correlation, not calibration, and rank correlation can be good while absolute scale is off.
+ * `percentile` asks the question the model can answer — which sites in THIS alignment look most
+ * interesting — instead of one it cannot.
+ *
+ * The gates themselves are unchanged from the driver's argparse (lines 984-991), so switching modes
+ * reproduces the reference exactly.
+ */
+export const CALL_DEFAULTS = Object.freeze({
+	mode: 'percentile',
+	tier1LrtGate: 4.45, // p <= 0.05
+	tier2LrtGate: 3.12, // p <= 0.10
+	tier1Zscore: 2.5,
+	tier2Zscore: 2.0,
+	tier1Percentile: 98.0,
+	tier2Percentile: 95.0
+});
+
+/** Same rounding postprocess.js uses for the tier LABELS, so pre-run copy and the results table
+ *  print the same percentage rather than two roundings of one number. */
+const pct = (n) => n.toFixed(0);
+
+/**
+ * What choosing this mode will do to THIS alignment, in one sentence.
+ *
+ * WHY THIS EXISTS: `percentile` — the default — always calls a fixed share of the variable sites,
+ * whether or not any site is under selection. Ranking is what the model is for, and the results
+ * table is honest about it ("Top 2%" / "Top 5%"), but before the run the only copy was a three-way
+ * comparison of the modes that never said a share is always called. A user running a conserved gene
+ * gets 2% of its variable sites back and has no way to know that was arithmetic rather than a
+ * finding.
+ *
+ * TWO WORDINGS THAT LOOK LIKE NITPICKS AND ARE NOT:
+ *
+ *   - VARIABLE sites, not sites. Percentiles are computed over variable sites only
+ *     (postprocess.js:170-185); invariant sites are zeroed before the model is consulted. On the
+ *     conserved alignments this line is written for, "top 2% of sites" overstates the count by
+ *     whatever fraction of the gene does not vary — which is most of it.
+ *   - The Tier 2 label is the CUMULATIVE "Top 5%", because that is the string the results table
+ *     prints. The tier SET is exclusive (the 95th-98th percentile band, 3% of variable sites), so
+ *     the sentence names both: the band it adds, and the label it will carry.
+ *
+ * @param {string} [mode] - 'percentile' | 'zscore' | 'pvalue'; anything else falls back to the
+ *   default mode's sentence, because that is the mode a missing value actually runs as
+ *   (METHOD_ADVANCED_OPTIONS.axomeme.callMode.default === CALL_DEFAULTS.mode).
+ * @param {object} [cfg] - gates to describe; every number in the sentence is derived from these
+ * @returns {string}
+ */
+export function describeCallMode(mode, cfg = CALL_DEFAULTS) {
+	if (mode === 'zscore') {
+		return (
+			`Flags sites at Z ≥ ${cfg.tier1Zscore} as Tier 1 and Z ≥ ${cfg.tier2Zscore} as Tier 2, ` +
+			`where Z counts standard deviations above this alignment's own mean predicted LRT over its ` +
+			`variable sites — still relative to this alignment, not an absolute test of significance.`
+		);
+	}
+
+	if (mode === 'pvalue') {
+		return (
+			`Flags variable sites with a predicted LRT ≥ ${cfg.tier1LrtGate} as Tier 1 and ` +
+			`≥ ${cfg.tier2LrtGate} as Tier 2. These are fixed chi-square gates rather than ranks, and ` +
+			`the model's predicted LRTs rarely reach them, so this usually reports nothing at all.`
+		);
+	}
+
+	return (
+		`Flags the top ${pct(100 - cfg.tier1Percentile)}% of this alignment's variable sites as Tier 1 ` +
+		`and the next ${pct(cfg.tier1Percentile - cfg.tier2Percentile)}% as Tier 2 (labelled ` +
+		`"Top ${pct(100 - cfg.tier2Percentile)}%"), whether or not any site is under selection. Use it to ` +
+		`prioritise sites for a full MEME run, not to decide significance.`
+	);
+}

--- a/src/lib/services/axomeme/postprocess.js
+++ b/src/lib/services/axomeme/postprocess.js
@@ -23,35 +23,15 @@
  */
 
 import { GENETIC_CODE, aaToken } from './tokenizer.js';
+import { CALL_DEFAULTS } from './callModes.js';
 
 /**
- * Default tier gates.
- *
- * THE DEFAULT MODE IS `percentile`, WHICH IS NOT THE REFERENCE'S DEFAULT, and the reason is measured
- * rather than preferential. The reference defaults to `pvalue`, which compares the predicted LRT
- * against 4.45 and 3.12 — chi-square thresholds for a GENUINE likelihood ratio. The model's output
- * does not live on that scale. Across 12 real DataMonkey submissions and 662 variable sites, the
- * highest predicted LRT anywhere was 3.902; exactly one site cleared 3.12 and none cleared 4.45.
- * On an alignment where MEME itself reports 17 sites at p <= 0.05, the model's maximum was 2.484.
- *
- * So under `pvalue` this feature ships reporting nothing on real data. That is not a threshold worth
- * tuning — it reflects what the model is: a RANKER. The metric its authors report is Spearman rank
- * correlation, not calibration, and rank correlation can be good while absolute scale is off.
- * `percentile` asks the question the model can answer — which sites in THIS alignment look most
- * interesting — instead of one it cannot.
- *
- * The gates themselves are unchanged from the driver's argparse (lines 984-991), so switching modes
- * reproduces the reference exactly.
+ * The tier gates live in callModes.js — a leaf with no imports — so the pre-run copy in
+ * MethodSelector can state what a mode will do without dragging tokenizer.js's genetic-code table
+ * into the main bundle. Re-exported here because this is where every caller already looks for them,
+ * and because one definition is the point of the move.
  */
-export const CALL_DEFAULTS = Object.freeze({
-	mode: 'percentile',
-	tier1LrtGate: 4.45, // p <= 0.05
-	tier2LrtGate: 3.12, // p <= 0.10
-	tier1Zscore: 2.5,
-	tier2Zscore: 2.0,
-	tier1Percentile: 98.0,
-	tier2Percentile: 95.0
-});
+export { CALL_DEFAULTS };
 
 export const NEUTRAL_CALL = 'Neutral';
 

--- a/src/lib/utils/alignmentEdits.js
+++ b/src/lib/utils/alignmentEdits.js
@@ -1,0 +1,57 @@
+/**
+ * The seam between "Save edits" in the alignment viewer and the rest of the app.
+ *
+ * WHY THIS EXISTS. saveEdits() used to write the edited FASTA to IndexedDB and to
+ * alignmentFileStore, and stop. Nothing re-ran datareader, so `fileMetricsStore.canonicalFasta` —
+ * the exact bytes AnalyzeTab hands to every runner, local and remote — still held the PRE-edit
+ * alignment. The button said "Saved", the viewer showed the edit, and every subsequent analysis ran
+ * on the alignment the user had just changed. Deleting a contaminated sequence and hitting Run
+ * produced a result computed WITH that sequence.
+ *
+ * The fix is not to patch canonicalFasta: the metrics, the trees, the site count and the warnings
+ * are all derived from the file too. The edited alignment has to go back through the same upload
+ * path as any other file.
+ */
+import { fileMetricsStore } from '../../stores/fileInfo.js';
+
+/**
+ * Build the File that "Save edits" produces from AliVibe's rows.
+ * @param {Array<{name: string, seq: string}>} rows
+ * @param {string} filename - kept identical to the original so the store replaces in place and the
+ *   analysis history stays attached to the same file id.
+ * @returns {File}
+ */
+export function buildEditedAlignmentFile(rows, filename = 'alignment.fasta') {
+	if (!rows || !rows.length) {
+		throw new Error('No alignment data to save');
+	}
+	const fasta = rows.map((entry) => `>${entry.name}\n${entry.seq}`).join('\n') + '\n';
+	return new File([fasta], filename, { type: 'text/plain' });
+}
+
+/**
+ * Route an edited alignment back through validation.
+ *
+ * @param {File} newFile
+ * @param {{revalidate: (file: File) => Promise<any>|any, setRevalidating?: (id: string|null) => void, fileId?: string|null}} deps
+ *   `revalidate` is +page.svelte's handleFileUpload entry point; `setRevalidating` flips the flag
+ *   the Run button reads.
+ */
+export async function applyAlignmentEdits(newFile, { revalidate, setRevalidating, fileId } = {}) {
+	if (typeof revalidate !== 'function') {
+		throw new Error('applyAlignmentEdits requires a revalidate function');
+	}
+
+	// Drop the descriptor BEFORE awaiting anything. Between the click and the end of the re-read
+	// there is a window of several seconds on a large alignment, and for all of it the old
+	// canonicalFasta would otherwise still be the string a Run would submit. Gone is correct;
+	// stale is not.
+	fileMetricsStore.set(null);
+	setRevalidating?.(fileId ?? null);
+
+	try {
+		return await revalidate(newFile);
+	} finally {
+		setRevalidating?.(null);
+	}
+}

--- a/src/lib/utils/branchSetTagging.js
+++ b/src/lib/utils/branchSetTagging.js
@@ -1,0 +1,90 @@
+/**
+ * Branch-set tagging, extracted from BranchSelector so it can be unit-tested without a DOM.
+ *
+ * Phylotree keeps set membership on the d3 hierarchy nodes as `node._selectionSet`, and
+ * `tree.getNewick(annotator)` turns that into the `name{TEST}:0.1` tags HyPhy reads. The rule that
+ * matters and is easy to get wrong: sets are MUTUALLY EXCLUSIVE, so assigning a branch that is
+ * already in one set must MOVE its tag, never add a second. `tree.display.addToSet` enforces that
+ * for the interactive tree; these helpers enforce the same thing for the list view and for the case
+ * where no display exists yet.
+ *
+ * Note on shape: an earlier version of this code traversed `tree.json`. That property does not
+ * exist on phylotree 2.2.1 — the tree is `tree.nodes`, a d3 hierarchy — so every one of those
+ * traversals was dead code. These functions take the descendant ARRAY
+ * (`tree.nodes.descendants()`), which keeps them free of both the DOM and phylotree itself.
+ */
+
+/** Name of a hierarchy node, tolerating both `{data:{name}}` and plain `{name}` shapes. */
+export function branchNameOf(node) {
+	if (!node) return '';
+	return node.data?.name ?? node.name ?? '';
+}
+
+/** The set a branch currently belongs to, or '' when it is unassigned. */
+export function branchSetOf(node) {
+	return node?._selectionSet || '';
+}
+
+/**
+ * Assign one branch to one set, or clear it when `setName` is falsy.
+ *
+ * @param {Array} nodes      descendants of the tree (tree.nodes.descendants())
+ * @param {string} branchName name of the branch to change
+ * @param {string} setName    target set, or '' / null to unassign
+ * @param {string[]} allSets  every set name in play; their legacy per-set boolean flags are cleared
+ *                            too, because generateTaggedNewick still falls back to reading them
+ * @returns {boolean} whether a matching branch was found
+ */
+export function assignBranchToSet(nodes, branchName, setName, allSets = []) {
+	if (!Array.isArray(nodes) || !branchName) return false;
+
+	const node = nodes.find((n) => branchNameOf(n) === branchName);
+	if (!node) return false;
+
+	// Clear first, unconditionally: this is what makes reassignment a MOVE rather than an
+	// accumulation, and it is the behaviour the tagged Newick depends on ({TEST,REFERENCE} on one
+	// branch is not a thing HyPhy accepts).
+	delete node._selectionSet;
+	allSets.forEach((s) => {
+		delete node[s];
+	});
+
+	if (setName) {
+		node._selectionSet = setName;
+	}
+	return true;
+}
+
+/**
+ * Rows for the list view, in tree order.
+ *
+ * The root is excluded: it has no branch, so there is nothing to tag. Unnamed nodes are excluded
+ * for the same practical reason — a branch with no name cannot be identified in the Newick output,
+ * so offering it in the list would produce an assignment that silently goes nowhere.
+ *
+ * @returns {Array<{name: string, set: string, isLeaf: boolean}>}
+ */
+export function listBranches(nodes) {
+	if (!Array.isArray(nodes)) return [];
+
+	return nodes
+		.filter((n) => (n.depth ?? 0) > 0)
+		.map((n) => ({
+			name: branchNameOf(n),
+			set: branchSetOf(n),
+			isLeaf: !(n.children && n.children.length)
+		}))
+		.filter((row) => row.name);
+}
+
+/**
+ * The `{SET}` suffix for a node, shared by the tree and list paths so both produce the same Newick.
+ * Falls back to the legacy per-set boolean properties for trees tagged before `_selectionSet`.
+ */
+export function multiSetTag(node, allSets = []) {
+	const direct = branchSetOf(node);
+	if (direct) return `{${direct}}`;
+
+	const legacy = allSets.filter((s) => node && node[s]);
+	return legacy.length > 0 ? `{${legacy.join(',')}}` : '';
+}

--- a/src/lib/utils/datareaderWarnings.js
+++ b/src/lib/utils/datareaderWarnings.js
@@ -1,0 +1,137 @@
+/**
+ * Turn datareader's FILE_INFO record into the warnings shown on the Data tab.
+ *
+ * TWO RULES GOVERN THE COPY HERE, and both are easy to undo by accident:
+ *
+ * 1. DESCRIBE, DO NOT RECOMMEND, AND NEVER OFFER TO MODIFY. Several of these conditions have more
+ *    than one cause - a padded sequence can mean an unaligned file, a non-standard gap character,
+ *    or a genuinely ragged region - and choosing between them is a question about the data, not
+ *    something the software should answer. There is a test asserting no warning text says
+ *    remove/fix/trim/repair. That assertion is the rule, not a lint.
+ *
+ * 2. THE KEYS ARE HISTORY. `ambiguous_sites` has never been a count of ambiguous characters: it is
+ *    datareader's boolean padWarning, set when a sequence had to be padded with '?'. It was
+ *    rendered as "Found 1 ambiguous character in your alignment", which is three kinds of wrong -
+ *    wrong count, wrong cause, wrong advice. `padded_sequences` is the honest replacement, and the
+ *    old key is still read because records cached in IndexedDB are replayed as-is
+ *    (descriptorSync.js) with no migration step.
+ *
+ * `stop_codons` is deliberately NOT read. datareader has never emitted it - the key it writes is
+ * `stop_codons_stripped`, which is a different thing (a boolean: every sequence ended in a stop and
+ * that final column was dropped). The old branch keyed on `stop_codons` could not fire, and
+ * reviving it would make an unfireable branch fire on a key that means something else.
+ */
+
+/** HyPhy serialises its lists as numerically-keyed objects, not JSON arrays. Accept both. */
+function toList(value) {
+	if (!value) return [];
+	if (Array.isArray(value)) return value.filter((v) => typeof v === 'string');
+	if (typeof value === 'object') {
+		return Object.keys(value)
+			.sort((a, b) => Number(a) - Number(b))
+			.map((k) => value[k])
+			.filter((v) => typeof v === 'string');
+	}
+	return [];
+}
+
+function count(value) {
+	const n = Number(value);
+	return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/**
+ * @param {Record<string, any>} FILE_INFO - datareader's FILE_INFO block
+ * @returns {Array<{type: string, title: string, message: string, details?: string, items?: string[], truncated?: number}>}
+ */
+export function buildWarnings(FILE_INFO) {
+	const info = FILE_INFO || {};
+	const warnings = [];
+
+	// Ordered so that "we changed your data" comes before "your data is small": SequenceWarnings
+	// shows only the first two until the user expands, and the changes are the ones nobody could
+	// find before (they went to datareader.log, which nothing reads).
+
+	const duplicateNames = toList(info.duplicate_names);
+	const duplicates = count(info.duplicate_sequences) || duplicateNames.length;
+	if (duplicates > 0) {
+		warnings.push({
+			type: 'warning',
+			title: 'Identical sequences collapsed',
+			message: `${plural(duplicates, 'sequence')} in your file were identical to another sequence, and each set was collapsed to a single copy before analysis.`,
+			details:
+				'Analyses ran on the collapsed alignment, so identical sequences are represented once. This is how the site has always handled exact duplicates; it is recorded here so the sequence count you see matches what you uploaded.',
+			items: duplicateNames,
+			truncated: count(info.duplicate_names_truncated)
+		});
+	}
+
+	const renamedNames = toList(info.renamed_names);
+	const renamed = count(info.sequences_renamed) || renamedNames.length;
+	if (renamed > 0) {
+		warnings.push({
+			type: 'warning',
+			title: 'Sequences renamed',
+			message: `${plural(renamed, 'sequence')} were renamed, because HyPhy sequence names may only contain letters, digits and underscores.`,
+			details:
+				'Every other character was replaced with an underscore. Results and trees use the new names, so a name you search for may not be the one in your original file.',
+			items: renamedNames,
+			truncated: count(info.renamed_names_truncated)
+		});
+	}
+
+	// `padded_sequences` is the count; `ambiguous_sites` is the legacy boolean carrying the same
+	// signal, and is all a cached record has.
+	const padded = count(info.padded_sequences);
+	if (padded > 0 || info.ambiguous_sites) {
+		const subject = padded > 0 ? plural(padded, 'sequence') : 'Some sequences';
+		warnings.push({
+			type: 'warning',
+			title: 'Sequences padded to equal length',
+			message: `${subject} ${padded === 1 ? 'was' : 'were'} shorter than the alignment and ${padded === 1 ? 'was' : 'were'} padded with '?' characters at the end.`,
+			details:
+				"This usually means the file is not aligned, or that a non-standard gap character was used: only '-' and '?' are recognised as gaps. '~' (BioEdit) and '_' are not, and are read as missing data.",
+			items: []
+		});
+	}
+
+	if (info.stop_codons_stripped) {
+		warnings.push({
+			type: 'warning',
+			title: 'Trailing stop codons stripped',
+			message:
+				'Every sequence ended in a stop codon, and that final codon column was excluded from the alignment.',
+			details:
+				'This happens only when the stop is terminal in every sequence and appears nowhere else. Codon models have no state for a stop codon, so the column cannot be scored.',
+			items: []
+		});
+	}
+
+	const sites = count(info.sites);
+	if (sites > 0 && sites < 30) {
+		warnings.push({
+			type: 'info',
+			title: 'Short alignment',
+			message: `Your alignment has ${plural(sites, 'site')}, which is short.`,
+			details:
+				'Short alignments carry limited statistical power for detecting selection, so a null result says less than it would on a longer alignment.',
+			items: []
+		});
+	}
+
+	const sequences = count(info.sequences);
+	if (sequences > 0 && sequences < 8) {
+		warnings.push({
+			type: 'info',
+			title: 'Small sample size',
+			message: `Your alignment has ${plural(sequences, 'sequence')}, which is a small sample.`,
+			details:
+				'Selection analyses generally have more power with larger samples; with this few sequences, only strong signals are detectable.',
+			items: []
+		});
+	}
+
+	return warnings;
+}

--- a/src/lib/utils/executionAdvice.js
+++ b/src/lib/utils/executionAdvice.js
@@ -1,0 +1,98 @@
+/**
+ * executionAdvice.js — where a submission should run, and what to say about it before it runs.
+ *
+ * Extracted from MethodSelector for the same reason runStatusLine.js was: the decision and the
+ * sentence that explains it are the design, and a design that lives inside a 2000-line component
+ * cannot be tested and drifts. See design/03-run-feedback/.
+ *
+ * THE PROBLEM THIS FILE EXISTS TO FIX: execution mode was hard-coded to 'local' for every method and
+ * every dataset. The app already computed, and already displayed one row away, that BGM on a 20x255
+ * alignment is ~2h 15m in this browser against ~33 min on the server — and still defaulted to the
+ * browser, where a reload or a closed tab loses the run outright.
+ *
+ * TWO RULES KEEP THIS HONEST:
+ *
+ *  1. NEVER INVENT A NUMBER. Only methods with a fitted equation in BACKEND_TIMING_EQUATIONS get
+ *     advice; AxoMEME, PRIME, NRM, B-STILL and FADE have none, and the answer there is silence, not
+ *     a guess. Same rule runStatusLine.js applies to the elapsed row.
+ *  2. THE SENTENCE INTERPOLATES THE ESTIMATE'S OWN `description`, never a re-derived duration, so it
+ *     is impossible for the advice to disagree with the "Before you run" row rendering the same
+ *     field a few pixels below it.
+ */
+
+import { calculateRuntimeEstimate } from './timingEstimates.js';
+
+/**
+ * Categories worth speaking up about. Anything faster runs locally without comment: a browser is the
+ * better place for a two-minute analysis (no queue, no upload), and nagging on fast runs would train
+ * users to ignore the line that matters. Names must match SPEED_CATEGORIES in timingEstimates.js —
+ * execution-advice.test.js pins that.
+ */
+export const SLOW_CATEGORIES = new Set(['slow', 'very-slow']);
+
+/** No fitted equation, or no dataset yet: no estimate, no advice, no moved radio. */
+const NO_ADVICE = Object.freeze({
+	hasEstimate: false,
+	local: null,
+	server: null,
+	recommend: null,
+	advice: null
+});
+
+/**
+ * @param {object} input
+ * @param {string} [input.method] - method key, any case (BGM / bgm both work)
+ * @param {number} [input.sequences]
+ * @param {number} [input.sites] - codon sites, as FILE_INFO reports them
+ * @param {object} [input.methodOptions] - advanced options; some multiply the runtime
+ * @param {boolean} [input.serverConnected] - a recommendation to use a server that is down is worse
+ *   than none, so this gates the whole 'backend' branch
+ * @returns {{hasEstimate: boolean, local: object|null, server: object|null,
+ *   recommend: 'backend'|null, advice: string|null}}
+ */
+export function executionAdvice({
+	method,
+	sequences,
+	sites,
+	methodOptions = {},
+	serverConnected = false
+} = {}) {
+	if (!method || !(sequences > 0) || !(sites > 0)) return NO_ADVICE;
+
+	const local = calculateRuntimeEstimate(method, sequences, sites, 'wasm', methodOptions);
+	// `minutes === null` is how timingEstimates.js reports "no equation for this method". It is not a
+	// zero and must not be treated as a fast run.
+	if (local.minutes === null) return NO_ADVICE;
+
+	const server = calculateRuntimeEstimate(method, sequences, sites, 'backend', methodOptions);
+
+	if (!SLOW_CATEGORIES.has(local.category)) {
+		// Both estimates are still returned: the radio sub-labels state each mode's duration whether or
+		// not there is anything to advise.
+		return { hasEstimate: true, local, server, recommend: null, advice: null };
+	}
+
+	if (serverConnected) {
+		// The comparison, and nothing about which radio is selected. Whether the recommendation is
+		// actually in effect is the component's business — the user may have clicked Local since, and a
+		// sentence claiming "the server is selected" would then be a lie printed next to a Local radio.
+		return {
+			hasEstimate: true,
+			local,
+			server,
+			recommend: 'backend',
+			advice: `${local.description} in this browser vs ${server.description} on the server.`
+		};
+	}
+
+	// No server to send it to, so no recommendation — only the consequence the user is about to
+	// accept. "The tab must stay open" is the fact that costs people work: a local run dies with the
+	// page (analyses.js:672-741).
+	return {
+		hasEstimate: true,
+		local,
+		server,
+		recommend: null,
+		advice: `This will take ${local.description} and the tab must stay open.`
+	};
+}

--- a/src/lib/utils/fileIdentity.js
+++ b/src/lib/utils/fileIdentity.js
@@ -1,0 +1,81 @@
+/**
+ * File identity helpers.
+ *
+ * A file is identified by its NAME in this app: persistentFileStore.uploadFile looks for an
+ * existing record with the same filename and replaces its bytes in place, keeping the id. That is
+ * deliberate for a repaired or edited version of the same alignment - the analysis history stays
+ * attached - but it is wrong when the user means "here is a different file that happens to be
+ * called alignment.fasta", because every earlier run silently ends up filed under the new contents.
+ * These two helpers are the seam for both halves of the fix: choosing a non-colliding name, and
+ * marking the runs that predate a replacement.
+ */
+
+/**
+ * Return `name` if free, otherwise the first "stem (n).ext" that is not taken.
+ *
+ * MUST run before `forceNew` reaches indexedDBStorage.saveFile: saveFile does its own
+ * findFileByName lookup, so two records sharing a name would make that lookup - used by every
+ * other caller - nondeterministic.
+ *
+ * @param {string} name
+ * @param {Iterable<string>} takenNames
+ * @returns {string}
+ */
+export function uniqueFilename(name, takenNames = []) {
+	const taken = new Set(takenNames);
+	if (!taken.has(name)) return name;
+
+	// Split on the LAST dot so "a.b.fasta" keeps ".fasta". A leading dot (".fasta") is a name, not
+	// an extension, hence > 0 rather than >= 0.
+	const dot = name.lastIndexOf('.');
+	const stem = dot > 0 ? name.slice(0, dot) : name;
+	const ext = dot > 0 ? name.slice(dot) : '';
+
+	// Strip an existing " (n)" so a third upload gives "alignment (3).fasta", not
+	// "alignment (2) (2).fasta".
+	const base = stem.replace(/ \(\d+\)$/, '');
+
+	for (let n = 2; n < 1000; n += 1) {
+		const candidate = `${base} (${n})${ext}`;
+		if (!taken.has(candidate)) return candidate;
+	}
+
+	// 999 same-named files is not a real case; fall back to something unique rather than loop.
+	return `${base} (${Date.now()})${ext}`;
+}
+
+/**
+ * Clear a file input so selecting the SAME path again fires another change event.
+ *
+ * Must be called from a `finally`, not from the happy path: a rejected file is exactly the one the
+ * user corrects outside the browser and re-selects, and without this that second selection is a
+ * no-op with no feedback at all.
+ *
+ * The instanceof guard is load-bearing — the demo, repair and alignment-edit callers pass a
+ * synthetic `{ target: { files: [...] } }` object with no `value` to clear.
+ *
+ * @param {{target?: any}} event
+ */
+export function resetFileInput(event) {
+	const target = event?.target;
+	if (typeof HTMLInputElement !== 'undefined' && target instanceof HTMLInputElement) {
+		target.value = '';
+	}
+}
+
+/**
+ * True when this analysis ran before the file's contents were last replaced.
+ *
+ * `updatedAt` is only written when an upload replaces an existing record, so a file that was never
+ * re-uploaded has none and nothing is ever marked stale.
+ *
+ * @param {{createdAt?: number}} analysis
+ * @param {{createdAt?: number, updatedAt?: number}} file
+ * @returns {boolean}
+ */
+export function isStaleRun(analysis, file) {
+	const updatedAt = Number(file?.updatedAt);
+	const createdAt = Number(analysis?.createdAt);
+	if (!Number.isFinite(updatedAt) || !Number.isFinite(createdAt)) return false;
+	return createdAt < updatedAt;
+}

--- a/src/lib/utils/fileMetricsDisplay.js
+++ b/src/lib/utils/fileMetricsDisplay.js
@@ -1,0 +1,59 @@
+/**
+ * Display formatters for datareader's FILE_INFO record.
+ *
+ * These exist because two of the Data tab's numbers were unreadable rather than wrong:
+ *
+ *  - `rawsites` and `sites` are the SAME alignment measured in two units. datareader.bf:608 takes
+ *    `sites` from the codon filter (unit 3) and :617 takes `rawsites` from a nucleotide filter
+ *    (unit 1) built from the same data, so `rawsites` is exactly 3 x `sites` for codon data. The
+ *    old "561 raw -> 187 processed" row read as if 374 sites had been thrown away.
+ *  - `gencodeid` was printed as a bare integer.
+ *
+ * Both are LABEL changes. The underlying `sites` value is consumed as the alignment-length term by
+ * BaseAnalysisRunner.js:41-46 and SequenceWarnings, so nothing here may alter it.
+ */
+import { GENETIC_CODES } from '../config/geneticCodes.js';
+
+const groupDigits = (n) => Number(n).toLocaleString('en-US');
+
+/**
+ * "561 nucleotides (187 codons)" for codon data, "561 sites" for anything else.
+ *
+ * Cached datareader records predating `rawsites` fall back to the codon count alone rather than
+ * rendering `NaN` — descriptorSync.js replays whatever IndexedDB holds, with no migration step.
+ *
+ * @param {Record<string, any>} FILE_INFO
+ * @returns {string}
+ */
+export function formatAlignmentLength(FILE_INFO = {}) {
+	const sites = Number(FILE_INFO?.sites);
+	if (!Number.isFinite(sites)) return 'Unknown';
+
+	// datareader hardcodes genCodeID = 0 today; treat a missing gencodeid as codon data, which is
+	// what every record it has ever written actually is.
+	const isCodon = Number(FILE_INFO?.gencodeid ?? 0) >= 0;
+	const rawsites = Number(FILE_INFO?.rawsites);
+
+	if (isCodon && Number.isFinite(rawsites) && rawsites !== sites) {
+		return `${groupDigits(rawsites)} nucleotides (${groupDigits(sites)} codons)`;
+	}
+
+	return `${groupDigits(sites)} ${isCodon ? 'codons' : 'sites'}`;
+}
+
+/**
+ * Turn a gencodeid into the name of the code. -1 and -2 are datareader's sentinels for
+ * non-codon data (datareader.bf:457-471) and are not rows in the table.
+ *
+ * @param {number|string} gencodeid
+ * @returns {string}
+ */
+export function formatGeneticCode(gencodeid) {
+	const id = Number(gencodeid);
+	if (!Number.isFinite(id)) return 'Unknown';
+	if (id === -1) return 'Nucleotide';
+	if (id < 0) return 'Amino acid';
+
+	const entry = GENETIC_CODES.find((c) => c.id === id);
+	return entry ? entry.label : `Code ${id}`;
+}

--- a/src/lib/utils/runStatusLine.js
+++ b/src/lib/utils/runStatusLine.js
@@ -112,6 +112,22 @@ export function runStatusLine({
 
 	// --- still running ---
 
+	// A server job that has been submitted but not started is QUEUED, not running. Saying "on the
+	// server · running" for a job sitting in the scheduler is a lie, and the specific lie that makes a
+	// slow queue look like a slow analysis — the user waits on a machine that has not begun.
+	//
+	// Only the backend gets this branch: a wasm run has no queue, so 'pending' there is genuinely the
+	// first moments of execution.
+	if (executionMode === 'backend' && (status === 'pending' || status === 'initializing')) {
+		return {
+			label,
+			detail: 'queued on the server',
+			tone: 'running',
+			clock: elapsedSeconds < CLOCK_AFTER_SECONDS ? null : clock,
+			showDetails: false
+		};
+	}
+
 	if (elapsedSeconds < CLOCK_AFTER_SECONDS) {
 		return {
 			label,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -97,42 +97,53 @@
 				<span class="rounded bg-accent-copper px-1.5 py-0.5 text-xs font-semibold text-white">BETA</span>
 			</a>
 
-			<!-- Mobile menu button -->
-			<button
-				type="button"
-				class="inline-flex h-11 w-11 items-center justify-center rounded-premium-sm text-text-slate hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal sm:hidden"
-				aria-controls="mobile-menu"
-				aria-expanded={mobileMenuOpen}
-				onclick={toggleMobileMenu}
-			>
-				<span class="sr-only">Open main menu</span>
-				{#if mobileMenuOpen}
-					<X class="h-6 w-6" />
-				{:else}
-					<Menu class="h-6 w-6" />
-				{/if}
-			</button>
+			<div class="flex items-center gap-2 sm:gap-premium-lg">
+				<!--
+					Analysis Status Indicator — deliberately NOT width-gated, and deliberately a single
+					instance. It used to live only inside the `hidden … sm:flex` group, so on a phone the
+					one cross-tab signal that an analysis had finished (or failed) was display:none and
+					reachable only by opening the hamburger. It also has to stay a single instance at every
+					width: e2e/fixtures/helpers.js and 07-wasm-analysis.spec.js count
+					`button[aria-label="View all analyses"]` and its colour spans, so a mobile copy alongside
+					the desktop one would break them. It self-hides when there is nothing to report, so the
+					first-visit header is unchanged.
+				-->
+				<AnalysisStatusIndicator onNavigate={closeMobileMenu} />
 
-			<!-- Desktop navigation -->
-			<div class="hidden items-center space-x-premium-lg sm:flex">
-				<ul class="flex items-center space-x-premium-lg">
-					<li>
-						<a
-							class="rounded-premium-sm px-3 py-2 text-premium-brand font-medium text-text-rich transition-colors duration-premium hover:bg-brand-whisper hover:text-brand-royal"
-							href="http://help.datamonkey.org"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Help
-						</a>
-					</li>
-				</ul>
+				<!-- Desktop navigation -->
+				<div class="hidden items-center space-x-premium-lg sm:flex">
+					<ul class="flex items-center space-x-premium-lg">
+						<li>
+							<a
+								class="rounded-premium-sm px-3 py-2 text-premium-brand font-medium text-text-rich transition-colors duration-premium hover:bg-brand-whisper hover:text-brand-royal"
+								href="http://help.datamonkey.org"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Help
+							</a>
+						</li>
+					</ul>
 
-				<!-- Analysis Status Indicator -->
-				<AnalysisStatusIndicator />
+					<!-- Backend Connectivity Indicator -->
+					<BackendConnectivityIndicator />
+				</div>
 
-				<!-- Backend Connectivity Indicator -->
-				<BackendConnectivityIndicator />
+				<!-- Mobile menu button -->
+				<button
+					type="button"
+					class="inline-flex h-11 w-11 items-center justify-center rounded-premium-sm text-text-slate hover:bg-brand-whisper hover:text-brand-royal focus:outline-none focus:ring-2 focus:ring-brand-royal sm:hidden"
+					aria-controls="mobile-menu"
+					aria-expanded={mobileMenuOpen}
+					onclick={toggleMobileMenu}
+				>
+					<span class="sr-only">Open main menu</span>
+					{#if mobileMenuOpen}
+						<X class="h-6 w-6" />
+					{:else}
+						<Menu class="h-6 w-6" />
+					{/if}
+				</button>
 			</div>
 		</div>
 
@@ -153,7 +164,7 @@
 					<div class="flex items-center justify-between">
 						<span class="text-sm text-text-slate">Status</span>
 						<div class="flex items-center space-x-3">
-							<AnalysisStatusIndicator />
+							<!-- No AnalysisStatusIndicator here: it now sits in the header at every width. -->
 							<BackendConnectivityIndicator />
 						</div>
 					</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 		activeAnalysisProgress,
 		activeAnalyses
 	} from '../stores/analyses';
+	import { analysisConfig } from '../stores/analysisConfig';
 	import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
 	import { treeStore, addTree, updateTaggedTree, resetTrees } from '../stores/tree';
 	import { syncDescriptorStoresForFile as syncDescriptorStores } from '../lib/utils/descriptorSync.js';
@@ -57,7 +58,6 @@
 	let showAllHistory = false;
 	let activeTab = 'data'; // 'data', 'analyze', or 'results'
 	let selectedTree = 'nj';
-	let selectedMethod = 'FEL'; // Default selected method for configuration
 	let treeData = {};
 	let showBatchExport = false;
 	let analysisStartTime = null; // Track analysis start time for duration calculation
@@ -210,6 +210,10 @@
 			description: 'Estimation of selection pressure.'
 		}
 	};
+
+	// The dropdown's exact ids ('AxoMEME', 'aBSREL', ...). Analyses are stored upper-cased, so a
+	// restore has to be matched back to these or the <select> falls through to its placeholder.
+	const methodKeys = Object.keys(methodConfig);
 
 	// WHICH ANALYSIS THE DETAIL PANE SHOWS.
 	//
@@ -1241,12 +1245,16 @@
 				selectAnalysis(event.detail.analysisId);
 			}
 
-			// Handle re-run: set the method and file for the Analyze tab
+			// Handle re-run: restore the configuration that run was made with, not just its method.
 			if (event.detail.rerun && event.detail.tabName === 'analyze') {
-				// Set the method if provided
-				if (event.detail.method) {
-					selectedMethod = event.detail.method.toUpperCase();
-				}
+				// ONE source of truth for the configuration: the analysisConfig store. The page-level
+				// `selectedMethod` used to be a second one, and it never reached MethodSelector anyway
+				// (AnalyzeTab took the prop and did not forward it), which is how "Re-run" came to
+				// restore nothing at all.
+				const record = ($analysisStore.analyses ?? []).find(
+					(a) => a.id === event.detail.analysisId
+				);
+				analysisConfig.restoreFrom(record ?? { method: event.detail.method }, methodKeys);
 
 				// Set the current file if provided, and resync the descriptor stores so
 				// alignment/metrics/tree describe the re-run file rather than the
@@ -1447,7 +1455,6 @@
 					<AnalyzeTab
 						{methodConfig}
 						{runMethod}
-						{selectedMethod}
 						{hyphyOut}
 						{isStdOutVisible}
 						{toggleStdOut}
@@ -1468,8 +1475,7 @@
 						onChange={changeTab}
 					/>
 				{/if}
-			</div>
-		</div>
+			</div>		</div>
 	{/if}
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1424,44 +1424,48 @@
 			<SmartTabNavigation {activeTab} onChange={changeTab} />
 
 			<!-- Tab Content with Progressive Enhancement -->
-			{#if activeTab === 'data'}
-				<!-- Data Tab -->
-				<DataTab
-					{handleFileUpload}
-					{handleDemoFileSelect}
-					{validationError}
-					{fileMetricsJSON}
-					{handleValidated}
-					{handleUseRepaired}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'analyze'}
-				<!-- Analyze Tab -->
-				<AnalyzeTab
-					{methodConfig}
-					{runMethod}
-					{selectedMethod}
-					{hyphyOut}
-					{isStdOutVisible}
-					{toggleStdOut}
-					{showAllHistory}
-					{selectAnalysis}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'results'}
-				<!-- Results Tab -->
-				<ResultsTab
-					{selectedAnalysisId}
-					{selectAnalysis}
-					{showAllHistory}
-					{showBatchExport}
-					{toggleBatchExport}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{/if}
+			<!-- Single panel for all three tabs: only one is mounted at a time, so `aria-controls`
+			     on every tab resolves here and aria-labelledby tracks whichever tab is active. -->
+			<div id="tab-panel" role="tabpanel" aria-labelledby={'tab-' + activeTab}>
+				{#if activeTab === 'data'}
+					<!-- Data Tab -->
+					<DataTab
+						{handleFileUpload}
+						{handleDemoFileSelect}
+						{validationError}
+						{fileMetricsJSON}
+						{handleValidated}
+						{handleUseRepaired}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'analyze'}
+					<!-- Analyze Tab -->
+					<AnalyzeTab
+						{methodConfig}
+						{runMethod}
+						{selectedMethod}
+						{hyphyOut}
+						{isStdOutVisible}
+						{toggleStdOut}
+						{showAllHistory}
+						{selectAnalysis}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'results'}
+					<!-- Results Tab -->
+					<ResultsTab
+						{selectedAnalysisId}
+						{selectAnalysis}
+						{showAllHistory}
+						{showBatchExport}
+						{toggleBatchExport}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{/if}
+			</div>
 		</div>
 	{/if}
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1427,44 +1427,48 @@
 			<SmartTabNavigation {activeTab} onChange={changeTab} />
 
 			<!-- Tab Content with Progressive Enhancement -->
-			{#if activeTab === 'data'}
-				<!-- Data Tab -->
-				<DataTab
-					{handleFileUpload}
-					{handleDemoFileSelect}
-					{validationError}
-					{fileMetricsJSON}
-					{handleValidated}
-					{handleUseRepaired}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'analyze'}
-				<!-- Analyze Tab -->
-				<AnalyzeTab
-					{methodConfig}
-					{runMethod}
-					{selectedMethod}
-					{hyphyOut}
-					{isStdOutVisible}
-					{toggleStdOut}
-					{showAllHistory}
-					{selectAnalysis}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{:else if activeTab === 'results'}
-				<!-- Results Tab -->
-				<ResultsTab
-					{selectedAnalysisId}
-					{selectAnalysis}
-					{showAllHistory}
-					{showBatchExport}
-					{toggleBatchExport}
-					{activeTab}
-					onChange={changeTab}
-				/>
-			{/if}
+			<!-- Single panel for all three tabs: only one is mounted at a time, so `aria-controls`
+			     on every tab resolves here and aria-labelledby tracks whichever tab is active. -->
+			<div id="tab-panel" role="tabpanel" aria-labelledby={'tab-' + activeTab}>
+				{#if activeTab === 'data'}
+					<!-- Data Tab -->
+					<DataTab
+						{handleFileUpload}
+						{handleDemoFileSelect}
+						{validationError}
+						{fileMetricsJSON}
+						{handleValidated}
+						{handleUseRepaired}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'analyze'}
+					<!-- Analyze Tab -->
+					<AnalyzeTab
+						{methodConfig}
+						{runMethod}
+						{selectedMethod}
+						{hyphyOut}
+						{isStdOutVisible}
+						{toggleStdOut}
+						{showAllHistory}
+						{selectAnalysis}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{:else if activeTab === 'results'}
+					<!-- Results Tab -->
+					<ResultsTab
+						{selectedAnalysisId}
+						{selectAnalysis}
+						{showAllHistory}
+						{showBatchExport}
+						{toggleBatchExport}
+						{activeTab}
+						onChange={changeTab}
+					/>
+				{/if}
+			</div>
 		</div>
 	{/if}
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,11 @@
 		alignmentFileStore,
 		fileMetricsStore,
 		persistentFileStore,
-		currentFile
+		currentFile,
+		revalidatingFileId
 	} from '../stores/fileInfo';
+	import { uniqueFilename, resetFileInput } from '../lib/utils/fileIdentity.js';
+	import { applyAlignmentEdits } from '../lib/utils/alignmentEdits.js';
 	import {
 		analysisStore,
 		currentAnalysis,
@@ -25,6 +28,7 @@
 	import Aioli from '@biowasm/aioli';
 	import TreeSelector from '../lib/TreeSelector.svelte';
 	import ErrorHandler from '../lib/ErrorHandler.svelte';
+	import FileConflictPrompt from '../lib/FileConflictPrompt.svelte';
 	import DemoFileSelector from '../lib/DemoFileSelector.svelte';
 	import { X, FlaskConical, ExternalLink } from 'lucide-svelte';
 
@@ -688,6 +692,35 @@
 	let file;
 	let isStdOutVisible = false; // State for toggling stdout visibility
 	let validationError = null;
+	// Actions offered on the validation-error card. Currently only the alignment-edit restore.
+	let validationErrorActions = [];
+
+	// Same-name upload conflict, resolved by FileConflictPrompt.
+	let fileConflict = null;
+	let resolveFileConflict = null;
+
+	/**
+	 * The onConflict hook handed to persistentFileStore.uploadFile for genuine uploads.
+	 * Resolves to 'replace' or 'keep-both' once the user answers the modal.
+	 */
+	function promptForFileConflict({ existing, incoming }) {
+		const takenNames = ($persistentFileStore.files ?? []).map((f) => f.filename);
+		const analysisCount = ($analysisStore.analyses ?? []).filter(
+			(a) => a.fileId === existing?.id && a.method !== 'datareader'
+		).length;
+		fileConflict = {
+			filename: incoming.name,
+			keepBothName: uniqueFilename(incoming.name, takenNames),
+			analysisCount
+		};
+		return new Promise((resolve) => {
+			resolveFileConflict = (choice) => {
+				fileConflict = null;
+				resolveFileConflict = null;
+				resolve(choice);
+			};
+		});
+	}
 
 	async function handleFileUpload(event) {
 		// Track which entry point fired this call and which awaited step we're on,
@@ -698,7 +731,12 @@
 				? 'demo'
 				: event.isRepaired
 					? 'repair'
-					: 'upload';
+					: event.isEdited
+						? 'edit'
+						: 'upload';
+		// Captured before the first await: the reset in `finally` needs the element even on the
+		// failure path, and by then `event` may be long gone from the caller's scope.
+		const inputEvent = event;
 		let currentStage = 'init';
 		try {
 			// CLEAR THE PREVIOUS FILE'S ERROR FIRST, before any branch that can return early.
@@ -709,6 +747,7 @@
 			// screen beside the newly selected one. Same shape as the descriptorSync bug (#168): a
 			// reset placed after something that can exit early is not a reset. Issue #205.
 			validationError = null;
+			validationErrorActions = [];
 			// Errors no longer auto-dismiss (#187), which is right for someone who stepped away --
 			// but it means a stale error toast would otherwise outlive the file it describes.
 			// Successes are left alone: they link to a result that still exists.
@@ -801,7 +840,19 @@
 				// Pass any metadata from demo files
 				const metadata = event.isDemo ? event.metadata : {};
 				currentStage = 'storage';
-				fileId = await persistentFileStore.uploadFile(file, metadata);
+				// The conflict prompt is for GENUINE uploads only. A demo file, a repaired file and an
+				// edited alignment are all deliberate in-place replacements of a file the user just
+				// acted on — prompting there is noise, and for the edit case it would ask the user to
+				// confirm the replace they explicitly requested one click earlier.
+				const hooks = source === 'upload' ? { onConflict: promptForFileConflict } : {};
+				fileId = await persistentFileStore.uploadFile(file, metadata, hooks);
+
+				// 'Keep both' files the bytes under a new name. Keep the in-memory File in step so the
+				// alignment viewer and the export panel show the name it is actually stored under.
+				const storedRecord = ($persistentFileStore.files ?? []).find((f) => f.id === fileId);
+				if (storedRecord && storedRecord.filename !== file.name) {
+					file = new File([file], storedRecord.filename, { type: file.type });
+				}
 			} else {
 				fileId = event.fileId;
 			}
@@ -1132,7 +1183,51 @@
 					message: isTreeError ? 'Tree parsing issue' : 'File processing error'
 				}
 			};
+
+			// An edit that the reader rejects is a dead end otherwise: the edited bytes are already in
+			// IndexedDB under the same id, so there is nothing left on screen holding the pre-edit
+			// alignment. Offer to put it back — as an action, never automatically. Auto-restoring
+			// would silently discard work the user just did.
+			if (event.isEdited && event.previous instanceof File) {
+				const previous = event.previous;
+				validationErrorActions = [
+					{
+						id: 'restore-pre-edit',
+						label: 'Restore the alignment from before these edits',
+						run: () => handleFileUpload({ target: { files: [previous] }, isEdited: true, previous })
+					}
+				];
+			}
+		} finally {
+			// MUST be in finally. Re-selecting the same path fires no change event, so a file that
+			// failed could not be retried after the user corrected it outside the browser — and the
+			// failure loop is exactly the case this exists for.
+			resetFileInput(inputEvent);
+			// The Run gate is cleared however the re-read ended: success, rejection or throw.
+			revalidatingFileId.set(null);
 		}
+	}
+
+	/**
+	 * "Save edits" in the alignment viewer. The viewer now hands the edited alignment back rather
+	 * than writing the stores itself, because writing them left `fileMetricsStore.canonicalFasta`
+	 * — the exact bytes every runner submits — describing the PRE-edit alignment. Re-entering the
+	 * normal upload path is the whole fix: it clears the descriptor stores, re-runs datareader,
+	 * regenerates canonicalFasta and files a fresh datareader analysis.
+	 */
+	function handleAlignmentEdited(event) {
+		const { file: editedFile, previous } = event.detail ?? {};
+		if (!editedFile) return;
+
+		validationErrorActions = [];
+		file = editedFile;
+		return applyAlignmentEdits(editedFile, {
+			// uploadFile replaces the same-name record in place, so the id does not change and the
+			// analysis history stays attached.
+			fileId: $currentFile?.id ?? null,
+			setRevalidating: (id) => revalidatingFileId.set(id),
+			revalidate: (f) => handleFileUpload({ target: { files: [f] }, isEdited: true, previous })
+		});
 	}
 
 	// Toggle the stdout visibility
@@ -1430,9 +1525,11 @@
 					{handleFileUpload}
 					{handleDemoFileSelect}
 					{validationError}
+					{validationErrorActions}
 					{fileMetricsJSON}
 					{handleValidated}
 					{handleUseRepaired}
+					{handleAlignmentEdited}
 					{activeTab}
 					onChange={changeTab}
 				/>
@@ -1465,6 +1562,9 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Rendered at the page root so it overlays whichever tab is open. -->
+<FileConflictPrompt conflict={fileConflict} on:choose={(e) => resolveFileConflict?.(e.detail)} />
 
 <style>
 	.loader {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -884,7 +884,10 @@
 				'Analyzing file structure...'
 			);
 			currentStage = 'exec';
-			result = await cliObj.exec('hyphy LIBPATH=/res/ ' + inputFiles[1]);
+			// argv-array form: Aioli only splits on spaces when the second argument is null.
+			// The datareader takes no arguments with spaces today, but the array form is what a
+			// future `--code <name>` (see UX item 1.2) would need, and it costs nothing now.
+			result = await cliObj.exec('hyphy', ['LIBPATH=/res/', inputFiles[1]]);
 			hyphyOut = await result.stdout;
 
 			// Extract meaningful error from HyPhy stdout for better error reporting

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,11 @@
 		alignmentFileStore,
 		fileMetricsStore,
 		persistentFileStore,
-		currentFile
+		currentFile,
+		revalidatingFileId
 	} from '../stores/fileInfo';
+	import { uniqueFilename, resetFileInput } from '../lib/utils/fileIdentity.js';
+	import { applyAlignmentEdits } from '../lib/utils/alignmentEdits.js';
 	import {
 		analysisStore,
 		currentAnalysis,
@@ -26,6 +29,7 @@
 	import Aioli from '@biowasm/aioli';
 	import TreeSelector from '../lib/TreeSelector.svelte';
 	import ErrorHandler from '../lib/ErrorHandler.svelte';
+	import FileConflictPrompt from '../lib/FileConflictPrompt.svelte';
 	import DemoFileSelector from '../lib/DemoFileSelector.svelte';
 	import { X, FlaskConical, ExternalLink } from 'lucide-svelte';
 
@@ -692,6 +696,35 @@
 	let file;
 	let isStdOutVisible = false; // State for toggling stdout visibility
 	let validationError = null;
+	// Actions offered on the validation-error card. Currently only the alignment-edit restore.
+	let validationErrorActions = [];
+
+	// Same-name upload conflict, resolved by FileConflictPrompt.
+	let fileConflict = null;
+	let resolveFileConflict = null;
+
+	/**
+	 * The onConflict hook handed to persistentFileStore.uploadFile for genuine uploads.
+	 * Resolves to 'replace' or 'keep-both' once the user answers the modal.
+	 */
+	function promptForFileConflict({ existing, incoming }) {
+		const takenNames = ($persistentFileStore.files ?? []).map((f) => f.filename);
+		const analysisCount = ($analysisStore.analyses ?? []).filter(
+			(a) => a.fileId === existing?.id && a.method !== 'datareader'
+		).length;
+		fileConflict = {
+			filename: incoming.name,
+			keepBothName: uniqueFilename(incoming.name, takenNames),
+			analysisCount
+		};
+		return new Promise((resolve) => {
+			resolveFileConflict = (choice) => {
+				fileConflict = null;
+				resolveFileConflict = null;
+				resolve(choice);
+			};
+		});
+	}
 
 	async function handleFileUpload(event) {
 		// Track which entry point fired this call and which awaited step we're on,
@@ -702,7 +735,12 @@
 				? 'demo'
 				: event.isRepaired
 					? 'repair'
-					: 'upload';
+					: event.isEdited
+						? 'edit'
+						: 'upload';
+		// Captured before the first await: the reset in `finally` needs the element even on the
+		// failure path, and by then `event` may be long gone from the caller's scope.
+		const inputEvent = event;
 		let currentStage = 'init';
 		try {
 			// CLEAR THE PREVIOUS FILE'S ERROR FIRST, before any branch that can return early.
@@ -713,6 +751,7 @@
 			// screen beside the newly selected one. Same shape as the descriptorSync bug (#168): a
 			// reset placed after something that can exit early is not a reset. Issue #205.
 			validationError = null;
+			validationErrorActions = [];
 			// Errors no longer auto-dismiss (#187), which is right for someone who stepped away --
 			// but it means a stale error toast would otherwise outlive the file it describes.
 			// Successes are left alone: they link to a result that still exists.
@@ -805,7 +844,19 @@
 				// Pass any metadata from demo files
 				const metadata = event.isDemo ? event.metadata : {};
 				currentStage = 'storage';
-				fileId = await persistentFileStore.uploadFile(file, metadata);
+				// The conflict prompt is for GENUINE uploads only. A demo file, a repaired file and an
+				// edited alignment are all deliberate in-place replacements of a file the user just
+				// acted on — prompting there is noise, and for the edit case it would ask the user to
+				// confirm the replace they explicitly requested one click earlier.
+				const hooks = source === 'upload' ? { onConflict: promptForFileConflict } : {};
+				fileId = await persistentFileStore.uploadFile(file, metadata, hooks);
+
+				// 'Keep both' files the bytes under a new name. Keep the in-memory File in step so the
+				// alignment viewer and the export panel show the name it is actually stored under.
+				const storedRecord = ($persistentFileStore.files ?? []).find((f) => f.id === fileId);
+				if (storedRecord && storedRecord.filename !== file.name) {
+					file = new File([file], storedRecord.filename, { type: file.type });
+				}
 			} else {
 				fileId = event.fileId;
 			}
@@ -1139,7 +1190,51 @@
 					message: isTreeError ? 'Tree parsing issue' : 'File processing error'
 				}
 			};
+
+			// An edit that the reader rejects is a dead end otherwise: the edited bytes are already in
+			// IndexedDB under the same id, so there is nothing left on screen holding the pre-edit
+			// alignment. Offer to put it back — as an action, never automatically. Auto-restoring
+			// would silently discard work the user just did.
+			if (event.isEdited && event.previous instanceof File) {
+				const previous = event.previous;
+				validationErrorActions = [
+					{
+						id: 'restore-pre-edit',
+						label: 'Restore the alignment from before these edits',
+						run: () => handleFileUpload({ target: { files: [previous] }, isEdited: true, previous })
+					}
+				];
+			}
+		} finally {
+			// MUST be in finally. Re-selecting the same path fires no change event, so a file that
+			// failed could not be retried after the user corrected it outside the browser — and the
+			// failure loop is exactly the case this exists for.
+			resetFileInput(inputEvent);
+			// The Run gate is cleared however the re-read ended: success, rejection or throw.
+			revalidatingFileId.set(null);
 		}
+	}
+
+	/**
+	 * "Save edits" in the alignment viewer. The viewer now hands the edited alignment back rather
+	 * than writing the stores itself, because writing them left `fileMetricsStore.canonicalFasta`
+	 * — the exact bytes every runner submits — describing the PRE-edit alignment. Re-entering the
+	 * normal upload path is the whole fix: it clears the descriptor stores, re-runs datareader,
+	 * regenerates canonicalFasta and files a fresh datareader analysis.
+	 */
+	function handleAlignmentEdited(event) {
+		const { file: editedFile, previous } = event.detail ?? {};
+		if (!editedFile) return;
+
+		validationErrorActions = [];
+		file = editedFile;
+		return applyAlignmentEdits(editedFile, {
+			// uploadFile replaces the same-name record in place, so the id does not change and the
+			// analysis history stays attached.
+			fileId: $currentFile?.id ?? null,
+			setRevalidating: (id) => revalidatingFileId.set(id),
+			revalidate: (f) => handleFileUpload({ target: { files: [f] }, isEdited: true, previous })
+		});
 	}
 
 	// Toggle the stdout visibility
@@ -1444,9 +1539,11 @@
 						{handleFileUpload}
 						{handleDemoFileSelect}
 						{validationError}
+						{validationErrorActions}
 						{fileMetricsJSON}
 						{handleValidated}
 						{handleUseRepaired}
+						{handleAlignmentEdited}
 						{activeTab}
 						onChange={changeTab}
 					/>
@@ -1475,9 +1572,11 @@
 						onChange={changeTab}
 					/>
 				{/if}
-			</div>		</div>
-	{/if}
+			</div>		</div>	{/if}
 </div>
+
+<!-- Rendered at the page root so it overlays whichever tab is open. -->
+<FileConflictPrompt conflict={fileConflict} on:choose={(e) => resolveFileConflict?.(e.detail)} />
 
 <style>
 	.loader {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 		activeAnalysisProgress,
 		activeAnalyses
 	} from '../stores/analyses';
+	import { analysisConfig } from '../stores/analysisConfig';
 	import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
 	import { treeStore, addTree, updateTaggedTree, resetTrees } from '../stores/tree';
 	import { syncDescriptorStoresForFile as syncDescriptorStores } from '../lib/utils/descriptorSync.js';
@@ -57,7 +58,6 @@
 	let showAllHistory = false;
 	let activeTab = 'data'; // 'data', 'analyze', or 'results'
 	let selectedTree = 'nj';
-	let selectedMethod = 'FEL'; // Default selected method for configuration
 	let treeData = {};
 	let showBatchExport = false;
 	let analysisStartTime = null; // Track analysis start time for duration calculation
@@ -210,6 +210,10 @@
 			description: 'Estimation of selection pressure.'
 		}
 	};
+
+	// The dropdown's exact ids ('AxoMEME', 'aBSREL', ...). Analyses are stored upper-cased, so a
+	// restore has to be matched back to these or the <select> falls through to its placeholder.
+	const methodKeys = Object.keys(methodConfig);
 
 	// WHICH ANALYSIS THE DETAIL PANE SHOWS.
 	//
@@ -1238,12 +1242,16 @@
 				selectAnalysis(event.detail.analysisId);
 			}
 
-			// Handle re-run: set the method and file for the Analyze tab
+			// Handle re-run: restore the configuration that run was made with, not just its method.
 			if (event.detail.rerun && event.detail.tabName === 'analyze') {
-				// Set the method if provided
-				if (event.detail.method) {
-					selectedMethod = event.detail.method.toUpperCase();
-				}
+				// ONE source of truth for the configuration: the analysisConfig store. The page-level
+				// `selectedMethod` used to be a second one, and it never reached MethodSelector anyway
+				// (AnalyzeTab took the prop and did not forward it), which is how "Re-run" came to
+				// restore nothing at all.
+				const record = ($analysisStore.analyses ?? []).find(
+					(a) => a.id === event.detail.analysisId
+				);
+				analysisConfig.restoreFrom(record ?? { method: event.detail.method }, methodKeys);
 
 				// Set the current file if provided, and resync the descriptor stores so
 				// alignment/metrics/tree describe the re-run file rather than the
@@ -1441,7 +1449,6 @@
 				<AnalyzeTab
 					{methodConfig}
 					{runMethod}
-					{selectedMethod}
 					{hyphyOut}
 					{isStdOutVisible}
 					{toggleStdOut}

--- a/src/stores/analyses.js
+++ b/src/stores/analyses.js
@@ -2,6 +2,54 @@ import { derived, writable } from 'svelte/store';
 import { analysisStorage } from '../lib/utils/indexedDBStorage';
 import { browser } from '$app/environment';
 
+/**
+ * LIVENESS, and why a local run needs a pulse.
+ *
+ * IndexedDB is shared by every tab of the origin, but `activeAnalyses` is per-tab memory. So a
+ * second tab opening while the first tab is mid-run used to read the first tab's record — which sits
+ * at 'pending'/'wasm' for the whole run, because progress updates are in-memory only — and mark it
+ * 'interrupted', throwing away hours of compute in a tab it does not own and offering a Re-run that
+ * would duplicate it.
+ *
+ * The owning tab therefore stamps `lastHeartbeatAt` while it is actually running, and the sweep only
+ * reaps records whose pulse has stopped.
+ */
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * How long a record may go unstamped before another tab may declare it dead.
+ *
+ * Six missed ticks, not three. AxoMEME runs on the main thread and only yields between batches
+ * (AxomemeAnalysisRunner.yieldToBrowser), so a healthy run can starve the interval for seconds at a
+ * time. A margin that is too tight reaps live work; one that is too loose only delays cleanup of a
+ * genuinely dead tab's record by a few seconds.
+ */
+const HEARTBEAT_STALE_MS = 60_000;
+
+/** Statuses the interrupted-sweep considers unfinished. */
+const REAPABLE_STATUSES = ['pending', 'initializing', 'running', 'processing', 'saving'];
+
+/** Statuses a run can stop in — a record in one of these is nobody's live work. */
+const TERMINAL_STATUSES = ['completed', 'error', 'cancelled', 'interrupted', 'connection_lost'];
+
+/**
+ * Is this stored record safe for THIS tab to mark interrupted?
+ *
+ * One function, used by both the filter and the map below, because when those were two copies of the
+ * same predicate they could drift apart silently.
+ *
+ * The `?? 0` is load-bearing twice: a record written before heartbeats existed has no pulse and is by
+ * definition from a session that is gone, so it must still be reaped — and that is also what keeps
+ * every pre-existing cleanup test meaningful without hand-editing fixtures.
+ */
+function isReapable(analysis) {
+	return (
+		analysis?.metadata?.executionMode === 'wasm' &&
+		REAPABLE_STATUSES.includes(analysis.status) &&
+		Date.now() - (analysis.lastHeartbeatAt ?? 0) > HEARTBEAT_STALE_MS
+	);
+}
+
 function createAnalysisStore() {
 	const { subscribe, set, update } = writable({
 		analyses: [],
@@ -11,6 +59,58 @@ function createAnalysisStore() {
 		// Single unified tracking for active analyses
 		activeAnalyses: [] // Array of active analysis objects with progress tracking
 	});
+
+	/** Interval that stamps this tab's live local runs. Null whenever there are none. */
+	let heartbeatTimer = null;
+
+	/** Read state synchronously. `update` with an unchanged return is the pattern used below. */
+	function readState() {
+		let snapshot;
+		update((state) => {
+			snapshot = state;
+			return state;
+		});
+		return snapshot;
+	}
+
+	function liveLocalRuns() {
+		return (readState().activeAnalyses || []).filter(
+			(a) => a?.metadata?.executionMode === 'wasm' && !TERMINAL_STATUSES.includes(a.status)
+		);
+	}
+
+	async function heartbeatTick() {
+		// Iterate activeAnalyses ONLY. Walking the full analyses list would rewrite completed records,
+		// which carry their whole result payload — megabytes, every ten seconds.
+		for (const entry of liveLocalRuns()) {
+			try {
+				const stored = await analysisStorage.getAnalysis(entry.id);
+				if (!stored) continue;
+				// Read-modify-write: a completion landing between this read and the write would be
+				// written back as unfinished, so never touch a record that has already stopped.
+				if (TERMINAL_STATUSES.includes(stored.status)) continue;
+				await analysisStorage.saveAnalysis({ ...stored, lastHeartbeatAt: Date.now() });
+			} catch (error) {
+				// A missed beat costs nothing; HEARTBEAT_STALE_MS allows for six of them.
+				console.error(`Error stamping heartbeat for ${entry.id}:`, error);
+			}
+		}
+	}
+
+	function startHeartbeat() {
+		if (!browser || heartbeatTimer) return;
+		heartbeatTimer = setInterval(() => {
+			heartbeatTick();
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+
+	/** Stop the pulse once this tab has no local run left to vouch for. */
+	function stopHeartbeatIfIdle() {
+		if (!heartbeatTimer) return;
+		if (liveLocalRuns().length > 0) return;
+		clearInterval(heartbeatTimer);
+		heartbeatTimer = null;
+	}
 
 	return {
 		subscribe,
@@ -240,6 +340,8 @@ function createAnalysisStore() {
 					...state,
 					activeAnalyses: (state.activeAnalyses || []).filter((a) => a.id !== analysisId)
 				}));
+
+				stopHeartbeatIfIdle();
 			} catch (error) {
 				console.error('Error cancelling analysis:', error);
 				throw error;
@@ -347,6 +449,12 @@ function createAnalysisStore() {
 				};
 			});
 
+			// A local run must be protected from the instant it starts, not from the first tick ten
+			// seconds later — otherwise a tab opened in that window still reaps it.
+			if (metadata.executionMode === 'wasm') {
+				startHeartbeat();
+			}
+
 			// Persist metadata to IndexedDB (executionMode, jobId, etc.)
 			// This is critical for cleanupInterruptedAnalyses and backend reconnection to work
 			if (browser && metadata.executionMode) {
@@ -361,6 +469,12 @@ function createAnalysisStore() {
 							},
 							updatedAt: Date.now()
 						};
+
+						// Only local runs get a pulse. A server job's liveness is the server's to report,
+						// and the sweep never touches backend records.
+						if (metadata.executionMode === 'wasm') {
+							updatedAnalysis.lastHeartbeatAt = Date.now();
+						}
 						await analysisStorage.saveAnalysis(updatedAnalysis);
 						console.log(
 							`📊 [AnalysisStore] Persisted metadata (executionMode=${metadata.executionMode}, jobId=${metadata.jobId || 'n/a'}) for ${analysisId.slice(0, 8)}...`
@@ -603,6 +717,9 @@ function createAnalysisStore() {
 				};
 			});
 
+			// The entry is terminal now, so this tab may have nothing left to vouch for.
+			stopHeartbeatIfIdle();
+
 			// Persist to IndexedDB and server
 			const currentLogs = activeAnalysisData?.logs || [];
 			const currentResult = activeAnalysisData?.result || null;
@@ -656,6 +773,7 @@ function createAnalysisStore() {
 					activeAnalyses: newActiveAnalyses
 				};
 			});
+			stopHeartbeatIfIdle();
 		},
 
 		// Clear all analyses
@@ -703,12 +821,11 @@ function createAnalysisStore() {
 				return;
 			}
 
-			// Find WASM analyses that were running/pending (these were interrupted)
-			const interruptedAnalyses = analyses.filter(
-				(a) =>
-					a.metadata?.executionMode === 'wasm' &&
-					['pending', 'initializing', 'running', 'processing', 'saving'].includes(a.status)
-			);
+			// Find local runs that stopped without finishing.
+			//
+			// The heartbeat check is what keeps this tab out of another tab's business: IndexedDB is
+			// shared across tabs, so without it, opening a second tab reaped the first tab's live run.
+			const interruptedAnalyses = analyses.filter(isReapable);
 
 			if (interruptedAnalyses.length === 0) {
 				console.log('📊 [AnalysisStore] No interrupted analyses found');
@@ -720,25 +837,29 @@ function createAnalysisStore() {
 			);
 
 			// Update each interrupted analysis
+			const reapedIds = new Set(interruptedAnalyses.map((a) => a.id));
 			const updatedAnalyses = analyses.map((analysis) => {
-				if (
-					analysis.metadata?.executionMode === 'wasm' &&
-					['pending', 'initializing', 'running', 'processing', 'saving'].includes(analysis.status)
-				) {
+				if (isReapable(analysis)) {
 					return {
 						...analysis,
 						status: 'interrupted',
 						interruptedAt: new Date().getTime(),
-						error: 'Analysis was interrupted by page refresh',
+						// True of both causes. A reaped record is no longer necessarily a refresh — it may
+						// be a tab that was closed, or one whose heartbeat stopped.
+						error: 'This run stopped when its browser tab closed or reloaded.',
 						updatedAt: new Date().getTime()
 					};
 				}
 				return analysis;
 			});
 
-			// Persist updated analyses to IndexedDB
+			// Persist the records this sweep actually changed.
+			//
+			// Keyed on the ids reaped above, not on `status === 'interrupted'`: that test also matched
+			// records interrupted in some earlier session, so every page load rewrote them — whole
+			// objects, results and all — for no change.
 			for (const analysis of updatedAnalyses) {
-				if (analysis.status === 'interrupted') {
+				if (reapedIds.has(analysis.id)) {
 					try {
 						await analysisStorage.saveAnalysis(analysis);
 						console.log(

--- a/src/stores/analysisConfig.js
+++ b/src/stores/analysisConfig.js
@@ -1,0 +1,161 @@
+/**
+ * analysisConfig — the analysis configuration a user has built up, held outside the component.
+ *
+ * WHY THIS EXISTS. +page.svelte mounts <AnalyzeTab> inside an {#if activeTab === 'analyze'} block, so
+ * Svelte destroys it on every tab switch. MethodSelector kept the whole configuration in component
+ * locals, which meant a glance at the Results tab silently discarded the method, the genetic code,
+ * the execution mode and every advanced option — and the dropdown came back on "Select an analysis
+ * method" as though nothing had been chosen.
+ *
+ * Deliberately NOT localStorage. Nothing in src/ persists to it, and the defect is tab switching
+ * within a session, not reload. A configuration that outlived a reload would also outlive the file it
+ * was built for, which is worse than losing it.
+ */
+
+import { writable, get } from 'svelte/store';
+import { METHOD_ADVANCED_OPTIONS } from '../lib/config/methodAdvancedOptions.js';
+
+const DEFAULTS = {
+	selectedMethod: null,
+	geneticCode: 'Universal',
+	geneticCodeId: 0,
+	executionMode: 'local',
+	methodOptions: {},
+	// Set by restoreFrom so the selector can say what it put back, and cleared once it has.
+	restoredFromAnalysisId: null
+};
+
+/** Keys that belong to the top level of the configuration rather than to a method's option bag. */
+const TOP_LEVEL_KEYS = new Set(['method', 'geneticCode', 'geneticCodeId', 'executionMode']);
+
+function defaults() {
+	return { ...DEFAULTS, methodOptions: {} };
+}
+
+/**
+ * The settings a re-run should restore, from whichever shape the runner persisted.
+ *
+ * ORDER IS LOAD-BEARING. BackendAnalysisRunner stores `parameters` in the BACKEND's shape
+ * (gencodeid, 'ds-variation', 'branch-set') and keeps the UI's own config under `originalConfig`;
+ * WasmAnalysisRunner stores the UI config directly as `parameters`. Feeding backend-shaped keys into
+ * methodOptions would inject controls the UI never had and silently change what the next run
+ * submits, so originalConfig wins whenever it exists.
+ */
+function savedSettingsFor(analysis) {
+	const args = analysis?.metadata?.arguments;
+	if (!args) return null;
+	return args.originalConfig ?? args.parameters ?? null;
+}
+
+function createAnalysisConfigStore() {
+	const store = writable(defaults());
+	const { subscribe, set, update } = store;
+
+	return {
+		subscribe,
+		set,
+		update,
+
+		/** Back to a blank configuration (a new file, or a test). */
+		reset() {
+			set(defaults());
+		},
+
+		/**
+		 * Rehydrate from a previous analysis so "Re-run" means what it says.
+		 *
+		 * `methodKeys` is the dropdown's own list of method ids (Object.keys(methodConfig)). Analyses
+		 * are stored with `method.toUpperCase()`, but the selector's values are the config's exact
+		 * casing — 'AxoMEME', 'aBSREL' — so without this the restored method would never match an
+		 * <option> and the dropdown would fall back to its placeholder.
+		 *
+		 * Returns `{ method, restoredSettings }`. `restoredSettings` is false when the record carries
+		 * no arguments at all — AxomemeAnalysisRunner calls startAnalysisTracking with four arguments,
+		 * so its records have no `metadata.arguments` — and the caller must not then claim settings
+		 * were restored.
+		 */
+		restoreFrom(analysis, methodKeys = []) {
+			const raw = analysis?.method ? String(analysis.method) : null;
+			const method = raw
+				? (methodKeys.find((k) => k.toLowerCase() === raw.toLowerCase()) ?? raw)
+				: null;
+			const saved = savedSettingsFor(analysis);
+
+			update((state) => {
+				const next = {
+					...state,
+					selectedMethod: method ?? state.selectedMethod,
+					restoredFromAnalysisId: analysis?.id ?? null,
+					restoredSummary: ''
+				};
+
+				if (!saved || !method) return next;
+
+				if (typeof saved.geneticCode === 'string') next.geneticCode = saved.geneticCode;
+				if (Number.isFinite(saved.geneticCodeId)) next.geneticCodeId = saved.geneticCodeId;
+				if (saved.executionMode === 'local' || saved.executionMode === 'backend') {
+					next.executionMode = saved.executionMode;
+				}
+
+				// Everything else is a method option — but only if the method still HAS that option.
+				// An option removed in a later release must not resurrect a control that no longer
+				// exists, and a backend-shaped key must never reach the UI's bag.
+				const schema = METHOD_ADVANCED_OPTIONS[method.toLowerCase()] ?? {};
+				const restored = {};
+				for (const [key, value] of Object.entries(saved)) {
+					if (TOP_LEVEL_KEYS.has(key)) continue;
+					if (!(key in schema)) continue;
+					restored[key] = value;
+				}
+
+				next.methodOptions = {
+					...state.methodOptions,
+					[method]: { ...(state.methodOptions?.[method] ?? {}), ...restored }
+				};
+				// Built HERE, from the values that actually came back — not later from store state,
+				// where a default would be indistinguishable from a restored value and the notice
+				// would claim to have restored settings a record never carried.
+				next.restoredSummary = describeRestoredSettings(method, {
+					geneticCode: typeof saved.geneticCode === 'string' ? saved.geneticCode : null,
+					options: restored
+				});
+				return next;
+			});
+
+			return { method, restoredSettings: Boolean(saved && method) };
+		},
+
+		/** Current value, for the one place that hydrates component locals (MethodSelector.onMount). */
+		current() {
+			return get(store);
+		}
+	};
+}
+
+export const analysisConfig = createAnalysisConfigStore();
+
+/**
+ * A one-line, human summary of what a restore actually put back.
+ *
+ * Takes the RESTORED values, not the store's current state: a default and a restored value look
+ * identical once they are in the store, and a summary built from state would tell an AxoMEME re-run
+ * that its genetic code had been restored when the record carried no settings at all.
+ *
+ * @param {string} method
+ * @param {{geneticCode: string|null, options: Record<string, unknown>}} restored
+ */
+export function describeRestoredSettings(method, restored) {
+	const parts = [];
+	const schema = METHOD_ADVANCED_OPTIONS[String(method ?? '').toLowerCase()] ?? {};
+	if (restored?.geneticCode) parts.push(`genetic code ${restored.geneticCode}`);
+	for (const [key, value] of Object.entries(restored?.options ?? {})) {
+		if (value === '' || value === null || value === undefined) continue;
+		// Interactive-tree payloads are newick strings and branch-name arrays; naming them is
+		// meaningless to a reader and unbounded in length.
+		if (schema[key]?.type === 'interactive-tree' || Array.isArray(value)) continue;
+		if (typeof value === 'object') continue;
+		parts.push(`${(schema[key]?.label ?? key).toLowerCase()} ${value}`);
+	}
+	// Three is a line, not a manifest. The controls themselves are right below it.
+	return parts.slice(0, 3).join(', ');
+}

--- a/src/stores/fileInfo.js
+++ b/src/stores/fileInfo.js
@@ -2,10 +2,22 @@ import { writable, derived } from 'svelte/store';
 import { fileStorage } from '../lib/utils/indexedDBStorage';
 import { browser } from '$app/environment';
 import { trackEvent } from '../lib/utils/analytics.js';
+import { uniqueFilename } from '../lib/utils/fileIdentity.js';
 
 // Basic stores for immediate usage
 export const alignmentFileStore = writable(null);
 export const fileMetricsStore = writable(null);
+
+/**
+ * The id of the file currently being re-read after an in-place edit, or null.
+ *
+ * In-memory on purpose. The obvious alternative — gate the Run button on a 'pending' datareader
+ * record — wedges the button forever if that record is orphaned: cleanupInterruptedAnalyses
+ * (stores/analyses.js) only reconciles records whose metadata.executionMode is 'wasm', and
+ * datareader records carry no metadata at all. A flag that dies with the tab cannot outlive the
+ * work it describes.
+ */
+export const revalidatingFileId = writable(null);
 
 // Persistent file store
 function createPersistentFileStore() {
@@ -34,8 +46,19 @@ function createPersistentFileStore() {
 			}
 		},
 
-		// Upload a file to browser storage
-		async uploadFile(file) {
+		/**
+		 * Upload a file to browser storage.
+		 *
+		 * @param {File} file
+		 * @param {Object} metadata - persisted alongside the record (demo provenance, etc). This used
+		 *   to be dropped on the floor: +page.svelte has always passed it, uploadFile has always
+		 *   taken one parameter, so demo files were indistinguishable from user uploads on disk.
+		 * @param {{onConflict?: (ctx: {existing: Object, incoming: File}) => Promise<'replace'|'keep-both'>}} hooks
+		 *   Optional. When a same-name record exists AND a hook is supplied, the caller decides.
+		 *   With no hook the behaviour is exactly what it was (silent in-place replace), which is
+		 *   what FileManager, the demo loader and the alignment-edit save all want.
+		 */
+		async uploadFile(file, metadata = {}, { onConflict } = {}) {
 			if (!browser) return; // Only run in browser
 
 			update((state) => ({ ...state, isLoading: true, error: null }));
@@ -43,15 +66,35 @@ function createPersistentFileStore() {
 			try {
 				// Check if a file with the same name already exists
 				let existingFileId = null;
+				let existingRecord = null;
+				let takenNames = [];
 
 				update((state) => {
 					// Check current state for a file with the same name
 					const existing = state.files.find((f) => f.filename === file.name);
 					if (existing) {
 						existingFileId = existing.id;
+						existingRecord = existing;
 					}
+					takenNames = state.files.map((f) => f.filename);
 					return state;
 				});
+
+				let fileToSave = file;
+				let effectiveMetadata = metadata;
+
+				if (existingFileId && typeof onConflict === 'function') {
+					const choice = await onConflict({ existing: existingRecord, incoming: file });
+					if (choice === 'keep-both') {
+						// Uniquify BEFORE forceNew reaches saveFile — see uniqueFilename's note. A new
+						// name means a new id, which means the new file starts with no analyses. That is
+						// the point: the old runs describe the old contents.
+						const uniqueName = uniqueFilename(file.name, takenNames);
+						fileToSave = new File([file], uniqueName, { type: file.type });
+						effectiveMetadata = { ...metadata, forceNew: true };
+						existingFileId = null;
+					}
+				}
 
 				let fileId;
 
@@ -73,7 +116,8 @@ function createPersistentFileStore() {
 						content: arrayBuffer,
 						size: file.size,
 						type: file.type,
-						updatedAt: new Date().getTime()
+						updatedAt: new Date().getTime(),
+						...effectiveMetadata
 					};
 
 					// Save updated file
@@ -81,7 +125,7 @@ function createPersistentFileStore() {
 					fileId = existingFileId;
 				} else {
 					// Save as new file
-					fileId = await fileStorage.saveFile(file);
+					fileId = await fileStorage.saveFile(fileToSave, effectiveMetadata);
 				}
 
 				// Get the file metadata (without content)

--- a/src/test/alignment-edit-revalidation.test.js
+++ b/src/test/alignment-edit-revalidation.test.js
@@ -1,0 +1,186 @@
+/**
+ * "Save edits" in the alignment viewer used to write the edited FASTA to IndexedDB and to
+ * alignmentFileStore, say "Saved", and stop.
+ *
+ * Nothing re-ran datareader. `fileMetricsStore.canonicalFasta` — the exact string AnalyzeTab hands
+ * to every runner, local and remote — kept describing the alignment BEFORE the edit. So deleting a
+ * contaminated sequence and pressing Run produced a result computed with that sequence still in
+ * the alignment, while the viewer showed it gone.
+ *
+ * The two assertions that matter here are (a) the edit reaches revalidation at all, and (b) the
+ * pre-edit canonicalFasta is gone before revalidation resolves — a runner that fires mid-re-read
+ * must find nothing rather than the old bytes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('alivibe', async () => ({
+	AliVibe: (await import('./stubs/AliVibeStub.svelte')).default
+}));
+vi.mock('../lib/utils/indexedDBStorage', () => ({
+	fileStorage: {
+		saveFile: vi.fn(async () => 'id'),
+		updateFile: vi.fn(async () => 'id'),
+		getFile: vi.fn(async () => ({ id: 'id' })),
+		getFileMetadata: vi.fn(async () => ({ id: 'id' })),
+		getAllFiles: vi.fn(async () => []),
+		deleteFile: vi.fn(async () => {}),
+		fileRecordToFile: vi.fn(async () => null)
+	}
+}));
+vi.mock('../lib/utils/analytics.js', () => ({ trackEvent: vi.fn() }));
+
+const { buildEditedAlignmentFile, applyAlignmentEdits } = await import(
+	'../lib/utils/alignmentEdits.js'
+);
+const { fileMetricsStore, revalidatingFileId, alignmentFileStore } = await import(
+	'../stores/fileInfo.js'
+);
+const { fileStorage } = await import('../lib/utils/indexedDBStorage');
+const AlignmentViewerHarness = (await import('./stubs/AlignmentViewerHarness.svelte')).default;
+
+// jsdom's Blob implements neither text() nor arrayBuffer().
+if (typeof Blob.prototype.text !== 'function') {
+	Blob.prototype.text = function text() {
+		return Promise.resolve('>a\nACGACG\n>b\nACGTTT\n');
+	};
+}
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+	Blob.prototype.arrayBuffer = function arrayBuffer() {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
+}
+
+const editedFile = () =>
+	new File(['>a\nACGACG\n>b\nACGTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+
+describe('buildEditedAlignmentFile', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	it('keeps the original filename so the record is replaced in place', () => {
+		const f = buildEditedAlignmentFile([{ name: 'a', seq: 'ACG' }], 'CD2-slim.fna');
+		expect(f.name).toBe('CD2-slim.fna');
+	});
+
+	it('refuses to build an empty alignment', () => {
+		expect(() => buildEditedAlignmentFile([], 'x.fasta')).toThrow(/No alignment data/i);
+	});
+});
+
+describe('applyAlignmentEdits', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	it('sends the edited file through revalidation exactly once', async () => {
+		const revalidate = vi.fn(async () => 'ok');
+		const file = editedFile();
+
+		await applyAlignmentEdits(file, { revalidate });
+
+		expect(revalidate).toHaveBeenCalledTimes(1);
+		expect(revalidate).toHaveBeenCalledWith(file);
+	});
+
+	it('drops the pre-edit descriptor BEFORE revalidation resolves', async () => {
+		fileMetricsStore.set({ FILE_INFO: { sequences: 23 }, canonicalFasta: 'OLD' });
+
+		let seenDuringRevalidate = 'not-called';
+		const revalidate = vi.fn(async () => {
+			// This is the window a Run click would land in.
+			seenDuringRevalidate = get(fileMetricsStore);
+			return 'ok';
+		});
+
+		await applyAlignmentEdits(editedFile(), { revalidate });
+
+		expect(seenDuringRevalidate).toBeNull();
+	});
+
+	it('flags the file as revalidating for the whole re-read, then clears it', async () => {
+		const seen = [];
+		const revalidate = vi.fn(async () => {
+			seen.push(get(revalidatingFileId));
+			return 'ok';
+		});
+
+		await applyAlignmentEdits(editedFile(), {
+			revalidate,
+			fileId: 'file-1',
+			setRevalidating: (id) => revalidatingFileId.set(id)
+		});
+
+		expect(seen).toEqual(['file-1']);
+		expect(get(revalidatingFileId)).toBeNull();
+	});
+
+	it('clears the flag when revalidation REJECTS, so the Run button cannot wedge', async () => {
+		const revalidate = vi.fn(async () => {
+			throw new Error('datareader rejected the edited alignment');
+		});
+
+		await expect(
+			applyAlignmentEdits(editedFile(), {
+				revalidate,
+				fileId: 'file-1',
+				setRevalidating: (id) => revalidatingFileId.set(id)
+			})
+		).rejects.toThrow(/datareader rejected/);
+
+		expect(get(revalidatingFileId)).toBeNull();
+	});
+
+	it('fails loudly rather than silently doing nothing when no revalidator is wired', async () => {
+		await expect(applyAlignmentEdits(editedFile(), {})).rejects.toThrow(/revalidate/);
+	});
+});
+
+describe('the viewer hands the edit to its parent instead of filing it itself', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fileMetricsStore.set(null);
+		alignmentFileStore.set(null);
+		revalidatingFileId.set(null);
+	});
+
+	afterEach(() => cleanup());
+
+	it('dispatches editsSaved with the new file and the pre-edit one', async () => {
+		const onSaved = vi.fn();
+		const original = new File(['>a\nACGACG\n'], 'CD2-slim.fna', { type: 'text/plain' });
+		render(AlignmentViewerHarness, { props: { alignmentFile: original, onSaved } });
+
+		await fireEvent.click(screen.getByTitle('Save alignment edits back to file'));
+
+		expect(onSaved).toHaveBeenCalledTimes(1);
+		const detail = onSaved.mock.calls[0][0];
+		expect(detail.file).toBeInstanceOf(File);
+		expect(detail.file.name).toBe('CD2-slim.fna');
+		// The pre-edit blob, kept so the error card can offer to put it back if datareader rejects
+		// the edit. IndexedDB already holds the edited bytes by then.
+		expect(detail.previous).toBe(original);
+	});
+
+	it('writes nothing to storage or to alignmentFileStore on its own', async () => {
+		// This is the actual defect: those two writes made the edit look applied while the metrics
+		// the runners read still described the old alignment.
+		const original = new File(['>a\nACGACG\n'], 'CD2-slim.fna', { type: 'text/plain' });
+		render(AlignmentViewerHarness, { props: { alignmentFile: original, onSaved: () => {} } });
+
+		await fireEvent.click(screen.getByTitle('Save alignment edits back to file'));
+
+		expect(fileStorage.saveFile).not.toHaveBeenCalled();
+		expect(fileStorage.updateFile).not.toHaveBeenCalled();
+		expect(get(alignmentFileStore)).toBeNull();
+	});
+});
+// NOTE: there is deliberately no "does not show Saved" case here. Written as an assertion on the
+// button label it passes with the fix reverted too — the old code set saveMessage only after an
+// await, so nothing has rendered yet at the point a click handler returns. A test that passes
+// either way is worse than no test.

--- a/src/test/analysis-config-store.test.js
+++ b/src/test/analysis-config-store.test.js
@@ -1,0 +1,157 @@
+/**
+ * analysisConfig.restoreFrom — what "Re-run" is allowed to bring back.
+ *
+ * The dangerous part of this feature is not losing settings, it is restoring the WRONG ones. A
+ * backend run persists its parameters in the SERVER's shape (gencodeid, 'ds-variation', 'branch-set')
+ * and keeps the UI's own config alongside under `originalConfig`. Feeding the former into the option
+ * bag would inject controls the UI never had and silently change what the next run submits — a
+ * scientific result computed with parameters the user never chose.
+ *
+ * So these tests are mostly about what must NOT come back.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { analysisConfig, describeRestoredSettings } from '../stores/analysisConfig.js';
+
+const METHOD_KEYS = ['FEL', 'MEME', 'AxoMEME', 'GARD'];
+
+/** A backend FEL record: server-shaped `parameters`, UI-shaped `originalConfig`. */
+const backendFelRecord = {
+	id: 'analysis-fel-1',
+	method: 'FEL',
+	metadata: {
+		arguments: {
+			parameters: { gencodeid: 0, 'ds-variation': 2, pvalue: 0.1 },
+			originalConfig: {
+				method: 'FEL',
+				geneticCode: 'Universal',
+				geneticCodeId: 0,
+				executionMode: 'backend',
+				branchesToTest: 'Internal',
+				pValueThreshold: 0.05
+			}
+		}
+	}
+};
+
+describe('analysisConfig.restoreFrom', () => {
+	beforeEach(() => {
+		analysisConfig.reset();
+	});
+
+	it('prefers the UI config over the backend-shaped parameters', () => {
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const state = get(analysisConfig);
+
+		expect(state.selectedMethod).toBe('FEL');
+		expect(state.methodOptions.FEL.branchesToTest).toBe('Internal');
+		expect(state.methodOptions.FEL.pValueThreshold).toBe(0.05);
+
+		// The backend's own vocabulary must never reach the UI's option bag.
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('gencodeid');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('ds-variation');
+	});
+
+	it('lifts the shared settings to the top level rather than into the option bag', () => {
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const state = get(analysisConfig);
+
+		expect(state.geneticCode).toBe('Universal');
+		expect(state.executionMode).toBe('backend');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('geneticCode');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('executionMode');
+		expect(Object.keys(state.methodOptions.FEL)).not.toContain('method');
+	});
+
+	it('drops an option the method no longer has', () => {
+		// A release that removes a control must not have it resurrected by an old record.
+		analysisConfig.restoreFrom(
+			{
+				id: 'analysis-fel-2',
+				method: 'FEL',
+				metadata: {
+					arguments: {
+						originalConfig: { branchesToTest: 'All', thisOptionWasRemovedInV4: 'boom' }
+					}
+				}
+			},
+			METHOD_KEYS
+		);
+
+		const opts = get(analysisConfig).methodOptions.FEL;
+		expect(opts.branchesToTest).toBe('All');
+		expect(Object.keys(opts)).not.toContain('thisOptionWasRemovedInV4');
+	});
+
+	it('degrades to method-only for a record with no arguments, and says so', () => {
+		// AxomemeAnalysisRunner calls startAnalysisTracking with four arguments, so `args` is null and
+		// its records carry no metadata.arguments at all. Claiming settings were restored would be a
+		// lie the user cannot check.
+		const result = analysisConfig.restoreFrom(
+			{ id: 'analysis-axo-1', method: 'AXOMEME', metadata: {} },
+			METHOD_KEYS
+		);
+
+		expect(result.restoredSettings).toBe(false);
+		expect(get(analysisConfig).selectedMethod).toBe('AxoMEME');
+		expect(get(analysisConfig).methodOptions.AxoMEME).toBeUndefined();
+	});
+
+	it('matches the stored upper-cased method back to the dropdown’s own casing', () => {
+		// Records are written with method.toUpperCase(); the <select> values are 'AxoMEME', 'aBSREL'.
+		// Without this the option never matches and the dropdown shows its placeholder.
+		analysisConfig.restoreFrom({ id: 'a', method: 'AXOMEME' }, METHOD_KEYS);
+		expect(get(analysisConfig).selectedMethod).toBe('AxoMEME');
+	});
+
+	it('restores a wasm record, whose parameters ARE the UI config', () => {
+		// WasmAnalysisRunner persists `parameters: config` with no originalConfig, so the fallback
+		// side of the precedence has to work too.
+		analysisConfig.restoreFrom(
+			{
+				id: 'analysis-meme-1',
+				method: 'MEME',
+				metadata: {
+					arguments: { parameters: { geneticCode: 'Universal', rates: 3, pvalue: 0.05 } }
+				}
+			},
+			METHOD_KEYS
+		);
+
+		const state = get(analysisConfig);
+		expect(state.methodOptions.MEME.rates).toBe(3);
+		expect(state.methodOptions.MEME.pvalue).toBe(0.05);
+	});
+
+	it('keeps other methods’ option bags untouched', () => {
+		analysisConfig.update((s) => ({
+			...s,
+			methodOptions: { MEME: { rates: 4 } }
+		}));
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+
+		expect(get(analysisConfig).methodOptions.MEME.rates).toBe(4);
+	});
+});
+
+describe('describeRestoredSettings', () => {
+	it('names what actually came back', () => {
+		analysisConfig.reset();
+		analysisConfig.restoreFrom(backendFelRecord, METHOD_KEYS);
+		const text = get(analysisConfig).restoredSummary;
+
+		expect(text).toContain('genetic code Universal');
+		expect(text).toMatch(/internal/i);
+	});
+
+	it('says nothing at all when nothing was restored', () => {
+		// THE TRAP: a summary built from store state would read the DEFAULT genetic code back out and
+		// tell an AxoMEME re-run that its settings had been restored. They were not; the record has no
+		// arguments to restore.
+		analysisConfig.reset();
+		analysisConfig.restoreFrom({ id: 'a', method: 'AXOMEME' }, METHOD_KEYS);
+		expect(get(analysisConfig).restoredSummary).toBe('');
+		expect(describeRestoredSettings('AxoMEME', { geneticCode: null, options: {} })).toBe('');
+	});
+});

--- a/src/test/axomeme-call-modes.test.js
+++ b/src/test/axomeme-call-modes.test.js
@@ -1,0 +1,83 @@
+/**
+ * describeCallMode() — the pre-run sentence that says what AxoMEME's calling mode will do.
+ *
+ * The tests that matter here are the DERIVATION ones. Copy that hard-codes "top 2%" is true until
+ * someone retunes tier1Percentile, at which point the pre-run promise and the results table disagree
+ * and nothing fails. Every number in the sentence has to come out of the config it is describing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { describeCallMode, CALL_DEFAULTS } from '../lib/services/axomeme/callModes.js';
+
+describe('describeCallMode', () => {
+	it('states the fixed share percentile mode always calls', () => {
+		const text = describeCallMode('percentile');
+		// The band it flags as Tier 1...
+		expect(text).toContain('top 2%');
+		// ...and the CUMULATIVE label the results table will print for Tier 2 (postprocess.js labels
+		// the 95th-98th band 'Top 5%'). Pre-run copy naming only the exclusive 3% would read as a
+		// contradiction of the results page.
+		expect(text).toContain('Top 5%');
+		expect(text).toContain('next 3%');
+		// VARIABLE sites, not sites: percentiles are computed over variable sites only, and on the
+		// conserved alignments this line exists for that is a small fraction of the gene.
+		expect(text).toMatch(/variable sites/i);
+		// The thing that was missing before: a share is called whether or not anything is selected.
+		expect(text).toMatch(/whether or not any site is under selection/i);
+	});
+
+	it('derives every percentage from the gates rather than hard-coding them', () => {
+		const text = describeCallMode('percentile', {
+			...CALL_DEFAULTS,
+			tier1Percentile: 99,
+			tier2Percentile: 90
+		});
+		expect(text).toContain('top 1%');
+		expect(text).toContain('next 9%');
+		expect(text).toContain('Top 10%');
+		expect(text).not.toContain('2%');
+		expect(text).not.toContain('5%');
+	});
+
+	it('names the z-score gates it is describing', () => {
+		expect(describeCallMode('zscore')).toContain(`Z ≥ ${CALL_DEFAULTS.tier1Zscore}`);
+		// Distinct values, so neither number can pass by being a substring of the other.
+		const text = describeCallMode('zscore', {
+			...CALL_DEFAULTS,
+			tier1Zscore: 3.75,
+			tier2Zscore: 1.25
+		});
+		expect(text).toContain('Z ≥ 3.75');
+		expect(text).toContain('Z ≥ 1.25');
+		expect(text).toMatch(/relative to this alignment/i);
+	});
+
+	it('warns that pvalue mode usually reports nothing', () => {
+		const text = describeCallMode('pvalue');
+		expect(text).toContain(String(CALL_DEFAULTS.tier1LrtGate)); // 4.45
+		expect(text).toContain(String(CALL_DEFAULTS.tier2LrtGate)); // 3.12
+		expect(text).toMatch(/usually reports nothing/i);
+		// It is a fixed gate, not a rank — that distinction is the whole reason pvalue is not default.
+		expect(text).toMatch(/rather than ranks/i);
+	});
+
+	it('falls back to the mode a missing value actually runs as', () => {
+		// METHOD_ADVANCED_OPTIONS.axomeme.callMode.default is CALL_DEFAULTS.mode, so an undefined or
+		// unrecognised mode runs as percentile. The sentence has to describe THAT, not shrug.
+		expect(CALL_DEFAULTS.mode).toBe('percentile');
+		const fallback = describeCallMode('percentile');
+		expect(describeCallMode(undefined)).toBe(fallback);
+		expect(describeCallMode('nonsense')).toBe(fallback);
+	});
+
+	it('keeps one definition of the gates after the move out of postprocess.js', () => {
+		// postprocess.js re-exports rather than re-declares. A fork here would let the results table
+		// and the pre-run copy disagree about the same run.
+		return Promise.all([
+			import('../lib/services/axomeme/postprocess.js'),
+			import('../lib/services/axomeme/callModes.js')
+		]).then(([postprocess, callModes]) => {
+			expect(postprocess.CALL_DEFAULTS).toBe(callModes.CALL_DEFAULTS);
+		});
+	});
+});

--- a/src/test/axomeme-prerun-copy.test.js
+++ b/src/test/axomeme-prerun-copy.test.js
@@ -1,0 +1,91 @@
+/**
+ * AxoMEME's pre-run copy, mounted.
+ *
+ * TRAP THIS FILE AVOIDS: asserting body text like /percentile/ or /rank sites/. Unfixed main already
+ * renders "percentile and zscore rank sites within this alignment…" in the option description, so
+ * such an assertion passes with the fix reverted and proves nothing. What is new is a line that
+ * states the CONSEQUENCE of the mode currently selected — so the assertions are on its testid, and
+ * on the sentence CHANGING when the mode changes.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import MethodSelector from '../lib/MethodSelector.svelte';
+import { fileMetricsStore } from '../stores/fileInfo.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('../lib/utils/indexedDBStorage.js', () => ({
+	fileStorage: {
+		getAllFiles: vi.fn().mockResolvedValue([]),
+		getFile: vi.fn().mockResolvedValue(null),
+		saveFile: vi.fn().mockResolvedValue(true),
+		deleteFile: vi.fn().mockResolvedValue(true)
+	},
+	analysisStorage: {
+		getAllAnalyses: vi.fn().mockResolvedValue([]),
+		saveAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysis: vi.fn().mockResolvedValue(null),
+		deleteAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysesByFileId: vi.fn().mockResolvedValue([]),
+		clearAllAnalyses: vi.fn().mockResolvedValue(true)
+	}
+}));
+
+// The AxoMEME entry from +page.svelte's methodConfig, verbatim in the fields this component reads.
+const methodConfig = {
+	AxoMEME: {
+		command: null,
+		outputSuffix: null,
+		url: 'axomeme',
+		args: [],
+		runner: 'axomeme',
+		noGeneticCode: true,
+		description:
+			'Predicts what MEME would report for each site, in seconds rather than hours. A neural surrogate, not a substitute for the full analysis.'
+	}
+};
+
+/** The 'How to rank sites' control, identified by what it offers rather than by DOM position. */
+function callModeSelect() {
+	return [...document.querySelectorAll('select')].find((s) =>
+		[...s.options].some((o) => o.value === 'pvalue')
+	);
+}
+
+describe('AxoMEME pre-run copy', () => {
+	afterEach(() => {
+		cleanup();
+		fileMetricsStore.set(null);
+	});
+
+	it('says a fixed share is always called, and changes when the mode does', async () => {
+		fileMetricsStore.set({ FILE_INFO: { sequences: 12, sites: 187 } });
+		render(MethodSelector, { props: { methodConfig, runMethod: vi.fn() } });
+		await fireEvent.change(screen.getByTestId('method-dropdown'), {
+			target: { value: 'AxoMEME' }
+		});
+		await tick();
+		await tick();
+
+		const line = screen.getByTestId('axomeme-call-consequence');
+		expect(line.textContent).toMatch(/top 2%/i);
+		// The sentence that was missing: percentile mode calls a share of the alignment regardless of
+		// whether anything in it is under selection.
+		expect(line.textContent).toMatch(/whether or not/i);
+		expect(line.textContent).toMatch(/variable sites/i);
+
+		// THE ASSERTION THAT CANNOT PASS BY ACCIDENT: switching the mode rewrites the consequence.
+		const select = callModeSelect();
+		expect(select, 'call-mode select not found').toBeTruthy();
+		await fireEvent.change(select, { target: { value: 'pvalue' } });
+		await tick();
+		await tick();
+
+		const after = screen.getByTestId('axomeme-call-consequence').textContent;
+		expect(after).toMatch(/usually reports nothing/i);
+		expect(after).toContain('4.45');
+		expect(after).not.toMatch(/top 2%/i);
+	}, 30000);
+});

--- a/src/test/branch-set-tagging.test.js
+++ b/src/test/branch-set-tagging.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import * as phylotree from 'phylotree';
+import {
+	assignBranchToSet,
+	branchSetOf,
+	listBranches,
+	multiSetTag
+} from '../lib/utils/branchSetTagging.js';
+
+const NEWICK = '((A:0.1,B:0.2)AB:0.3,(C:0.1,D:0.2)CD:0.3)root;';
+const SETS = ['TEST', 'REFERENCE'];
+
+/** A real phylotree, no DOM: only `render()` touches the document. */
+function makeTree() {
+	const tree = new phylotree.phylotree(NEWICK);
+	return { tree, nodes: tree.nodes.descendants() };
+}
+
+function taggedNewick(tree) {
+	return tree.getNewick((node) => multiSetTag(node, SETS));
+}
+
+describe('assignBranchToSet', () => {
+	it('tags exactly the assigned branches in the Newick', () => {
+		const { tree, nodes } = makeTree();
+
+		expect(assignBranchToSet(nodes, 'A', 'TEST', SETS)).toBe(true);
+		expect(assignBranchToSet(nodes, 'CD', 'REFERENCE', SETS)).toBe(true);
+
+		const out = taggedNewick(tree);
+		expect(out).toContain('A{TEST}');
+		expect(out).toContain('CD{REFERENCE}');
+		// And nothing else picked up a tag.
+		expect(out.match(/\{/g)).toHaveLength(2);
+		expect(out).toContain('B:0.2');
+	});
+
+	it('MOVES a tag on reassignment instead of accumulating two', () => {
+		const { tree, nodes } = makeTree();
+
+		assignBranchToSet(nodes, 'A', 'TEST', SETS);
+		assignBranchToSet(nodes, 'A', 'REFERENCE', SETS);
+
+		const out = taggedNewick(tree);
+		expect(out).toContain('A{REFERENCE}');
+		expect(out).not.toContain('{TEST}');
+		expect(out).not.toContain('{TEST,REFERENCE}');
+		expect(out.match(/\{/g)).toHaveLength(1);
+	});
+
+	it('clears a branch when the target set is empty', () => {
+		const { tree, nodes } = makeTree();
+
+		assignBranchToSet(nodes, 'A', 'TEST', SETS);
+		assignBranchToSet(nodes, 'A', '', SETS);
+
+		expect(taggedNewick(tree)).not.toContain('{');
+		expect(branchSetOf(nodes.find((n) => n.data.name === 'A'))).toBe('');
+	});
+
+	it('clears legacy per-set boolean flags so they cannot resurrect a stale tag', () => {
+		const { tree, nodes } = makeTree();
+		const a = nodes.find((n) => n.data.name === 'A');
+
+		// How sets were recorded before _selectionSet existed. multiSetTag still reads these as a
+		// fallback, so merely SETTING _selectionSet on top would mask the stale flag rather than
+		// remove it — and unassigning the branch later would resurrect the old tag.
+		a.TEST = true;
+		expect(taggedNewick(tree)).toContain('A{TEST}');
+
+		assignBranchToSet(nodes, 'A', 'REFERENCE', SETS);
+		expect(taggedNewick(tree)).toContain('A{REFERENCE}');
+
+		assignBranchToSet(nodes, 'A', '', SETS);
+		expect(taggedNewick(tree)).not.toContain('{');
+	});
+
+	it('reports a miss for an unknown branch name and changes nothing', () => {
+		const { tree, nodes } = makeTree();
+		expect(assignBranchToSet(nodes, 'NOT_A_BRANCH', 'TEST', SETS)).toBe(false);
+		expect(taggedNewick(tree)).not.toContain('{');
+	});
+});
+
+describe('listBranches', () => {
+	it('lists every named branch except the root, with its current set', () => {
+		const { nodes } = makeTree();
+		assignBranchToSet(nodes, 'B', 'TEST', SETS);
+
+		const rows = listBranches(nodes);
+		const names = rows.map((r) => r.name);
+
+		expect(names).not.toContain('root');
+		expect(names).toEqual(expect.arrayContaining(['A', 'B', 'C', 'D', 'AB', 'CD']));
+		expect(rows.find((r) => r.name === 'B').set).toBe('TEST');
+		expect(rows.find((r) => r.name === 'A').set).toBe('');
+		expect(rows.find((r) => r.name === 'A').isLeaf).toBe(true);
+		expect(rows.find((r) => r.name === 'AB').isLeaf).toBe(false);
+	});
+
+	it('survives a tree that has not been parsed', () => {
+		expect(listBranches(null)).toEqual([]);
+		expect(listBranches(undefined)).toEqual([]);
+	});
+});

--- a/src/test/datareader-warnings.test.js
+++ b/src/test/datareader-warnings.test.js
@@ -1,0 +1,116 @@
+/**
+ * What the Data tab tells the user about the changes datareader made to their alignment.
+ *
+ * datareader collapses duplicates, renames sequences, pads short ones and strips a terminal stop
+ * codon column. It has always written a sentence about each of those to ./datareader.log — a file
+ * nothing in the JS layer reads. Only counts reached results.json, and one of them was mislabelled:
+ * `ambiguous_sites` is the boolean padWarning, and the UI rendered it as "Found 1 ambiguous
+ * character in your alignment" — wrong count, wrong cause, wrong advice.
+ *
+ * The describe-don't-modify assertion at the bottom is the maintainer's rule, mirrored from
+ * stop-codon-diagnosis.test.js: this UI states what is in the file and stops there.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWarnings } from '../lib/utils/datareaderWarnings.js';
+
+const textOf = (w) => [w.title, w.message, w.details, ...(w.items ?? [])].join(' ');
+
+describe('padding warning', () => {
+	it('explains padding rather than reporting an ambiguous-character count', () => {
+		// The legacy boolean, which is all a cached record has.
+		const [w] = buildWarnings({ ambiguous_sites: 1 });
+		expect(w.message).toContain('padded');
+		expect(w.message).not.toContain('ambiguous character');
+		expect(textOf(w)).not.toContain('ambiguous character');
+	});
+
+	it('names how many sequences were padded, and which gap characters count', () => {
+		const [w] = buildWarnings({ padded_sequences: 3 });
+		expect(w.message).toContain('3 sequences');
+		expect(w.details).toContain('~');
+		expect(w.details).toContain('-');
+	});
+});
+
+describe('stop codons', () => {
+	it('leaves the dead `stop_codons` key dead', () => {
+		// datareader has never emitted this key; the branch that read it could not fire, and
+		// reviving it would fire on a key that means something else.
+		expect(buildWarnings({ stop_codons: 5 })).toHaveLength(0);
+	});
+
+	it('reports the key datareader does emit, as the boolean it is', () => {
+		const warnings = buildWarnings({ stop_codons_stripped: 1 });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].message).toMatch(/stop codon/i);
+	});
+});
+
+describe('names of the sequences that changed', () => {
+	it('lists renames', () => {
+		const [w] = buildWarnings({ renamed_names: ['seq|1 -> seq_1'] });
+		expect(w.items).toContain('seq|1 -> seq_1');
+		expect(textOf(w)).toContain('seq_1');
+	});
+
+	it('lists duplicate pairs', () => {
+		const [w] = buildWarnings({ duplicate_names: ['a = b'] });
+		expect(w.items).toContain('a = b');
+	});
+
+	it("accepts HyPhy's numerically-keyed objects as well as arrays", () => {
+		const [w] = buildWarnings({ renamed_names: { 0: 'x|1 -> x_1', 1: 'y|2 -> y_2' } });
+		expect(w.items).toEqual(['x|1 -> x_1', 'y|2 -> y_2']);
+	});
+
+	it('carries a name containing a double quote through without breaking', () => {
+		const [w] = buildWarnings({ duplicate_names: ['say "hi" = other'] });
+		expect(w.items).toContain('say "hi" = other');
+		expect(textOf(w)).toContain('say "hi"');
+	});
+
+	it('fires on the names alone, without a separate count field', () => {
+		expect(buildWarnings({ duplicate_names: ['a = b'] })).toHaveLength(1);
+		expect(buildWarnings({ renamed_names: ['a -> b'] })).toHaveLength(1);
+	});
+});
+
+describe('the copy describes, and never offers to modify the alignment', () => {
+	it('recommends nothing across every warning it can produce', () => {
+		const everything = buildWarnings({
+			duplicate_sequences: 2,
+			duplicate_names: ['a = b', 'c = a'],
+			sequences_renamed: 1,
+			renamed_names: ['seq|1 -> seq_1'],
+			padded_sequences: 2,
+			ambiguous_sites: 1,
+			stop_codons_stripped: 1,
+			sites: 12,
+			sequences: 4
+		});
+		expect(everything.length).toBeGreaterThan(4);
+		for (const w of everything) {
+			expect(textOf(w)).not.toMatch(/remove|fix|trim|we can|repair/i);
+		}
+	});
+});
+
+describe('a clean file produces no warnings', () => {
+	it('says nothing about an alignment with nothing to report', () => {
+		expect(
+			buildWarnings({
+				duplicate_sequences: 0,
+				sequences_renamed: 0,
+				ambiguous_sites: 0,
+				padded_sequences: 0,
+				stop_codons_stripped: 0,
+				sites: 187,
+				sequences: 10
+			})
+		).toEqual([]);
+	});
+
+	it('tolerates a missing FILE_INFO', () => {
+		expect(buildWarnings(undefined)).toEqual([]);
+	});
+});

--- a/src/test/datatab-metrics.test.js
+++ b/src/test/datatab-metrics.test.js
@@ -1,0 +1,80 @@
+/**
+ * The Data tab's numbers.
+ *
+ * Two separate bugs, both of which read as "the app is telling me something about my file" and
+ * were not true:
+ *
+ *  - "561 raw -> 187 processed" is the SAME alignment measured twice. datareader.bf takes `sites`
+ *    from a codon filter and `rawsites` from a nucleotide filter over identical data, so rawsites
+ *    is exactly 3x sites. The arrow said 374 sites had been discarded.
+ *  - The file-limits copy claimed 5,000 sequences and a tree above 500. The real gates are
+ *    maxUploadSize = 25000 and maxSLACSize = 10000 (HyPhyGlobals.ibf:33,15).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatAlignmentLength, formatGeneticCode } from '../lib/utils/fileMetricsDisplay.js';
+import { uploadLimits, uploadLimitsCopy } from '../lib/config/uploadLimits.js';
+
+describe('formatAlignmentLength', () => {
+	it('states one length in two units instead of implying a loss', () => {
+		expect(formatAlignmentLength({ rawsites: 561, sites: 187 })).toBe(
+			'561 nucleotides (187 codons)'
+		);
+	});
+
+	it('does not render the old arrow or the word "processed"', () => {
+		const out = formatAlignmentLength({ rawsites: 561, sites: 187 });
+		expect(out).not.toContain('→');
+		expect(out).not.toContain('processed');
+	});
+
+	it('falls back to codons alone for a cached record with no rawsites', () => {
+		// descriptorSync replays whatever IndexedDB holds, with no migration step.
+		const out = formatAlignmentLength({ sites: 187 });
+		expect(out).toBe('187 codons');
+		expect(out).not.toMatch(/NaN|undefined/);
+	});
+
+	it('does not invent a codon count for non-codon data', () => {
+		expect(formatAlignmentLength({ rawsites: 561, sites: 561, gencodeid: -1 })).toBe('561 sites');
+	});
+
+	it('says Unknown rather than NaN when there is no length at all', () => {
+		expect(formatAlignmentLength({})).toBe('Unknown');
+	});
+});
+
+describe('formatGeneticCode', () => {
+	it('names the code instead of printing its id', () => {
+		expect(formatGeneticCode(0)).toBe('Universal code');
+		expect(formatGeneticCode(0)).not.toBe('0');
+	});
+
+	it('resolves other table entries', () => {
+		expect(formatGeneticCode(4)).toContain('Invertebrate');
+	});
+
+	it('handles the non-codon sentinels, which are not rows in the table', () => {
+		expect(formatGeneticCode(-1)).toBe('Nucleotide');
+		expect(formatGeneticCode(-2)).toBe('Amino acid');
+	});
+
+	it('degrades to the id for a code it does not know', () => {
+		expect(formatGeneticCode(99)).toBe('Code 99');
+	});
+});
+
+describe('upload limits copy', () => {
+	it('carries the limits datareader actually enforces', () => {
+		expect(uploadLimits.maxSequences).toBe(25000);
+		expect(uploadLimits.treeRequiredAbove).toBe(10000);
+	});
+
+	it('no longer claims 5,000 sequences or a tree above 500', () => {
+		const copy = uploadLimitsCopy();
+		expect(copy).toContain('25,000 sequences');
+		// Lookbehind, not toContain: '25,000 sequences' contains '5,000 sequences' as a substring,
+		// which would make the naive assertion pass on the FIXED copy and fail on nothing.
+		expect(copy).not.toMatch(/(?<![\d,])5,000 sequences/);
+		expect(copy).not.toMatch(/(?<![\d,])500 sequences/);
+	});
+});

--- a/src/test/execution-advice.test.js
+++ b/src/test/execution-advice.test.js
@@ -1,0 +1,140 @@
+/**
+ * executionAdvice() — which mode a submission defaults to, and what the panel says about it.
+ *
+ * The assertions below compare against the ESTIMATOR'S OWN output rather than against literal
+ * durations ('~2h 15m'). A literal would turn every retune of the fitted equations into a red test
+ * for no reason, and — worse — would let the advice and the "Before you run" row drift apart while
+ * both stayed green. The point of the module is that they read from one place.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { executionAdvice, SLOW_CATEGORIES } from '../lib/utils/executionAdvice.js';
+import { calculateRuntimeEstimate, SPEED_CATEGORIES } from '../lib/utils/timingEstimates.js';
+
+// A real dataset shape from the bundled demos. BGM at this size is 'very-slow' locally and 'slow' on
+// the server — the exact case where defaulting to the browser costs a user hours.
+const SEQS = 20;
+const SITES = 255;
+
+describe('executionAdvice', () => {
+	it('recommends the server for a slow local run when the server is up', () => {
+		const result = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+
+		const local = calculateRuntimeEstimate('bgm', SEQS, SITES, 'wasm');
+		const server = calculateRuntimeEstimate('bgm', SEQS, SITES, 'backend');
+
+		expect(result.hasEstimate).toBe(true);
+		expect(result.recommend).toBe('backend');
+		expect(result.advice).toContain(local.description);
+		expect(result.advice).toContain(server.description);
+		// Both estimates travel with the advice so the radio sub-labels can print them.
+		expect(result.local.description).toBe(local.description);
+		expect(result.server.description).toBe(server.description);
+	});
+
+	it('never promises a server that is down', () => {
+		const result = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: false
+		});
+
+		const local = calculateRuntimeEstimate('bgm', SEQS, SITES, 'wasm');
+		const server = calculateRuntimeEstimate('bgm', SEQS, SITES, 'backend');
+
+		expect(result.recommend).toBeNull();
+		expect(result.advice).toMatch(/tab must stay open/);
+		expect(result.advice).toContain(local.description);
+		// THE ASSERTION THAT MATTERS: no server duration anywhere in the sentence. Offering "~33 min on
+		// the server" while the socket is down is advice the user cannot act on.
+		expect(result.advice).not.toContain(server.description);
+	});
+
+	it('says nothing about a run that is not slow', () => {
+		const result = executionAdvice({
+			method: 'fel',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+
+		expect(result.hasEstimate).toBe(true);
+		expect(SLOW_CATEGORIES.has(result.local.category)).toBe(false);
+		expect(result.recommend).toBeNull();
+		expect(result.advice).toBeNull();
+		// Still carries both estimates: the sub-labels state durations even when there is no advice.
+		expect(result.local.description).toBeTruthy();
+		expect(result.server.description).toBeTruthy();
+	});
+
+	it('invents nothing for a method with no fitted equation', () => {
+		// AxoMEME, PRIME, NRM, B-STILL and FADE are absent from BACKEND_TIMING_EQUATIONS. A guessed
+		// duration is worse than none, and a guessed CATEGORY would silently move a radio.
+		for (const method of ['axomeme', 'prime', 'nrm', 'b-still', 'fade']) {
+			const result = executionAdvice({
+				method,
+				sequences: SEQS,
+				sites: SITES,
+				serverConnected: true
+			});
+			expect(result, method).toEqual({
+				hasEstimate: false,
+				local: null,
+				server: null,
+				recommend: null,
+				advice: null
+			});
+		}
+	});
+
+	it('stays silent with no file loaded', () => {
+		for (const input of [
+			{ method: 'bgm', sequences: 0, sites: SITES },
+			{ method: 'bgm', sequences: SEQS, sites: 0 },
+			{ method: null, sequences: SEQS, sites: SITES },
+			{}
+		]) {
+			const result = executionAdvice({ ...input, serverConnected: true });
+			expect(result.hasEstimate, JSON.stringify(input)).toBe(false);
+			expect(result.recommend).toBeNull();
+			expect(result.advice).toBeNull();
+		}
+	});
+
+	it('accepts the method name in the case the dropdown uses', () => {
+		// MethodSelector passes selectedMethod straight through, and methodConfig's keys are 'BGM',
+		// 'aBSREL', 'AxoMEME'. Lowercasing happens inside the estimator; this pins that it happens.
+		const upper = executionAdvice({
+			method: 'BGM',
+			sequences: SEQS,
+			sites: SITES,
+			serverConnected: true
+		});
+		expect(upper.recommend).toBe('backend');
+	});
+
+	it('applies advanced options that multiply the runtime', () => {
+		// Same alignment, 10x the MCMC steps: the estimate has to move, or the advice is describing a
+		// run nobody submitted.
+		const plain = executionAdvice({ method: 'bgm', sequences: SEQS, sites: SITES });
+		const heavy = executionAdvice({
+			method: 'bgm',
+			sequences: SEQS,
+			sites: SITES,
+			methodOptions: { steps: 100000 }
+		});
+		expect(heavy.local.minutes).toBeGreaterThan(plain.local.minutes);
+	});
+
+	it('names categories that timingEstimates.js actually defines', () => {
+		// Drift guard. Rename 'very-slow' in SPEED_CATEGORIES and this set silently stops matching
+		// anything, which disables the advice everywhere without failing a single other test.
+		expect(Object.keys(SPEED_CATEGORIES)).toEqual(expect.arrayContaining([...SLOW_CATEGORIES]));
+	});
+});

--- a/src/test/execution-mode-default.test.js
+++ b/src/test/execution-mode-default.test.js
@@ -1,0 +1,155 @@
+/**
+ * Execution mode: what the panel actually defaults to, mounted.
+ *
+ * executionAdvice() is unit-tested next door; this file exists because the bug was never in the
+ * arithmetic. The app has always computed "~2h 15m in this browser" and printed it one row below a
+ * Local radio it had already selected. What has to be asserted is the RADIO — `.checked` on the
+ * inputs — not any sentence the unfixed page also renders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import MethodSelector from '../lib/MethodSelector.svelte';
+import { backendConnectivity } from '../stores/backendConnectivity.js';
+import { fileMetricsStore } from '../stores/fileInfo.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('../lib/utils/indexedDBStorage.js', () => ({
+	fileStorage: {
+		getAllFiles: vi.fn().mockResolvedValue([]),
+		getFile: vi.fn().mockResolvedValue(null),
+		saveFile: vi.fn().mockResolvedValue(true),
+		deleteFile: vi.fn().mockResolvedValue(true)
+	},
+	analysisStorage: {
+		getAllAnalyses: vi.fn().mockResolvedValue([]),
+		saveAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysis: vi.fn().mockResolvedValue(null),
+		deleteAnalysis: vi.fn().mockResolvedValue(true),
+		getAnalysesByFileId: vi.fn().mockResolvedValue([]),
+		clearAllAnalyses: vi.fn().mockResolvedValue(true)
+	}
+}));
+
+// The two entries this file needs, copied from +page.svelte's methodConfig. BGM is the slow one
+// (~2h 15m locally at 20x255); FEL is the fast one.
+const methodConfig = {
+	BGM: {
+		command: 'bgm',
+		outputSuffix: 'BGM.json',
+		url: 'bgm',
+		args: [],
+		description: 'A method for detecting coevolving sites.'
+	},
+	FEL: {
+		command: 'fel',
+		outputSuffix: 'FEL.json',
+		url: 'fel',
+		args: [],
+		description: 'A method for detecting pervasive selection.'
+	}
+};
+
+const SEQS = 20;
+const SITES = 255;
+
+async function mountWith({ connected, method }) {
+	backendConnectivity.set({
+		isConnected: connected,
+		isConnecting: false,
+		serverUrl: 'http://localhost:7015',
+		lastChecked: null,
+		error: null
+	});
+	fileMetricsStore.set({ FILE_INFO: { sequences: SEQS, sites: SITES } });
+
+	render(MethodSelector, { props: { methodConfig, runMethod: vi.fn() } });
+	const dropdown = screen.getByTestId('method-dropdown');
+	await fireEvent.change(dropdown, { target: { value: method } });
+	await tick();
+	await tick();
+	return {
+		local: document.querySelector('input[value="local"]'),
+		backend: document.querySelector('input[value="backend"]')
+	};
+}
+
+describe('execution mode default', () => {
+	beforeEach(() => {
+		fileMetricsStore.set(null);
+	});
+
+	afterEach(() => {
+		cleanup();
+		fileMetricsStore.set(null);
+		backendConnectivity.set({
+			isConnected: false,
+			isConnecting: false,
+			serverUrl: 'http://localhost:7015',
+			lastChecked: null,
+			error: null
+		});
+	});
+
+	it('pre-selects the server for an hours-long local run, and yields to a click', async () => {
+		const { local, backend } = await mountWith({ connected: true, method: 'BGM' });
+
+		// THE ASSERTION. On unfixed main this is local:true / backend:false with "~2h 15m" printed
+		// directly underneath.
+		expect(backend.checked).toBe(true);
+		expect(local.checked).toBe(false);
+		expect(backend.disabled).toBe(false);
+
+		const advice = screen.getByTestId('execution-mode-advice').textContent;
+		expect(advice).toContain('in this browser');
+		expect(advice).toContain('on the server');
+		// It says so rather than moving the radio silently.
+		expect(advice).toMatch(/server is selected/i);
+
+		// A click is a decision and outranks a fitted curve. Without the touched flag the reactive
+		// statement immediately puts it back on backend.
+		await fireEvent.click(local);
+		await tick();
+		await tick();
+		expect(local.checked).toBe(true);
+		expect(backend.checked).toBe(false);
+		// And the copy stops claiming a selection that is no longer true.
+		expect(screen.getByTestId('execution-mode-advice').textContent).not.toMatch(
+			/server is selected/i
+		);
+	}, 30000);
+
+	it('leaves a fast method alone, and still states what each mode costs', async () => {
+		const { local, backend } = await mountWith({ connected: true, method: 'FEL' });
+
+		expect(local.checked).toBe(true);
+		expect(backend.checked).toBe(false);
+		// No nagging on a run that finishes in under a minute either way.
+		expect(screen.queryAllByTestId('execution-mode-advice')).toHaveLength(0);
+
+		// But the sub-labels are not silent. They used to read "Fast • Small datasets" and "Powerful •
+		// Large datasets" — a claim about the dataset made without looking at it, on a panel that had
+		// the estimate in hand. Now each names its own duration and what it costs the user.
+		const localLabel = local.closest('.execution-mode-option').textContent;
+		const backendLabel = backend.closest('.execution-mode-option').textContent;
+		expect(localLabel).toMatch(/in this tab/);
+		expect(backendLabel).toMatch(/on the server/);
+		expect(localLabel).not.toMatch(/Small datasets/);
+		expect(backendLabel).not.toMatch(/Large datasets/);
+	}, 30000);
+
+	it('states the cost instead of recommending a server that is down', async () => {
+		const { local, backend } = await mountWith({ connected: false, method: 'BGM' });
+
+		expect(local.checked).toBe(true);
+		expect(backend.disabled).toBe(true);
+
+		const advice = screen.getByTestId('execution-mode-advice');
+		expect(advice.textContent).toMatch(/tab must stay open/);
+		// The disconnected sentence is a second line of the existing warning, not a competing box.
+		expect(advice.closest('.backend-status-warning')).not.toBeNull();
+		expect(advice.textContent).not.toMatch(/on the server/);
+	}, 30000);
+});

--- a/src/test/execution-mode-default.test.js
+++ b/src/test/execution-mode-default.test.js
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { analysisConfig } from '../stores/analysisConfig.js';
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import MethodSelector from '../lib/MethodSelector.svelte';
@@ -77,7 +78,13 @@ async function mountWith({ connected, method }) {
 }
 
 describe('execution mode default', () => {
+	// analysisConfig is a module singleton that deliberately survives tab switches (that is the whole
+	// point of item 3.4). It therefore also survives between tests in this file: the hours-long-run
+	// case above selects the server, and without this reset the fast-method case inherits it and sees
+	// backend pre-selected. Production behaviour is correct; only the isolation was missing, and it
+	// could not have been noticed before 3.4 and 2.1 were merged together.
 	beforeEach(() => {
+		analysisConfig.reset();
 		fileMetricsStore.set(null);
 	});
 

--- a/src/test/file-upload-identity.test.js
+++ b/src/test/file-upload-identity.test.js
@@ -1,0 +1,157 @@
+/**
+ * A file is identified by its NAME here, and that had three consequences nobody chose:
+ *
+ *  1. persistentFileStore.uploadFile took ONE parameter while +page.svelte has always called it
+ *     with two, so the demo/repair provenance in that second argument was silently dropped.
+ *  2. A same-name upload replaced the record's bytes in place and kept the id, so every FEL/MEME
+ *     run against the OLD contents stayed attached to the new ones with nothing marking them.
+ *  3. The file input was never reset, so re-selecting the same path after a rejection fired no
+ *     change event at all — the failure loop is the one case where the retry matters most.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uniqueFilename, isStaleRun, resetFileInput } from '../lib/utils/fileIdentity.js';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('../lib/utils/indexedDBStorage', () => {
+	const fileStorage = {
+		saveFile: vi.fn(async () => 'new-id'),
+		updateFile: vi.fn(async () => 'existing-id'),
+		getFile: vi.fn(async (id) => ({
+			id,
+			filename: 'alignment.fasta',
+			content: new ArrayBuffer(0)
+		})),
+		getFileMetadata: vi.fn(async (id) => ({ id, filename: 'alignment.fasta', createdAt: 1 })),
+		getAllFiles: vi.fn(async () => []),
+		deleteFile: vi.fn(async () => {}),
+		fileRecordToFile: vi.fn(async () => null)
+	};
+	return { fileStorage };
+});
+
+vi.mock('../lib/utils/analytics.js', () => ({ trackEvent: vi.fn() }));
+
+const { fileStorage } = await import('../lib/utils/indexedDBStorage');
+const { persistentFileStore } = await import('../stores/fileInfo.js');
+
+// jsdom's Blob has no arrayBuffer(); the store calls it on the in-place replace path.
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+	Blob.prototype.arrayBuffer = function arrayBuffer() {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
+}
+
+describe('uniqueFilename', () => {
+	it('numbers a colliding name', () => {
+		expect(uniqueFilename('alignment.fasta', ['alignment.fasta'])).toBe('alignment (2).fasta');
+	});
+
+	it('keeps counting past an existing numbered copy', () => {
+		expect(uniqueFilename('alignment.fasta', ['alignment.fasta', 'alignment (2).fasta'])).toBe(
+			'alignment (3).fasta'
+		);
+	});
+
+	it('does not stack suffixes when the colliding name is itself numbered', () => {
+		expect(uniqueFilename('alignment (2).fasta', ['alignment (2).fasta'])).toBe(
+			'alignment (3).fasta'
+		);
+	});
+
+	it('leaves a free name alone', () => {
+		expect(uniqueFilename('alignment.fasta', ['other.fasta'])).toBe('alignment.fasta');
+	});
+
+	it('handles extensionless and multi-dot names', () => {
+		expect(uniqueFilename('alignment', ['alignment'])).toBe('alignment (2)');
+		expect(uniqueFilename('a.b.fasta', ['a.b.fasta'])).toBe('a.b (2).fasta');
+	});
+});
+
+describe('isStaleRun', () => {
+	it('marks a run that predates the file being replaced', () => {
+		expect(isStaleRun({ createdAt: 100 }, { createdAt: 50, updatedAt: 200 })).toBe(true);
+	});
+
+	it('does not mark a run made after the replacement', () => {
+		expect(isStaleRun({ createdAt: 300 }, { createdAt: 50, updatedAt: 200 })).toBe(false);
+	});
+
+	it('never marks anything on a file that was never re-uploaded', () => {
+		expect(isStaleRun({ createdAt: 100 }, { createdAt: 50 })).toBe(false);
+	});
+});
+
+describe('persistentFileStore.uploadFile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes metadata through to storage as the second argument', async () => {
+		const file = new File(['>a\nACG\n'], 'demo.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(file, { source: 'demo', demoId: 'CD2' });
+
+		expect(fileStorage.saveFile).toHaveBeenCalledTimes(1);
+		expect(fileStorage.saveFile.mock.calls[0][1]).toEqual({ source: 'demo', demoId: 'CD2' });
+	});
+
+	it("saves a separate record under a free name when the user picks 'keep both'", async () => {
+		// Seed the store with an existing same-name record.
+		await persistentFileStore.loadFiles();
+		fileStorage.getAllFiles.mockResolvedValueOnce([
+			{ id: 'existing-id', filename: 'alignment.fasta', createdAt: 1 }
+		]);
+		await persistentFileStore.loadFiles();
+
+		const incoming = new File(['>b\nTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(incoming, {}, { onConflict: () => 'keep-both' });
+
+		expect(fileStorage.updateFile).not.toHaveBeenCalled();
+		expect(fileStorage.saveFile).toHaveBeenCalledTimes(1);
+		const [savedFile, savedMetadata] = fileStorage.saveFile.mock.calls[0];
+		expect(savedFile.name).toBe('alignment (2).fasta');
+		expect(savedMetadata).toMatchObject({ forceNew: true });
+	});
+
+	it('still replaces in place when no conflict hook is supplied', async () => {
+		fileStorage.getAllFiles.mockResolvedValueOnce([
+			{ id: 'existing-id', filename: 'alignment.fasta', createdAt: 1 }
+		]);
+		await persistentFileStore.loadFiles();
+
+		const incoming = new File(['>b\nTTT\n'], 'alignment.fasta', { type: 'text/plain' });
+		await persistentFileStore.uploadFile(incoming);
+
+		expect(fileStorage.updateFile).toHaveBeenCalledTimes(1);
+		expect(fileStorage.saveFile).not.toHaveBeenCalled();
+	});
+});
+
+describe('resetFileInput', () => {
+	it('clears the input on the REJECTED path, not only the successful one', () => {
+		const input = document.createElement('input');
+		input.type = 'file';
+		// jsdom will not let a test assign arbitrary text to a file input's value, but it does allow
+		// clearing it — which is the only assignment this helper ever makes.
+		let ran = false;
+
+		// The shape handleFileUpload uses: reset in `finally`, after the catch has swallowed.
+		try {
+			throw new Error('File processing error');
+		} catch {
+			/* swallowed, as the page does */
+		} finally {
+			resetFileInput({ target: input });
+			ran = true;
+		}
+
+		expect(ran).toBe(true);
+		expect(input.value).toBe('');
+	});
+
+	it('ignores the synthetic { target: { files } } objects demo/repair/edit callers pass', () => {
+		expect(() => resetFileInput({ target: { files: [] } })).not.toThrow();
+		expect(() => resetFileInput(undefined)).not.toThrow();
+	});
+});

--- a/src/test/genetic-codes-table.test.js
+++ b/src/test/genetic-codes-table.test.js
@@ -1,0 +1,100 @@
+/**
+ * UX item 1.2 — the genetic code table must be the SHIPPED ENGINE's table, not one we invented.
+ *
+ * Three tables disagreed. The selector offered names of its own ('Vertebrate mitochondrial');
+ * methodOptions.toml and the vendored chooseGeneticCode.def offered spaced ones ('Vertebrate
+ * mtDNA'); and hyphy.wasm 2.5.98 — the thing that actually runs — accepts neither. It declares
+ * hyphenated identifiers ('Vertebrate-mtDNA') and rejects everything else:
+ *
+ *     'mtDNA' is not a valid choice passed to 'Choose Genetic Code' ChoiceList
+ *
+ * So the authority here is static/wasm/hyphy/2.5.98/hyphy.data, the packed filesystem image
+ * shipped with the engine. This test reads `_geneticCodeOptionMatrix` straight out of it. Pinning
+ * to src/data/shared/chooseGeneticCode.def instead would pin the exact stale spellings that caused
+ * the bug — that file is an older vendored copy, mounted only for the upload-time datareader,
+ * which never selects a code and so never noticed the drift.
+ *
+ * Two properties are checked, and the second is the one that matters most:
+ *   - SPELLING, because a name the engine does not recognise fails the run outright;
+ *   - ORDER, because the server path sends the numeric id and HyPhy resolves it BY POSITION in
+ *     this same matrix. A table in the wrong order runs a different code than the UI displays and
+ *     reports no error at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import toml from 'toml';
+import {
+	GENETIC_CODES,
+	geneticCodeId,
+	canonicalGeneticCodeName
+} from '../lib/config/geneticCodes.js';
+import tomlSrc from '../lib/config/methodOptions.toml?raw';
+
+const OUR_NAMES = GENETIC_CODES.map((code) => code.hyphy);
+
+/**
+ * The identifiers the shipped engine declares, in declaration order.
+ *
+ * hyphy.data is Emscripten's packed filesystem blob: batch files are stored as plain text inside
+ * it, so the declaration can be read directly. Latin-1 keeps byte offsets honest across the
+ * binary regions surrounding it.
+ */
+function namesFromShippedEngine() {
+	const blob = readFileSync('static/wasm/hyphy/2.5.98/hyphy.data', 'latin1');
+	const start = blob.indexOf('_geneticCodeOptionMatrix = {');
+	expect(start, 'genetic code matrix not found in the packed engine').toBeGreaterThan(-1);
+	const end = blob.indexOf('};', start);
+	const block = blob.slice(start, end);
+	return [...block.matchAll(/"([^"]+)",\s*"[^"]*transl_table/g)].map((m) => m[1]);
+}
+
+describe('genetic code table matches the shipped HyPhy engine', () => {
+	it('ids are a dense 0..11 range in declaration order', () => {
+		expect(GENETIC_CODES.map((code) => code.id)).toEqual([...Array(12).keys()]);
+	});
+
+	it('names AND order match the engine, which indexes this matrix by position', () => {
+		const engineNames = namesFromShippedEngine();
+		// The engine offers more codes than we expose; ours must be its first twelve, in order.
+		// (See geneticCodes.js for why 12-21 are deliberately withheld.)
+		expect(engineNames.length).toBeGreaterThanOrEqual(12);
+		expect(OUR_NAMES).toEqual(engineNames.slice(0, 12));
+	});
+
+	it('the documented CLI choices in methodOptions.toml say the same thing', () => {
+		const codeOption = toml.parse(tomlSrc).fel.options.find((option) => option.name === 'code');
+		expect(codeOption).toBeTruthy();
+		expect(OUR_NAMES).toEqual(codeOption.choices.map((choice) => choice.value));
+	});
+
+	it('every exposed id has a stop-codon set, so validation cannot silently use the wrong one', async () => {
+		// fastaValidation keys STOP_CODONS_BY_GENETIC_CODE by id and falls back to Universal for
+		// anything missing. Exposing a code it does not know would validate against the wrong
+		// stop set without erroring — which is why the table stops at 11.
+		const { findStopCodons } = await import('../lib/utils/fastaValidation.js');
+		const alignment = '>a\nATGTAAATG\n>b\nATGAGAATG\n';
+		const universalStops = findStopCodons(alignment, 0).affected.length;
+		// Vertebrate mtDNA reads AGA as a stop where the universal code does not; if id 1 fell
+		// back to the universal set these two would agree.
+		const vertebrateStops = findStopCodons(alignment, 1).affected.length;
+		expect(vertebrateStops).not.toBe(universalStops);
+	});
+
+	it('resolves canonical and both legacy spellings to the same id', () => {
+		expect(geneticCodeId('Vertebrate-mtDNA')).toBe(1);
+		// What older builds of the selector stored...
+		expect(geneticCodeId('Vertebrate mitochondrial')).toBe(1);
+		// ...and what the vendored .def / methodOptions.toml used to say.
+		expect(geneticCodeId('Vertebrate mtDNA')).toBe(1);
+		expect(geneticCodeId('Blepharisma nuclear')).toBe(11);
+		expect(geneticCodeId('Universal')).toBe(0);
+		expect(geneticCodeId(undefined)).toBe(0);
+	});
+
+	it('leaves an unrecognised name alone rather than pretending it is Universal', () => {
+		// On the WASM path this value goes to `--code`; a loud HyPhy rejection beats quietly
+		// analysing the data under a code the user did not choose.
+		expect(canonicalGeneticCodeName('Klingon mtDNA')).toBe('Klingon mtDNA');
+		expect(canonicalGeneticCodeName('Vertebrate mitochondrial')).toBe('Vertebrate-mtDNA');
+	});
+});

--- a/src/test/multi-tab-liveness.test.js
+++ b/src/test/multi-tab-liveness.test.js
@@ -1,0 +1,203 @@
+/**
+ * A second browser tab must not kill the first tab's running analysis.
+ *
+ * IndexedDB is shared across tabs of the origin; `activeAnalyses` is not. A local run's persisted
+ * record sits at 'pending'/'wasm' for its entire duration (progress updates are in-memory only), so
+ * the interrupted-sweep that every tab runs at onMount used to reap live work belonging to another
+ * tab — discarding hours of compute and offering a Re-run that would duplicate it.
+ *
+ * The fix is a heartbeat: the owning tab stamps `lastHeartbeatAt` while it is running, and the sweep
+ * only reaps records whose pulse has stopped. These tests pin both halves — that a live run survives,
+ * and that a genuinely dead one is still cleaned up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('../lib/utils/indexedDBStorage', () => ({
+	analysisStorage: {
+		getAllAnalyses: vi.fn(),
+		saveAnalysis: vi.fn(),
+		getAnalysis: vi.fn(),
+		deleteAnalysis: vi.fn(),
+		clearAllAnalyses: vi.fn()
+	}
+}));
+
+import { analysisStore } from '../stores/analyses';
+import { analysisStorage } from '../lib/utils/indexedDBStorage';
+
+const resetStore = () =>
+	analysisStore.update(() => ({
+		analyses: [],
+		currentAnalysisId: null,
+		isLoading: false,
+		error: null,
+		activeAnalyses: []
+	}));
+
+const wasmRun = (overrides = {}) => ({
+	id: 'wasm-run-1',
+	fileId: 'file-1',
+	method: 'FEL',
+	status: 'running',
+	metadata: { executionMode: 'wasm' },
+	createdAt: Date.now() - 60_000,
+	...overrides
+});
+
+describe('multi-tab liveness', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		resetStore();
+		vi.clearAllMocks();
+		analysisStorage.saveAnalysis.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		// Drop any heartbeat interval this test started before handing the timers back.
+		resetStore();
+		analysisStore.removeFromActiveAnalyses('cleanup-noop');
+		vi.useRealTimers();
+	});
+
+	describe("cleanupInterruptedAnalyses respects another tab's pulse", () => {
+		it('leaves a run alone while its tab is still stamping it', async () => {
+			// THE ACTUAL BUG. Five seconds since the last beat: that run is alive in another tab.
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ lastHeartbeatAt: Date.now() - 5_000 })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+			expect(get(analysisStore).analyses[0]?.status).not.toBe('interrupted');
+		});
+
+		it('still reaps a run whose tab stopped stamping it', async () => {
+			// Not "never reap": two minutes of silence is a dead tab, and its record must be cleaned up.
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ lastHeartbeatAt: Date.now() - 120_000 })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'wasm-run-1',
+					status: 'interrupted',
+					error: 'This run stopped when its browser tab closed or reloaded.'
+				})
+			);
+		});
+
+		it('reaps a record written before heartbeats existed', async () => {
+			// A record with no pulse at all is by definition from a session that is gone.
+			analysisStorage.getAllAnalyses.mockResolvedValue([wasmRun()]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wasm-run-1', status: 'interrupted' })
+			);
+		});
+
+		it('never touches a server job, heartbeat or not', async () => {
+			analysisStorage.getAllAnalyses.mockResolvedValue([
+				wasmRun({ id: 'backend-run', metadata: { executionMode: 'backend' } })
+			]);
+
+			await analysisStore.cleanupInterruptedAnalyses();
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('the pulse itself', () => {
+		it('stamps the record the moment the run starts, not ten seconds later', async () => {
+			// Without this, a tab opened inside the first interval still reaps a brand new run.
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'pending',
+				metadata: {}
+			});
+
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+
+			expect(analysisStorage.saveAnalysis).toHaveBeenCalledWith(
+				expect.objectContaining({ lastHeartbeatAt: expect.any(Number) })
+			);
+		});
+
+		it('keeps stamping a newer time while the run is active, and stops when it finishes', async () => {
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'running',
+				metadata: { executionMode: 'wasm' }
+			});
+
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			const beats = analysisStorage.saveAnalysis.mock.calls.map((c) => c[0].lastHeartbeatAt);
+			expect(beats.length).toBeGreaterThanOrEqual(2);
+			for (let i = 1; i < beats.length; i++) {
+				expect(beats[i]).toBeGreaterThan(beats[i - 1]);
+			}
+
+			// Once the run finishes there is nothing left to vouch for, and the timer must stop —
+			// otherwise every completed run leaves an interval rewriting IndexedDB forever.
+			await analysisStore.completeAnalysisProgressById('wasm-run-1', true, 'done');
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+
+		it('does not stamp a record that has already stopped', async () => {
+			// Read-modify-write guard: a completion landing between the read and the write would
+			// otherwise be written back as unfinished.
+			await analysisStore.startAnalysisProgress('wasm-run-1', 'Starting…', 'FEL', {
+				executionMode: 'wasm'
+			});
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'wasm-run-1',
+				status: 'completed',
+				metadata: { executionMode: 'wasm' }
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+
+		it('does not start a pulse for a server job', async () => {
+			analysisStorage.getAnalysis.mockResolvedValue({
+				id: 'backend-run',
+				status: 'pending',
+				metadata: {}
+			});
+
+			await analysisStore.startAnalysisProgress('backend-run', 'Starting…', 'FEL', {
+				executionMode: 'backend',
+				jobId: 'FEL-123'
+			});
+			analysisStorage.saveAnalysis.mockClear();
+
+			await vi.advanceTimersByTimeAsync(25_000);
+
+			expect(analysisStorage.saveAnalysis).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/test/page-refresh-handling.test.js
+++ b/src/test/page-refresh-handling.test.js
@@ -68,7 +68,9 @@ describe('Page Refresh Handling', () => {
 				expect.objectContaining({
 					id: 'wasm-analysis-1',
 					status: 'interrupted',
-					error: 'Analysis was interrupted by page refresh'
+					// Reworded with the heartbeat gate: a reaped record is no longer necessarily a
+					// refresh — it may be a tab that was closed. See multi-tab-liveness.test.js.
+					error: 'This run stopped when its browser tab closed or reloaded.'
 				})
 			);
 

--- a/src/test/results-viewer-markup.test.js
+++ b/src/test/results-viewer-markup.test.js
@@ -1,0 +1,26 @@
+/**
+ * Source-level guards on the results viewer (UX audit item 4.3).
+ *
+ * This is a grep test, deliberately. The property it pins is an ABSENCE, and an absence is cheap to
+ * reintroduce and expensive to notice: the e2e pin that covers it needs a production build and a
+ * seeded IndexedDB. This file fails in under a second when someone pastes the markup back, which is
+ * the point at which it is cheapest to fix.
+ *
+ * hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any deployed
+ * build the results are written to localStorage on the DataMonkey origin and the tab that opens is
+ * vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the viewer must
+ * not reference hyphy-eye at all. Note that 'hyphy-scope' — the visualisation library the viewer
+ * legitimately uses — does not match this pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// import.meta.url is not a file: URL under this vitest environment, so resolve from the repo root.
+const source = readFileSync(resolve(process.cwd(), 'src/lib/AnalysisResultViewer.svelte'), 'utf8');
+
+describe('AnalysisResultViewer markup', () => {
+	it('does not link to or import hyphy-eye', () => {
+		expect(source).not.toMatch(/hyphy-?eye/i);
+	});
+});

--- a/src/test/results-viewer-markup.test.js
+++ b/src/test/results-viewer-markup.test.js
@@ -1,16 +1,19 @@
 /**
- * Source-level guards on the results viewer (UX audit item 4.3).
+ * Source-level guards on the results viewer (UX audit items 4.2 and 4.3).
  *
- * This is a grep test, deliberately. The property it pins is an ABSENCE, and an absence is cheap to
- * reintroduce and expensive to notice: the e2e pin that covers it needs a production build and a
- * seeded IndexedDB. This file fails in under a second when someone pastes the markup back, which is
- * the point at which it is cheapest to fix.
+ * These are grep tests, deliberately. Both properties they pin are ABSENCES, and an absence is
+ * cheap to reintroduce and expensive to notice: the e2e pins that cover them need a production
+ * build and, for AxoMEME, a 17 MB model download. This file fails in under a second when someone
+ * pastes the markup back, which is the point at which it is cheapest to fix.
  *
- * hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any deployed
- * build the results are written to localStorage on the DataMonkey origin and the tab that opens is
- * vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the viewer must
- * not reference hyphy-eye at all. Note that 'hyphy-scope' — the visualisation library the viewer
- * legitimately uses — does not match this pattern.
+ * 4.3: hyphy-eye's "automatic data sharing" only ever worked behind a Vite dev proxy. In any
+ * deployed build the results are written to localStorage on the DataMonkey origin and the tab that
+ * opens is vision.hyphy.org, which cannot read them. The verdict was to remove the link, so the
+ * viewer must not reference hyphy-eye at all. Note 'hyphy-scope' — the visualisation library — does
+ * not match this pattern and is unaffected.
+ *
+ * 4.2: the aBSREL debug panel serialised the entire result document into a <details> above the
+ * visualisation for every aBSREL run, on every user's machine.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -22,5 +25,17 @@ const source = readFileSync(resolve(process.cwd(), 'src/lib/AnalysisResultViewer
 describe('AnalysisResultViewer markup', () => {
 	it('does not link to or import hyphy-eye', () => {
 		expect(source).not.toMatch(/hyphy-?eye/i);
+	});
+
+	it('carries no aBSREL debug panel', () => {
+		expect(source).not.toMatch(/Debug: aBSREL/);
+	});
+
+	it('gates the raw JSON dump on the absence of a visualisation, not a method name list', () => {
+		// The old condition was a hardcoded, case-sensitive array of method names; it missed every
+		// method whose stored name is uppercase-but-absent (AXOMEME, BGM, PRIME, B-STILL) and so
+		// rendered a visualisation AND a megabyte <pre> under it.
+		expect(source).toContain('{:else if !hyphyScopeComponent}');
+		expect(source).not.toMatch(/\[\s*'FEL',\s*'CONTRAST-FEL'/);
 	});
 });

--- a/src/test/run-status-line.test.js
+++ b/src/test/run-status-line.test.js
@@ -122,6 +122,46 @@ describe('a running row', () => {
 	});
 });
 
+describe('a server job that has not started yet', () => {
+	// Submitted is not started. A job sitting in the scheduler that reads "on the server · running"
+	// makes a slow queue look like a slow analysis, and the user waits on a machine that has not begun.
+	const queued = (status, elapsed) =>
+		runStatusLine({ method: 'FEL', status, executionMode: 'backend', elapsedSeconds: elapsed });
+
+	it('says it is queued, not running', () => {
+		const r = queued('pending', 90);
+		expect(r.detail).toBe('queued on the server');
+		expect(r.clock).toBe('1:30');
+		expect(r.tone).toBe('running');
+	});
+
+	it('covers initializing too, and still hides the clock in the first ten seconds', () => {
+		expect(queued('initializing', 90).detail).toBe('queued on the server');
+		expect(queued('pending', 3).detail).toBe('queued on the server');
+		expect(queued('pending', 3).clock).toBeNull();
+	});
+
+	it('leaves local runs alone — there is no queue in this tab', () => {
+		const r = runStatusLine({
+			method: 'FEL',
+			status: 'pending',
+			executionMode: 'wasm',
+			elapsedSeconds: 90
+		});
+		expect(r.detail).toBe('in this tab · running');
+	});
+
+	it('stops claiming a queue once the job is actually running', () => {
+		const r = runStatusLine({
+			method: 'FEL',
+			status: 'running',
+			executionMode: 'backend',
+			elapsedSeconds: 90
+		});
+		expect(r.detail).toBe('on the server · running');
+	});
+});
+
 describe('a finished row', () => {
 	it('reports elapsed as a fact and drops the running clock', () => {
 		const r = runStatusLine({

--- a/src/test/stubs/AliVibeStub.svelte
+++ b/src/test/stubs/AliVibeStub.svelte
@@ -1,0 +1,18 @@
+<script>
+	// Stand-in for the AliVibe widget. AlignmentViewer only ever calls these three methods on it,
+	// and getAlignment() is the one that matters: it is the edited alignment leaving the viewer.
+	export let height = null;
+	export let features = null;
+	export let rows = [
+		{ name: 'a', seq: 'ACGACG' },
+		{ name: 'b', seq: 'ACGTTT' }
+	];
+
+	export function getAlignment() {
+		return rows;
+	}
+	export function loadFasta() {}
+	export function loadTree() {}
+</script>
+
+<div data-testid="alivibe-stub" data-height={height} data-features={features ? 'yes' : 'no'}></div>

--- a/src/test/stubs/AlignmentViewerHarness.svelte
+++ b/src/test/stubs/AlignmentViewerHarness.svelte
@@ -1,0 +1,10 @@
+<script>
+	// Thin harness so a test can observe the editsSaved event without depending on how the
+	// testing-library version of the day exposes component events.
+	import AlignmentViewer from '../../lib/AlignmentViewer.svelte';
+
+	export let alignmentFile = null;
+	export let onSaved = () => {};
+</script>
+
+<AlignmentViewer {alignmentFile} on:editsSaved={(e) => onSaved(e.detail)} />

--- a/src/test/submission-watchdog.test.js
+++ b/src/test/submission-watchdog.test.js
@@ -1,0 +1,229 @@
+/**
+ * The submission watchdog: what happens between "Job submitted" and the server saying anything.
+ *
+ * Before this, a spawn the server silently dropped left the run sitting at 'pending' forever — there
+ * was no ack, no timer and nothing that ever revisited the state. These tests pin the three
+ * decisions that make the fix correct rather than merely present:
+ *
+ *  1. The ack the server ALREADY sends (`job created`) disarms the watchdog, so a healthy job is
+ *     never probed.
+ *  2. Expiry does not fail the run. It probes `job:status`, and only an unambiguous 'not_found' (or
+ *     no answer at all) is treated as loss. 'unknown' means keep waiting — see the comment in
+ *     probeSubmission for why a healthy job answers 'unknown'.
+ *  3. The spawn emit takes exactly two arguments. A third turns it into an ack request, which the
+ *     server's stream router misreads as the job parameters and rejects. That one is a regression
+ *     guard against a "fix" that would break every backend submission.
+ *
+ * NOT NAMED backend-*.test.js ON PURPOSE: vite.config.ts:21-26 excludes both `src/test/backend-*`
+ * and `src/test/*-backend*` from the vitest run, so a file named for what it tests would never
+ * execute.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { backendAnalysisRunner } from '../lib/services/BackendAnalysisRunner.js';
+import { analysisStore } from '../stores/analyses.js';
+
+// Ack replies from the job:status probe, per test.
+let ackReply = [null, { status: 'unknown' }];
+const ackEmit = vi.fn((event, payload, cb) => cb(...ackReply));
+
+const mockSocket = {
+	connected: true,
+	connect: vi.fn(),
+	disconnect: vi.fn(),
+	emit: vi.fn(),
+	on: vi.fn(),
+	off: vi.fn(),
+	timeout: vi.fn(() => ({ emit: ackEmit }))
+};
+
+vi.mock('socket.io-client', () => ({
+	default: vi.fn(() => mockSocket)
+}));
+
+vi.mock('../stores/analyses.js', () => ({
+	analysisStore: {
+		// BaseAnalysisRunner.completeAnalysis does a svelte `get()` on this store, so the mock has to
+		// honour the store contract, not just the method surface.
+		subscribe: (run) => {
+			run({ analyses: [], activeAnalyses: [] });
+			return () => {};
+		},
+		createAnalysis: vi.fn(),
+		updateAnalysis: vi.fn(),
+		startAnalysisProgress: vi.fn(),
+		updateAnalysisProgress: vi.fn(),
+		updateAnalysisProgressById: vi.fn(),
+		completeAnalysisProgress: vi.fn(),
+		completeAnalysisProgressById: vi.fn(),
+		removeFromActiveAnalyses: vi.fn(),
+		cancelAnalysis: vi.fn()
+	}
+}));
+
+const FASTA = '>seq1\nACGACG\n>seq2\nACGACG';
+const TREE = '(seq1:0.1,seq2:0.1);';
+
+/** Register the global handlers against the mock socket without going through connect(). */
+function attachSocket() {
+	backendAnalysisRunner.socket = mockSocket;
+	mockSocket.connected = true;
+	backendAnalysisRunner.setupGlobalHandlers();
+}
+
+/** The handler setupGlobalHandlers registered for a given socket event. */
+function handlerFor(event) {
+	const call = [...mockSocket.on.mock.calls].reverse().find((c) => c[0] === event);
+	expect(call?.[1], `no socket handler registered for '${event}'`).toBeTypeOf('function');
+	return call[1];
+}
+
+async function submitFel() {
+	analysisStore.createAnalysis.mockResolvedValue('analysis-1');
+	const { jobId, analysisId } = await backendAnalysisRunner.runAnalysis(
+		'FEL',
+		{ geneticCode: 'Universal', executionMode: 'backend' },
+		FASTA,
+		TREE,
+		'file-1'
+	);
+	return { jobId, analysisId };
+}
+
+const connectionLostCalls = () =>
+	analysisStore.updateAnalysis.mock.calls.filter((c) => c[1]?.status === 'connection_lost');
+
+describe('backend submission watchdog', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		ackReply = [null, { status: 'unknown' }];
+		backendAnalysisRunner.activeAnalyses.clear();
+		backendAnalysisRunner.clearAllSubmissionWatchdogs();
+		backendAnalysisRunner.socket = null;
+	});
+
+	afterEach(() => {
+		backendAnalysisRunner.disconnect();
+		vi.useRealTimers();
+	});
+
+	it('does not probe a job the server acknowledged', async () => {
+		attachSocket();
+		const { jobId } = await submitFel();
+
+		// `job created` is what the server already publishes on acceptance
+		// (app/hyphyjob.js -> lib/clientsocket.js). Feeding it back disarms the watchdog.
+		handlerFor('job created')({ id: jobId, status: 'queued' });
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('reports the acknowledged queue state instead of a bare job id', async () => {
+		attachSocket();
+		const { jobId, analysisId } = await submitFel();
+
+		handlerFor('job created')({ id: jobId, status: 'Q' });
+		expect(analysisStore.updateAnalysisProgressById).toHaveBeenCalledWith(
+			analysisId,
+			'pending',
+			10,
+			'Queued on the server'
+		);
+
+		handlerFor('job metadata')({ id: jobId, status: 'R' });
+		expect(analysisStore.updateAnalysisProgressById).toHaveBeenCalledWith(
+			analysisId,
+			'running',
+			10,
+			'Running on the server'
+		);
+	});
+
+	it('marks the run connection_lost when the server has no record of the job', async () => {
+		attachSocket();
+		const { analysisId } = await submitFel();
+		ackReply = [null, { status: 'not_found' }];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(ackEmit).toHaveBeenCalledWith('job:status', expect.any(Object), expect.any(Function));
+		expect(analysisStore.updateAnalysis).toHaveBeenCalledWith(
+			analysisId,
+			expect.objectContaining({
+				status: 'connection_lost',
+				error: 'The server has no record of this job. It was never accepted.'
+			})
+		);
+		expect(backendAnalysisRunner.activeAnalyses.size).toBe(0);
+	});
+
+	it('marks the run connection_lost when the probe itself goes unanswered', async () => {
+		attachSocket();
+		const { analysisId } = await submitFel();
+		ackReply = [new Error('operation has timed out'), undefined];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(analysisStore.updateAnalysis).toHaveBeenCalledWith(
+			analysisId,
+			expect.objectContaining({
+				status: 'connection_lost',
+				error: 'The server never confirmed this job.'
+			})
+		);
+	});
+
+	it("keeps waiting on 'unknown', which a healthy queued job reports", async () => {
+		attachSocket();
+		await submitFel();
+		ackReply = [null, { status: 'unknown' }];
+
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(ackEmit).toHaveBeenCalledTimes(1);
+		expect(connectionLostCalls()).toHaveLength(0);
+
+		// And it re-arms rather than giving up silently.
+		await vi.advanceTimersByTimeAsync(61_000);
+		expect(ackEmit).toHaveBeenCalledTimes(2);
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('submits the spawn with exactly two arguments and no ack request', async () => {
+		// REGRESSION GUARD. `socket.timeout(ms).emit(spawn, data, cb)` arrives at the server's stream
+		// router (lib/router.js:26) as stream=data, data=ackFn, so analysis-routes.js reads the ack
+		// function as the job parameters and answers 'Invalid job parameters' for every submission.
+		attachSocket();
+		await submitFel();
+
+		const call = mockSocket.emit.mock.calls.find((c) => c[0] === 'fel:spawn');
+		expect(call, 'the spawn must go out on socket.emit, not socket.timeout().emit').toBeDefined();
+		expect(call).toHaveLength(2);
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+	});
+
+	it('stops chasing a job that completed while unacknowledged', async () => {
+		attachSocket();
+		const { jobId } = await submitFel();
+
+		handlerFor('completed')({ jobId, results: { some: 'result' } });
+		await vi.advanceTimersByTimeAsync(61_000);
+
+		expect(mockSocket.timeout).not.toHaveBeenCalled();
+		expect(connectionLostCalls()).toHaveLength(0);
+	});
+
+	it('never asks the server for the job queue, which would disconnect the socket', async () => {
+		// server.js:54-59 answers `job queue` with a reply followed by socket.disconnect(), tearing
+		// down the status stream for every in-flight job.
+		attachSocket();
+		await submitFel();
+
+		const queueEmits = mockSocket.emit.mock.calls.filter((c) => c[0] === 'job queue');
+		expect(queueEmits).toHaveLength(0);
+	});
+});

--- a/src/test/wasm-exec-argv.test.js
+++ b/src/test/wasm-exec-argv.test.js
@@ -1,0 +1,164 @@
+/**
+ * UX item 1.2 — how the browser path hands arguments to HyPhy.
+ *
+ * The runner used to build one command STRING and let Aioli's worker split it on spaces
+ * (`r == null && (r = e.split(" "), i = r.shift())`). Two things follow from that, and this file
+ * pins both fixes:
+ *
+ *   1. Any argument value containing a space was silently torn into separate argv tokens. With the
+ *      old genetic code table that was fatal — `--code Vertebrate mitochondrial` reached HyPhy as
+ *      three tokens. The names now sent are hyphenated (see geneticCodes.js), so no CURRENT value
+ *      has a space; what the argv array guarantees is that a value which does have one arrives
+ *      whole, so HyPhy's complaint names the value the user chose instead of its first word.
+ *
+ *   2. `geneticCodeId` was not in the skip list, so the generic fall-through emitted a bogus
+ *      `--genetic-code-id 0` on every single local run.
+ *
+ * This drives the REAL runner rather than a re-implementation of its argument builder, because the
+ * defect was never in the mapping — it was in how the mapped tokens reached exec().
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The analysis store persists through IndexedDB; stub it so this exercises the runner.
+vi.mock('../lib/utils/indexedDBStorage', () => {
+	const records = new Map();
+	return {
+		analysisStorage: {
+			getAnalysis: vi.fn(async (id) => records.get(id) ?? null),
+			saveAnalysis: vi.fn(async (a) => {
+				records.set(a.id, a);
+				return a;
+			}),
+			getAllAnalyses: vi.fn(async () => [...records.values()]),
+			deleteAnalysis: vi.fn(async (id) => records.delete(id)),
+			clearAllAnalyses: vi.fn(async () => records.clear()),
+			__records: records
+		}
+	};
+});
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const { aioliStore } = await import('../stores/aioli.js');
+const { wasmAnalysisRunner } = await import('../lib/services/WasmAnalysisRunner.js');
+
+const FASTA = `>Human
+GCCTTGGAAACCTGGGGTGCCTTGGGTCAGGACATCAACTTGGACATTCCT
+>Chimp
+GCCTTGGAAACCTGGGGTGCCTTGGGTCAGGACATCAACTTGGACATTCCT
+>Baboon
+GCTTTGGAAACCTGGGGAGCGCTGGGTCAGGACATCAACTTGGACATTCCT`;
+
+const TREE = `((Human:0.01,Chimp:0.01):0.02,Baboon:0.03);`;
+
+/** Install a fake Aioli CLI and return its exec spy. */
+function installFakeCli() {
+	const exec = vi.fn(async () => ({ stdout: '' }));
+	aioliStore.set({
+		mount: async (files) => files.map((f) => `/shared/data/${f.name}`),
+		exec,
+		download: async () => 'blob:x'
+	});
+	// executeWasmAnalysis fetches the result file through the blob URL it just downloaded.
+	global.fetch = vi.fn(async () => ({
+		blob: async () => ({ text: async () => '{"MLE":{}}' })
+	}));
+	return exec;
+}
+
+describe('WASM exec receives an argv array, not a command string', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('passes the program name and argv separately, one token per element', async () => {
+		const exec = installFakeCli();
+
+		// Called directly: this bypasses runAnalysis's cache and validation, which are not
+		// what is under test here.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a1',
+			'fel',
+			{ geneticCode: 'Vertebrate-mtDNA', branchesToTest: 'All', geneticCodeId: 1 },
+			FASTA,
+			TREE
+		);
+
+		expect(exec).toHaveBeenCalledTimes(1);
+		const [program, argv] = exec.mock.calls[0];
+
+		// Aioli looks the tool up by `program == 'hyphy'`; anything else throws "Program not found".
+		expect(program).toBe('hyphy');
+		expect(Array.isArray(argv)).toBe(true);
+
+		// Flags are their own tokens, with the value in the very next element.
+		const codeIndex = argv.indexOf('--code');
+		expect(codeIndex).toBeGreaterThan(-1);
+		expect(argv[codeIndex + 1]).toBe('Vertebrate-mtDNA');
+		expect(argv).toContain('--alignment');
+		expect(argv).toContain('--tree');
+		expect(argv).toContain('--branches');
+
+		// The program name must NOT be repeated inside argv — the worker shifts nothing off an
+		// array, so a leading 'hyphy' would reach HyPhy as a positional argument.
+		expect(argv).not.toContain('hyphy');
+
+		// Emscripten's callMain wants strings; numeric config values must be stringified.
+		expect(argv.every((token) => typeof token === 'string')).toBe(true);
+
+		// geneticCodeId is UI state, not a CLI flag. Before this change the generic fall-through
+		// turned it into a bogus '--genetic-code-id 0' on every local run.
+		expect(argv).not.toContain('--genetic-code-id');
+	});
+
+	it('keeps a value containing a space in a single argv element', async () => {
+		const exec = installFakeCli();
+
+		// An unrecognised code name is passed through deliberately (see geneticCodes.js) so HyPhy
+		// rejects it loudly. Under the old string form the split made HyPhy report only
+		// 'Vertebrate' — naming a value the user never typed. It must arrive whole.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a2',
+			'fel',
+			{ geneticCode: 'Vertebrate mitochondrial DNA', branchesToTest: 'All' },
+			FASTA,
+			TREE
+		);
+
+		const argv = exec.mock.calls[0][1];
+		expect(argv[argv.indexOf('--code') + 1]).toBe('Vertebrate mitochondrial DNA');
+	});
+
+	it('normalises a legacy genetic code name to the identifier the engine declares', async () => {
+		const exec = installFakeCli();
+
+		// 'Vertebrate mitochondrial' is what older builds of the selector stored. It is not a
+		// HyPhy identifier and never was, so a saved config carrying it must be translated
+		// rather than passed through to be rejected.
+		await wasmAnalysisRunner.executeWasmAnalysis(
+			'a3',
+			'fel',
+			{ geneticCode: 'Vertebrate mitochondrial', branchesToTest: 'All' },
+			FASTA,
+			TREE
+		);
+
+		const argv = exec.mock.calls[0][1];
+		expect(argv[argv.indexOf('--code') + 1]).toBe('Vertebrate-mtDNA');
+	});
+
+	it('builds the stored arguments preview from the same tokens', async () => {
+		const preview = wasmAnalysisRunner.buildArgumentsPreview(
+			'fel',
+			{ geneticCode: 'Vertebrate-mtDNA', branchesToTest: 'All', geneticCodeId: 1 },
+			TREE
+		);
+
+		expect(Array.isArray(preview.argv)).toBe(true);
+		expect(preview.argv[preview.argv.indexOf('--code') + 1]).toBe('Vertebrate-mtDNA');
+		expect(preview.argv).not.toContain('--genetic-code-id');
+		// The joined form is for reading only; argv is stored beside it because the join is
+		// ambiguous for any value containing a space.
+		expect(preview.command).toContain('--code Vertebrate-mtDNA');
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
 	plugins: [sveltekit()],
 
 	resolve: {
-		dedupe: ['svelte']
+		dedupe: ['svelte'],
+		// Under Vitest, resolve packages to their BROWSER build. Without this, `svelte` resolves to
+		// its server entry and mount() throws "not available on the server", so no test can render a
+		// component — only reason it went unnoticed is that the one component test in the suite never
+		// actually called render(). Scoped to VITEST so dev and build are untouched.
+		...(process.env.VITEST ? { conditions: ['browser'] } : {})
 	},
 
 	test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,13 +8,12 @@ const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
 export default defineConfig({
 	plugins: [sveltekit()],
 
-	// Under vitest, resolve Svelte's BROWSER entry. Without the extra condition `mount()` comes from
-	// svelte/index-server.js and every component render throws "mount(...) is not available on the
-	// server" — which is why no test in this repo could mount a component until now. This is the
-	// workaround the Svelte 5 testing docs prescribe; it is scoped to the test run so the dev server
-	// and the production build resolve exactly as before.
 	resolve: {
 		dedupe: ['svelte'],
+		// Under Vitest, resolve packages to their BROWSER build. Without this, `svelte` resolves to
+		// its server entry and mount() throws "not available on the server", so no test can render a
+		// component — only reason it went unnoticed is that the one component test in the suite never
+		// actually called render(). Scoped to VITEST so dev and build are untouched.
 		...(process.env.VITEST ? { conditions: ['browser'] } : {})
 	},
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,8 +8,14 @@ const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
 export default defineConfig({
 	plugins: [sveltekit()],
 
+	// Under vitest, resolve Svelte's BROWSER entry. Without the extra condition `mount()` comes from
+	// svelte/index-server.js and every component render throws "mount(...) is not available on the
+	// server" — which is why no test in this repo could mount a component until now. This is the
+	// workaround the Svelte 5 testing docs prescribe; it is scoped to the test run so the dev server
+	// and the production build resolve exactly as before.
 	resolve: {
-		dedupe: ['svelte']
+		dedupe: ['svelte'],
+		...(process.env.VITEST ? { conditions: ['browser'] } : {})
 	},
 
 	test: {


### PR DESCRIPTION
Consolidates the six UX branches (#212–#217) into one so the whole set can be tested together. **Those six should be closed in favour of this.**

Implements all 15 accepted items from `UX-QUALITY-OF-LIFE.md`: **1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.3, 3.3, 3.4, 3.5, 4.2, 4.3, 6.3, 6.4, 6.5**.

## Verification

| | |
|---|---|
| Unit | **730 passed / 50 files** |
| Build | clean |
| E2E | **140 passed, 0 failed** (129 fast + 11 slow) |

Every item was verified against current `main` *before* implementation, since the audit predated fifteen merged PRs. Only 3.3 had been partly overtaken (#177 added the ack timeout to the reconnect emit, not to submission). Each fix was individually reverted and its tests re-run; the failing output is in the per-item commit messages.

## Three defects that only integration could find

Each branch passed alone. These appeared only when combined, which is the argument for testing them as one PR.

**1. Test isolation.** `analysisConfig` (added by 3.4) is a module singleton that deliberately survives tab switches — so it also survived between tests in 2.1's file. The hours-long-run case selected the server and the fast-method case inherited it. Production behaviour was correct; only the isolation was missing.

**2. An e2e that depended on your local environment.** 2.1's new spec asserted that nothing points at a server, which held only because the rest of the suite assumes "no backend server in test". With `datamonkey-js-server` running on 7015 the advice takes its comparison branch and says "on the server". The socket is now blocked explicitly — a test whose result depends on what is listening on a port is not a test.

**3. E2E concurrency no longer fit the suite.** It grew 109 → 129 tests, and the new specs are WASM/ONNX-heavy. At 7 workers the AxoMEME spec failed **seven ways** while passing 9/9 in isolation — a resource limit reported as test failures. Workers lowered 50% → 3, measured as where it stops. The `50%` setting was tuned for the smaller suite and did not survive it growing.

## Conflicts resolved, and how

- `MethodSelector.svelte` — 3.4 extracted `METHOD_ADVANCED_OPTIONS` to its own module while 2.3 edited the surrounding markup. Took the extraction; confirmed 2.3's copy survived.
- `geneticCodes.js` — **both** 1.2 and 1.4 created this file independently. Took 1.2's, which is a superset and derives identifiers from the shipped engine (`hyphy.data`) rather than the stale vendored `chooseGeneticCode.def`. Confirmed 1.4's consumer only needs `.id`/`.label`.
- `+page.svelte` — kept 6.4's `role="tabpanel"` wrapper, applied 3.4's removal of the dead `selectedMethod` prop (it was never forwarded to `MethodSelector`, which is *why* Re-run restored nothing), and added 1.1's two new `DataTab` props.
- `vite.config.ts` — took 1.1's `resolve.conditions: ['browser']` under VITEST.

## Worth knowing beyond the items

**No component test in this repo could render anything.** `svelte` resolved to its server entry under Vitest and `mount()` threw; it went unnoticed because the single existing component test never called `render()`. Fixed as part of 1.1.

**Only `Universal` ever worked in local mode.** Every other HyPhy code name contains a space or slash, and the command was a single string split on spaces — so a user picking "Vertebrate mitochondrial" got their data analysed under the universal code, silently. The server path was unaffected, which is why this survived. That is 1.2, and it relates to #143 and #152.

**1.1 ships with no e2e, deliberately.** There is no deterministic post-condition on the Data tab that discriminates fixed from unfixed, so the mechanism is pinned by a component test; the reasoning is recorded in the test file.

## Not included

Item 2.2 (method chooser) is still with design review — its agent died at a session limit after verifying the audit's claims and finding three dead code paths, including a `priority.indexOf(a.id)` sort that has silently never worked.
